### PR TITLE
feat(auth): per-person credentials, roles, and invite flow

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -930,7 +930,10 @@ function Members() {
       const res = await fetch(`/api/people/${p.id}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: p.name, discount: p.discount, discount_long: p.discount_long, active: p.active }),
+        body: JSON.stringify({
+          name: p.name, discount: p.discount, discount_long: p.discount_long,
+          active: p.active, username: p.username, is_admin: p.is_admin,
+        }),
       });
       if (!res.ok) throw new Error("Failed");
     },
@@ -967,8 +970,31 @@ function PersonCard({ person, onSave }: { person: Person; onSave: (p: Person) =>
   const t = useT();
   const [disc, setDisc] = useState(person.discount);
   const [discLong, setDiscLong] = useState(person.discount_long);
-  const dirty = disc !== person.discount || discLong !== person.discount_long;
+  const [username, setUsername] = useState(person.username ?? "");
+  const [isAdmin, setIsAdmin] = useState(person.is_admin === 1);
+  const [inviteBanner, setInviteBanner] = useState<string | null>(null);
+
+  const dirty =
+    disc !== person.discount ||
+    discLong !== person.discount_long ||
+    username !== (person.username ?? "") ||
+    isAdmin !== (person.is_admin === 1);
+
   const isActive = !!person.active;
+
+  const handleInvite = async () => {
+    try {
+      const res = await fetch(`/api/people/${person.id}/invite`, { method: "POST" });
+      if (!res.ok) throw new Error();
+      const { url } = await res.json();
+      await navigator.clipboard.writeText(url);
+      setInviteBanner(t("admin.invite_copied"));
+      setTimeout(() => setInviteBanner(null), 3000);
+    } catch {
+      setInviteBanner("Error generating invite");
+      setTimeout(() => setInviteBanner(null), 3000);
+    }
+  };
 
   if (!isActive) {
     return (
@@ -993,12 +1019,73 @@ function PersonCard({ person, onSave }: { person: Person; onSave: (p: Person) =>
     <Card>
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 10 }}>
         <div style={{ fontFamily: fontSerif, fontSize: 17, fontWeight: 700, color: paper.ink }}>{person.name}</div>
-        {(disc > 0 || discLong > 0) && (
-          <div style={{
-            fontFamily: fontMono, fontSize: 9, color: paper.amber, fontWeight: 700,
-            letterSpacing: 1, border: `1px solid ${paper.amber}`, padding: "2px 6px",
-            textTransform: "uppercase",
-          }}>{t("admin.discount_badge")}</div>
+        <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+          {isAdmin && (
+            <div style={{
+              fontFamily: fontMono, fontSize: 9, color: paper.blue, fontWeight: 700,
+              letterSpacing: 1, border: `1px solid ${paper.blue}`, padding: "2px 6px",
+              textTransform: "uppercase",
+            }}>Admin</div>
+          )}
+          {(disc > 0 || discLong > 0) && (
+            <div style={{
+              fontFamily: fontMono, fontSize: 9, color: paper.amber, fontWeight: 700,
+              letterSpacing: 1, border: `1px solid ${paper.amber}`, padding: "2px 6px",
+              textTransform: "uppercase",
+            }}>{t("admin.discount_badge")}</div>
+          )}
+        </div>
+      </div>
+
+      {/* Login credentials */}
+      <div style={{ marginBottom: 12, display: "flex", gap: 8, alignItems: "flex-end" }}>
+        <div style={{ flex: 1 }}>
+          <div style={{ fontFamily: fontMono, fontSize: 9, color: paper.inkDim, letterSpacing: 1.5, textTransform: "uppercase", marginBottom: 4 }}>
+            {t("admin.username_label")}
+          </div>
+          <input
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            placeholder={t("admin.no_username")}
+            style={{
+              width: "100%", padding: "6px 8px",
+              border: `1px solid ${paper.paperDark}`,
+              background: paper.paperDeep,
+              fontFamily: fontMono, fontSize: 12, color: paper.ink,
+              outline: "none",
+            }}
+          />
+        </div>
+        <label style={{ display: "flex", alignItems: "center", gap: 6, paddingBottom: 6, cursor: "pointer" }}>
+          <input
+            type="checkbox"
+            checked={isAdmin}
+            onChange={(e) => setIsAdmin(e.target.checked)}
+            style={{ accentColor: paper.blue, width: 14, height: 14 }}
+          />
+          <span style={{ fontFamily: fontMono, fontSize: 9, letterSpacing: 1.5, textTransform: "uppercase", color: paper.inkDim }}>
+            {t("admin.is_admin_label")}
+          </span>
+        </label>
+      </div>
+
+      {/* Invite */}
+      <div style={{ marginBottom: 12 }}>
+        <button
+          onClick={handleInvite}
+          style={{
+            padding: "7px 12px", background: "transparent",
+            border: `1px dashed ${paper.inkDim}`, cursor: "pointer",
+            fontFamily: fontMono, fontSize: 9, letterSpacing: 1.5, textTransform: "uppercase",
+            color: paper.inkDim,
+          }}>
+          {t("admin.invite_copy")}
+        </button>
+        {inviteBanner && (
+          <span style={{ marginLeft: 10, fontFamily: fontMono, fontSize: 10, color: paper.green }}>
+            {inviteBanner}
+          </span>
         )}
       </div>
 
@@ -1023,7 +1110,11 @@ function PersonCard({ person, onSave }: { person: Person; onSave: (p: Person) =>
       <div style={{ display: "flex", gap: 8 }}>
         {dirty && (
           <button
-            onClick={() => onSave({ ...person, discount: disc, discount_long: discLong })}
+            onClick={() => onSave({
+              ...person,
+              discount: disc, discount_long: discLong,
+              username: username || null, is_admin: isAdmin ? 1 : 0,
+            })}
             style={{
               flex: 1, padding: "10px", background: paper.ink, color: paper.paper,
               border: "none", cursor: "pointer", fontFamily: fontMono, fontSize: 10,

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -2,11 +2,12 @@ import { NextResponse } from "next/server";
 import { getIronSession } from "iron-session";
 import { sessionOptions, type SessionData } from "@/lib/session";
 import { verifyCredentials } from "@/lib/auth";
+import { getDb } from "@/lib/db";
+import { getPersonByUsername, isOwner } from "@/lib/queries/people";
 
 export async function POST(req: Request) {
-  const { AUTH_USERNAME, AUTH_PASSWORD_HASH } = process.env;
-  if (!AUTH_USERNAME || !AUTH_PASSWORD_HASH || !process.env.SESSION_PASSWORD) {
-    console.error("AUTH_USERNAME, AUTH_PASSWORD_HASH, or SESSION_PASSWORD env vars are not set");
+  if (!process.env.SESSION_PASSWORD) {
+    console.error("SESSION_PASSWORD env var is not set");
     return NextResponse.json({ error: "server_misconfiguration" }, { status: 500 });
   }
 
@@ -22,18 +23,57 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "invalid_credentials" }, { status: 401 });
   }
 
-  const ok = await verifyCredentials(
-    { username, password },
-    { username: AUTH_USERNAME, passwordHash: AUTH_PASSWORD_HASH }
-  );
+  const db = getDb();
+  const person = getPersonByUsername(db, username);
 
-  if (!ok) {
+  let authenticated = false;
+  let sessionPersonId: number | undefined;
+  let sessionPersonName: string | undefined;
+  let sessionIsAdmin = false;
+
+  if (person?.password_hash) {
+    // DB-based per-person auth
+    authenticated = await verifyCredentials(
+      { username, password },
+      { username: person.username!, passwordHash: person.password_hash }
+    );
+    if (authenticated) {
+      sessionPersonId = person.id;
+      sessionPersonName = person.name;
+      sessionIsAdmin = person.is_admin === 1;
+    }
+  } else {
+    // Env-var fallback for initial/legacy setup
+    const { AUTH_USERNAME, AUTH_PASSWORD_HASH } = process.env;
+    if (AUTH_USERNAME && AUTH_PASSWORD_HASH) {
+      authenticated = await verifyCredentials(
+        { username, password },
+        { username: AUTH_USERNAME, passwordHash: AUTH_PASSWORD_HASH }
+      );
+      if (authenticated) {
+        sessionIsAdmin = true;
+        // Try to find the person by name for env-var admin
+        const adminPerson = db
+          .prepare("SELECT id, name FROM people WHERE name=? LIMIT 1")
+          .get(AUTH_USERNAME) as { id: number; name: string } | undefined;
+        if (adminPerson) {
+          sessionPersonId = adminPerson.id;
+          sessionPersonName = adminPerson.name;
+        }
+      }
+    }
+  }
+
+  if (!authenticated) {
     return NextResponse.json({ error: "invalid_credentials" }, { status: 401 });
   }
 
   const res = NextResponse.json({ ok: true });
   const session = await getIronSession<SessionData>(req, res, sessionOptions);
   session.authenticated = true;
+  session.personId = sessionPersonId;
+  session.personName = sessionPersonName;
+  session.isAdmin = sessionIsAdmin;
   await session.save();
   return res;
 }

--- a/app/api/invite/[token]/route.ts
+++ b/app/api/invite/[token]/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import bcrypt from "bcryptjs";
+import { getDb } from "@/lib/db";
+import { getInviteToken, deleteInviteToken, setPasswordHash, getPersonById } from "@/lib/queries/people";
+import { getIronSession } from "iron-session";
+import { sessionOptions, type SessionData } from "@/lib/session";
+
+const Schema = z.object({
+  password: z.string().min(8),
+});
+
+export async function POST(
+  req: Request,
+  ctx: { params: Promise<{ token: string }> }
+) {
+  const { token } = await ctx.params;
+  const db = getDb();
+
+  const record = getInviteToken(db, token);
+  if (!record) {
+    return NextResponse.json({ error: "invalid_token" }, { status: 400 });
+  }
+  if (new Date(record.expires_at) < new Date()) {
+    deleteInviteToken(db, token);
+    return NextResponse.json({ error: "token_expired" }, { status: 400 });
+  }
+
+  let body: unknown;
+  try { body = await req.json(); } catch {
+    return NextResponse.json({ error: "bad_request" }, { status: 400 });
+  }
+  const parsed = Schema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "bad_request" }, { status: 400 });
+  }
+
+  const hash = await bcrypt.hash(parsed.data.password, 12);
+  setPasswordHash(db, record.person_id, hash);
+  deleteInviteToken(db, token);
+
+  const person = getPersonById(db, record.person_id);
+  if (!person) return NextResponse.json({ error: "not_found" }, { status: 404 });
+
+  const res = NextResponse.json({ ok: true });
+  const session = await getIronSession<SessionData>(req, res, sessionOptions);
+  session.authenticated = true;
+  session.personId = person.id;
+  session.personName = person.name;
+  session.isAdmin = person.is_admin === 1;
+  await session.save();
+  return res;
+}

--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { getIronSession } from "iron-session";
+import { sessionOptions, type SessionData } from "@/lib/session";
+import { getDb } from "@/lib/db";
+import { isOwner } from "@/lib/queries/people";
+
+export async function GET(req: Request) {
+  const res = NextResponse.next();
+  const session = await getIronSession<SessionData>(req, res, sessionOptions);
+  if (!session.authenticated) {
+    return NextResponse.json(null);
+  }
+
+  let owner = false;
+  if (session.personName) {
+    owner = isOwner(getDb(), session.personName);
+  }
+
+  return NextResponse.json({
+    personId: session.personId ?? null,
+    personName: session.personName ?? null,
+    isAdmin: session.isAdmin ?? false,
+    isOwner: owner,
+  });
+}

--- a/app/api/people/[id]/invite/route.ts
+++ b/app/api/people/[id]/invite/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { randomBytes } from "crypto";
+import { getDb } from "@/lib/db";
+import { getPersonById, createInviteToken } from "@/lib/queries/people";
+import { getIronSession } from "iron-session";
+import { sessionOptions, type SessionData } from "@/lib/session";
+import { json, readId } from "@/lib/api";
+
+export const POST = json(async (req, ctx) => {
+  const session = await getIronSession<SessionData>(req, NextResponse.next(), sessionOptions);
+  if (!session.isAdmin) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  const id = await readId(ctx);
+  const person = getPersonById(getDb(), id);
+  if (!person) return NextResponse.json({ error: "not_found" }, { status: 404 });
+
+  const token = randomBytes(24).toString("hex");
+  const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+  createInviteToken(getDb(), id, token, expiresAt);
+
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || `${new URL(req.url).origin}`;
+  const url = `${baseUrl}/invite/${token}`;
+  return NextResponse.json({ url });
+});

--- a/app/api/people/[id]/route.ts
+++ b/app/api/people/[id]/route.ts
@@ -8,6 +8,8 @@ const PersonSchema = z.object({
   discount: z.number().min(0).max(1).default(0),
   discount_long: z.number().min(0).max(1).default(0),
   active: z.union([z.literal(0), z.literal(1)]).default(1),
+  username: z.string().min(1).nullable().optional(),
+  is_admin: z.union([z.literal(0), z.literal(1)]).default(0),
 });
 
 export const GET = json(async (_req, ctx) => {
@@ -19,6 +21,13 @@ export const GET = json(async (_req, ctx) => {
 export const PUT = json(async (req, ctx) => {
   const id = await readId(ctx);
   const data = await readBody(req, PersonSchema);
-  updatePerson(getDb(), id, data);
+  const existing = getPersonById(getDb(), id);
+  if (!existing) notFound();
+  updatePerson(getDb(), id, {
+    ...existing,
+    ...data,
+    username: data.username ?? existing.username,
+    is_admin: data.is_admin ?? existing.is_admin,
+  });
   return { ok: true };
 });

--- a/app/api/people/route.ts
+++ b/app/api/people/route.ts
@@ -9,12 +9,19 @@ const PersonSchema = z.object({
   discount: z.number().min(0).max(1).default(0),
   discount_long: z.number().min(0).max(1).default(0),
   active: z.union([z.literal(0), z.literal(1)]).default(1),
+  username: z.string().min(1).nullable().optional(),
+  is_admin: z.union([z.literal(0), z.literal(1)]).default(0),
 });
 
 export const GET = json(async () => getPeople(getDb()));
 
 export const POST = json(async (req) => {
   const data = await readBody(req, PersonSchema);
-  const id = insertPerson(getDb(), data);
+  const id = insertPerson(getDb(), {
+    ...data,
+    password_hash: null,
+    username: data.username ?? null,
+    is_admin: data.is_admin ?? 0,
+  });
   return NextResponse.json({ id }, { status: 201 });
 });

--- a/app/invite/[token]/page.tsx
+++ b/app/invite/[token]/page.tsx
@@ -1,0 +1,167 @@
+"use client";
+import { useState } from "react";
+import { useRouter, useParams } from "next/navigation";
+import { paper, fontMono, fontSerif } from "@/lib/paper-theme";
+import { useT } from "@/components/locale-provider";
+
+export default function InvitePage() {
+  const t = useT();
+  const router = useRouter();
+  const { token } = useParams<{ token: string }>();
+
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const inputStyle: React.CSSProperties = {
+    width: "100%",
+    padding: "10px 12px",
+    border: `1.5px solid ${paper.inkDim}`,
+    background: paper.paper,
+    fontFamily: fontMono,
+    fontSize: 14,
+    color: paper.ink,
+    outline: "none",
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (password.length < 8) { setError(t("invite.too_short")); return; }
+    if (password !== confirm) { setError(t("invite.mismatch")); return; }
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/invite/${token}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ password }),
+      });
+      if (res.ok) {
+        router.replace("/");
+      } else {
+        setError(t("invite.invalid"));
+      }
+    } catch {
+      setError(t("invite.invalid"));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div style={{
+      minHeight: "100dvh",
+      background: paper.paperDeep,
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      padding: "20px",
+    }}>
+      <div style={{ width: "100%", maxWidth: 360 }}>
+        <div style={{ textAlign: "center", marginBottom: 28 }}>
+          <div style={{
+            fontFamily: fontSerif,
+            fontSize: 28,
+            fontWeight: 600,
+            color: paper.ink,
+            letterSpacing: -0.5,
+            marginBottom: 6,
+          }}>
+            {t("invite.title")}
+          </div>
+          <div style={{
+            fontFamily: fontMono,
+            fontSize: 11,
+            color: paper.inkDim,
+            letterSpacing: 1,
+            textTransform: "uppercase",
+          }}>
+            {t("invite.subtitle")}
+          </div>
+        </div>
+
+        <form onSubmit={handleSubmit} style={{
+          background: paper.paper,
+          padding: "24px 20px",
+          boxShadow: "0 4px 24px rgba(0,0,0,0.1)",
+        }}>
+          <div style={{ marginBottom: 16 }}>
+            <label style={{
+              display: "block",
+              fontFamily: fontMono,
+              fontSize: 9,
+              letterSpacing: 1.5,
+              textTransform: "uppercase",
+              color: paper.inkDim,
+              marginBottom: 6,
+            }}>
+              {t("invite.password_label")}
+            </label>
+            <input
+              type="password"
+              autoComplete="new-password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              style={inputStyle}
+              required
+            />
+          </div>
+
+          <div style={{ marginBottom: 20 }}>
+            <label style={{
+              display: "block",
+              fontFamily: fontMono,
+              fontSize: 9,
+              letterSpacing: 1.5,
+              textTransform: "uppercase",
+              color: paper.inkDim,
+              marginBottom: 6,
+            }}>
+              {t("invite.confirm_label")}
+            </label>
+            <input
+              type="password"
+              autoComplete="new-password"
+              value={confirm}
+              onChange={(e) => setConfirm(e.target.value)}
+              style={inputStyle}
+              required
+            />
+          </div>
+
+          {error && (
+            <div style={{
+              fontFamily: fontMono,
+              fontSize: 11,
+              color: paper.accent,
+              marginBottom: 16,
+              letterSpacing: 0.5,
+            }}>
+              {error}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={loading}
+            style={{
+              width: "100%",
+              padding: "12px",
+              background: loading ? paper.inkDim : paper.ink,
+              color: paper.paper,
+              border: "none",
+              fontFamily: fontMono,
+              fontSize: 11,
+              letterSpacing: 2,
+              textTransform: "uppercase",
+              cursor: loading ? "not-allowed" : "pointer",
+            }}
+          >
+            {loading ? "…" : t("invite.submit")}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/components/bottom-tab-bar.tsx
+++ b/components/bottom-tab-bar.tsx
@@ -3,20 +3,26 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { paper, fontMono } from "@/lib/paper-theme";
 import { useT } from "@/components/locale-provider";
+import { useMe } from "@/hooks/use-me";
 
-const TABS = [
+const BASE_TABS = [
   { href: "/",         labelKey: "nav.dashboard" as const,        icon: "◉" },
   { href: "/trips",    labelKey: "nav.trips" as const,             icon: "↦" },
   { href: "/fuel",     labelKey: "nav.fuel" as const,              icon: "⛽" },
   { href: "/calendar", labelKey: "nav.tab.reservations" as const,  icon: "▦" },
   { href: "/expenses", labelKey: "nav.tab.expenses" as const,      icon: "₪" },
-  { href: "/admin",    labelKey: "nav.admin" as const,             icon: "✎" },
 ];
+
+const ADMIN_TAB = { href: "/admin", labelKey: "nav.admin" as const, icon: "✎" };
 
 export function BottomTabBar() {
   const t = useT();
   const pathname = usePathname();
-  if (pathname === "/login") return null;
+  const { data: me } = useMe();
+
+  if (pathname === "/login" || pathname.startsWith("/invite")) return null;
+
+  const tabs = (me?.isAdmin || me?.isOwner) ? [...BASE_TABS, ADMIN_TAB] : BASE_TABS;
 
   return (
     <nav
@@ -35,7 +41,7 @@ export function BottomTabBar() {
         margin: "0 auto",
       }}
     >
-      {TABS.map(({ href, labelKey, icon }) => {
+      {tabs.map(({ href, labelKey, icon }) => {
         const active = href === "/" ? pathname === "/" : pathname.startsWith(href);
         return (
           <Link

--- a/hooks/use-me.ts
+++ b/hooks/use-me.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+
+export interface Me {
+  personId: number | null;
+  personName: string | null;
+  isAdmin: boolean;
+  isOwner: boolean;
+}
+
+export function useMe() {
+  return useQuery<Me | null>({
+    queryKey: ["me"],
+    queryFn: async () => {
+      const res = await fetch("/api/me");
+      if (!res.ok) return null;
+      return res.json();
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/lib/__tests__/db.test.ts
+++ b/lib/__tests__/db.test.ts
@@ -3,7 +3,7 @@ import Database from "better-sqlite3";
 import { applySchema } from "../schema.sql";
 
 describe("applySchema", () => {
-  it("creates all 7 tables", () => {
+  it("creates all 9 tables", () => {
     const db = new Database(":memory:");
     applySchema(db);
     const tables = db
@@ -11,7 +11,7 @@ describe("applySchema", () => {
       .all()
       .map((r: any) => r.name);
     expect(tables).toEqual([
-      "cars", "expenses", "fuel_fillups", "payments", "people", "reservations", "trips"
+      "car_price_history", "cars", "expenses", "fuel_fillups", "invite_tokens", "payments", "people", "reservations", "trips"
     ]);
   });
 

--- a/lib/__tests__/queries.test.ts
+++ b/lib/__tests__/queries.test.ts
@@ -16,10 +16,12 @@ function makeDb() {
   return db;
 }
 
+const basePerson = { discount: 0, discount_long: 0, active: 1 as const, username: null, password_hash: null, is_admin: 0 as const };
+
 describe("people queries", () => {
   it("inserts and retrieves a person", () => {
     const db = makeDb();
-    const id = insertPerson(db, { name: "Roeland", discount: 0, discount_long: 0, active: 1 });
+    const id = insertPerson(db, { name: "Roeland", ...basePerson });
     const person = getPersonById(db, id);
     expect(person?.name).toBe("Roeland");
   });
@@ -43,7 +45,7 @@ describe("cars queries", () => {
 describe("trips queries", () => {
   it("inserts a trip and computes km and amount", () => {
     const db = makeDb();
-    const pid = insertPerson(db, { name: "Roeland", discount: 0, discount_long: 0, active: 1 });
+    const pid = insertPerson(db, { name: "Roeland", ...basePerson });
     const cid = insertCar(db, { short: "LEW", name: "Lewis", price_per_km: 0.25, brand: null, color: null });
     insertTrip(db, { person_id: pid, car_id: cid, date: "2026-04-18", start_odometer: 233900, end_odometer: 241929, location: null });
     const trips = getTrips(db);
@@ -61,7 +63,7 @@ describe("getLastCarState", () => {
 
   it("returns the last trip's end_odometer when trips exist", () => {
     const db = makeDb();
-    const pid = insertPerson(db, { name: "P", discount: 0, discount_long: 0, active: 1 });
+    const pid = insertPerson(db, { name: "P", ...basePerson });
     const cid = insertCar(db, { short: "A", name: "A", price_per_km: 0.25, brand: null, color: null });
     insertTrip(db, { person_id: pid, car_id: cid, date: "2026-04-01", start_odometer: 100, end_odometer: 150, location: "51.0,4.4" });
     insertTrip(db, { person_id: pid, car_id: cid, date: "2026-04-10", start_odometer: 150, end_odometer: 200, location: "51.1,4.5" });
@@ -70,7 +72,7 @@ describe("getLastCarState", () => {
 
   it("prefers a later fuel fill-up over an earlier trip", () => {
     const db = makeDb();
-    const pid = insertPerson(db, { name: "P", discount: 0, discount_long: 0, active: 1 });
+    const pid = insertPerson(db, { name: "P", ...basePerson });
     const cid = insertCar(db, { short: "A", name: "A", price_per_km: 0.25, brand: null, color: null });
     insertTrip(db, { person_id: pid, car_id: cid, date: "2026-04-01", start_odometer: 100, end_odometer: 150, location: null });
     insertFuelFillup(db, { person_id: pid, car_id: cid, date: "2026-04-05", amount: 50, liters: 30, odometer: 180, receipt: null, location: "station" });
@@ -79,7 +81,7 @@ describe("getLastCarState", () => {
 
   it("ignores fuel fill-ups where odometer is null", () => {
     const db = makeDb();
-    const pid = insertPerson(db, { name: "P", discount: 0, discount_long: 0, active: 1 });
+    const pid = insertPerson(db, { name: "P", ...basePerson });
     const cid = insertCar(db, { short: "A", name: "A", price_per_km: 0.25, brand: null, color: null });
     insertTrip(db, { person_id: pid, car_id: cid, date: "2026-04-01", start_odometer: 100, end_odometer: 150, location: "loc-trip" });
     insertFuelFillup(db, { person_id: pid, car_id: cid, date: "2026-04-05", amount: 50, liters: 30, odometer: null, receipt: null, location: "loc-fuel" });
@@ -88,7 +90,7 @@ describe("getLastCarState", () => {
 
   it("prefers trip over fuel when both share the same date", () => {
     const db = makeDb();
-    const pid = insertPerson(db, { name: "P", discount: 0, discount_long: 0, active: 1 });
+    const pid = insertPerson(db, { name: "P", ...basePerson });
     const cid = insertCar(db, { short: "A", name: "A", price_per_km: 0.25, brand: null, color: null });
     insertFuelFillup(db, { person_id: pid, car_id: cid, date: "2026-04-10", amount: 50, liters: 30, odometer: 175, receipt: null, location: "station" });
     insertTrip(db, { person_id: pid, car_id: cid, date: "2026-04-10", start_odometer: 175, end_odometer: 225, location: "parked" });
@@ -99,7 +101,7 @@ describe("getLastCarState", () => {
 describe("getDashboard", () => {
   it("returns zero balance for person with no activity", () => {
     const db = makeDb();
-    insertPerson(db, { name: "Test", discount: 0, discount_long: 0, active: 1 });
+    insertPerson(db, { name: "Test", ...basePerson });
     const rows = getDashboard(db, 2026);
     expect(rows[0].balance).toBe(0);
     expect(rows[0].trip_count).toBe(0);
@@ -107,7 +109,7 @@ describe("getDashboard", () => {
 
   it("computes negative balance when trip amount exceeds payments", () => {
     const db = makeDb();
-    const pid = insertPerson(db, { name: "Roeland", discount: 0, discount_long: 0, active: 1 });
+    const pid = insertPerson(db, { name: "Roeland", ...basePerson });
     const cid = insertCar(db, {
       short: "LEW",
       name: "Lewis",
@@ -131,7 +133,7 @@ describe("getDashboard", () => {
 
   it("filters trips outside target year", () => {
     const db = makeDb();
-    const pid = insertPerson(db, { name: "X", discount: 0, discount_long: 0, active: 1 });
+    const pid = insertPerson(db, { name: "X", ...basePerson });
     const cid = insertCar(db, {
       short: "A",
       name: "A",
@@ -154,7 +156,7 @@ describe("getDashboard", () => {
 
   it("includes payments in balance calculation", () => {
     const db = makeDb();
-    const pid = insertPerson(db, { name: "Y", discount: 0, discount_long: 0, active: 1 });
+    const pid = insertPerson(db, { name: "Y", ...basePerson });
     const cid = insertCar(db, {
       short: "B",
       name: "B",

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -293,4 +293,23 @@ export const en: Messages = {
   "history.price_title": "Price history",
   "history.current": "current",
   "history.no_history": "No price changes yet",
+
+  // Invite / first-login
+  "invite.title": "Welcome to Autodelen",
+  "invite.subtitle": "Set your password to get started.",
+  "invite.password_label": "Choose a password",
+  "invite.confirm_label": "Confirm password",
+  "invite.submit": "Set password",
+  "invite.mismatch": "Passwords don't match",
+  "invite.too_short": "Minimum 8 characters",
+  "invite.invalid": "Invalid or expired invitation",
+  "invite.success": "Password set — you're logged in",
+
+  // Admin members
+  "admin.members_title": "Members",
+  "admin.invite_copy": "Copy invite link",
+  "admin.invite_copied": "Link copied!",
+  "admin.username_label": "Username",
+  "admin.is_admin_label": "Admin",
+  "admin.no_username": "No login yet",
 };

--- a/lib/i18n/messages/nl.ts
+++ b/lib/i18n/messages/nl.ts
@@ -291,6 +291,25 @@ export const nl = {
   "history.price_title": "Prijshistoriek",
   "history.current": "huidig",
   "history.no_history": "Nog geen prijswijzigingen",
+
+  // Invite / first-login
+  "invite.title": "Welkom bij Autodelen",
+  "invite.subtitle": "Stel je wachtwoord in om te beginnen.",
+  "invite.password_label": "Kies een wachtwoord",
+  "invite.confirm_label": "Bevestig wachtwoord",
+  "invite.submit": "Wachtwoord instellen",
+  "invite.mismatch": "Wachtwoorden komen niet overeen",
+  "invite.too_short": "Minimaal 8 tekens",
+  "invite.invalid": "Ongeldige of verlopen uitnodiging",
+  "invite.success": "Wachtwoord ingesteld — je bent ingelogd",
+
+  // Admin members
+  "admin.members_title": "Leden",
+  "admin.invite_copy": "Kopieer uitnodigingslink",
+  "admin.invite_copied": "Link gekopieerd!",
+  "admin.username_label": "Gebruikersnaam",
+  "admin.is_admin_label": "Admin",
+  "admin.no_username": "Nog geen login",
 } as const;
 
 export type MessageKey = keyof typeof nl;

--- a/lib/queries/people.ts
+++ b/lib/queries/people.ts
@@ -1,26 +1,101 @@
 import type Database from "better-sqlite3";
 import type { Person } from "@/types";
 
+// Strip password_hash from public-facing person objects
+function strip(p: Person): Person {
+  const { password_hash: _ph, ...rest } = p as Person & { password_hash: string | null };
+  return rest as unknown as Person;
+}
+
 export function getPeople(db: Database.Database): Person[] {
-  return db.prepare("SELECT * FROM people ORDER BY name").all() as Person[];
+  return (db.prepare("SELECT * FROM people ORDER BY name").all() as Person[]).map(strip);
 }
 
 export function getActivePeople(db: Database.Database): Person[] {
-  return db.prepare("SELECT * FROM people WHERE active=1 ORDER BY name").all() as Person[];
+  return (db.prepare("SELECT * FROM people WHERE active=1 ORDER BY name").all() as Person[]).map(strip);
 }
 
 export function getPersonById(db: Database.Database, id: number): Person | null {
-  return (db.prepare("SELECT * FROM people WHERE id=?").get(id) as Person) ?? null;
+  const row = (db.prepare("SELECT * FROM people WHERE id=?").get(id) as Person) ?? null;
+  return row ? strip(row) : null;
+}
+
+export function getPersonByUsername(db: Database.Database, username: string): Person | null {
+  return (db.prepare("SELECT * FROM people WHERE username=?").get(username) as Person) ?? null;
 }
 
 export function insertPerson(db: Database.Database, data: Omit<Person, "id">): number {
   const result = db
-    .prepare("INSERT INTO people (name,discount,discount_long,active) VALUES (?,?,?,?)")
-    .run(data.name, data.discount, data.discount_long, data.active);
+    .prepare(
+      "INSERT INTO people (name,discount,discount_long,active,username,is_admin) VALUES (?,?,?,?,?,?)"
+    )
+    .run(
+      data.name,
+      data.discount,
+      data.discount_long,
+      data.active,
+      data.username ?? null,
+      data.is_admin ?? 0
+    );
   return result.lastInsertRowid as number;
 }
 
-export function updatePerson(db: Database.Database, id: number, data: Omit<Person, "id">): void {
-  db.prepare("UPDATE people SET name=?,discount=?,discount_long=?,active=? WHERE id=?")
-    .run(data.name, data.discount, data.discount_long, data.active, id);
+export function updatePerson(
+  db: Database.Database,
+  id: number,
+  data: Omit<Person, "id">
+): void {
+  db.prepare(
+    "UPDATE people SET name=?,discount=?,discount_long=?,active=?,username=?,is_admin=? WHERE id=?"
+  ).run(
+    data.name,
+    data.discount,
+    data.discount_long,
+    data.active,
+    data.username ?? null,
+    data.is_admin ?? 0,
+    id
+  );
+}
+
+export function setPasswordHash(
+  db: Database.Database,
+  id: number,
+  passwordHash: string
+): void {
+  db.prepare("UPDATE people SET password_hash=? WHERE id=?").run(passwordHash, id);
+}
+
+export function isOwner(db: Database.Database, personName: string): boolean {
+  const row = db
+    .prepare("SELECT COUNT(*) as n FROM cars WHERE owner_name=? AND active=1")
+    .get(personName) as { n: number };
+  return row.n > 0;
+}
+
+// Invite token helpers
+export function createInviteToken(
+  db: Database.Database,
+  personId: number,
+  token: string,
+  expiresAt: string
+): void {
+  db.prepare(
+    "INSERT OR REPLACE INTO invite_tokens (token,person_id,expires_at) VALUES (?,?,?)"
+  ).run(token, personId, expiresAt);
+}
+
+export function getInviteToken(
+  db: Database.Database,
+  token: string
+): { person_id: number; expires_at: string } | null {
+  return (
+    db
+      .prepare("SELECT person_id,expires_at FROM invite_tokens WHERE token=?")
+      .get(token) as { person_id: number; expires_at: string } | undefined
+  ) ?? null;
+}
+
+export function deleteInviteToken(db: Database.Database, token: string): void {
+  db.prepare("DELETE FROM invite_tokens WHERE token=?").run(token);
 }

--- a/lib/schema.sql.ts
+++ b/lib/schema.sql.ts
@@ -7,7 +7,16 @@ export function applySchema(db: Database.Database) {
       name          TEXT    NOT NULL,
       discount      REAL    NOT NULL DEFAULT 0,
       discount_long REAL    NOT NULL DEFAULT 0,
-      active        INTEGER NOT NULL DEFAULT 1
+      active        INTEGER NOT NULL DEFAULT 1,
+      username      TEXT    UNIQUE,
+      password_hash TEXT,
+      is_admin      INTEGER NOT NULL DEFAULT 0
+    );
+
+    CREATE TABLE IF NOT EXISTS invite_tokens (
+      token      TEXT    PRIMARY KEY,
+      person_id  INTEGER NOT NULL REFERENCES people(id) ON DELETE CASCADE,
+      expires_at TEXT    NOT NULL
     );
 
     CREATE TABLE IF NOT EXISTS cars (
@@ -85,6 +94,9 @@ export function applySchema(db: Database.Database) {
 
   // Migrations for existing databases (safe to run multiple times)
   const migrations = [
+    "ALTER TABLE people ADD COLUMN username TEXT",
+    "ALTER TABLE people ADD COLUMN password_hash TEXT",
+    "ALTER TABLE people ADD COLUMN is_admin INTEGER NOT NULL DEFAULT 0",
     "ALTER TABLE reservations ADD COLUMN status TEXT NOT NULL DEFAULT 'pending'",
     "ALTER TABLE reservations ADD COLUMN note TEXT",
     "ALTER TABLE cars ADD COLUMN owner_name TEXT",

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -1,9 +1,10 @@
 import type { SessionOptions } from "iron-session";
 
 export interface SessionData {
-  // Phase B widens this with personId?: number and isAdmin?: boolean
-  // without breaking any Phase A consumer — only authenticated is checked here.
   authenticated: boolean;
+  personId?: number;
+  personName?: string;
+  isAdmin?: boolean;
 }
 
 export const sessionOptions: SessionOptions = {

--- a/middleware.ts
+++ b/middleware.ts
@@ -7,15 +7,18 @@ const PUBLIC_PATHS = [
   "/login",
   "/api/auth/login",
   "/api/auth/logout",
+  "/invite",
+  "/api/invite",
 ];
+
+// Pages only admins can visit (non-admins get redirected to /).
+const ADMIN_ONLY_PAGES = ["/cars", "/people", "/payments"];
 
 export async function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
 
   // Static assets and Next.js internals are excluded via the matcher below.
-  // Explicitly public API/page paths bypass the session check.
   if (PUBLIC_PATHS.some((p) => pathname === p || pathname.startsWith(p + "/"))) {
-    // If already authenticated and hitting /login, redirect home.
     if (pathname === "/login") {
       const res = NextResponse.next();
       const session = await getIronSession<SessionData>(req, res, sessionOptions);
@@ -34,10 +37,16 @@ export async function middleware(req: NextRequest) {
     return NextResponse.redirect(loginUrl);
   }
 
+  // Admin-only pages — redirect non-admins to dashboard
+  if (ADMIN_ONLY_PAGES.some((p) => pathname === p || pathname.startsWith(p + "/"))) {
+    if (!session.isAdmin) {
+      return NextResponse.redirect(new URL("/", req.url));
+    }
+  }
+
   return res;
 }
 
-// Run on all paths except Next.js build artefacts and static files.
 export const config = {
   matcher: [
     "/((?!_next/static|_next/image|favicon\\.ico|icon.*\\.png|manifest\\.webmanifest).*)",

--- a/types/index.ts
+++ b/types/index.ts
@@ -4,6 +4,9 @@ export interface Person {
   discount: number;
   discount_long: number;
   active: 0 | 1;
+  username: string | null;
+  password_hash: string | null;
+  is_admin: 0 | 1;
 }
 
 export interface Car {
@@ -113,7 +116,10 @@ export interface DashboardRow {
 }
 
 // Form input types (no id, no computed fields)
-export type PersonInput = Pick<Person, "name"|"discount"|"discount_long"|"active">;
+export type PersonInput = Pick<Person, "name"|"discount"|"discount_long"|"active"> & {
+  username?: string | null;
+  is_admin?: 0 | 1;
+};
 export type CarInput = Pick<Car, "short"|"name"|"price_per_km"|"brand"|"color"> & {
   owner_name?: string | null;
   long_threshold?: number;


### PR DESCRIPTION
## Summary
- Replace single shared env-var login with per-person `username` + `password_hash` stored in the `people` table; `is_admin` flag added
- Session now carries `personId`, `personName`, `isAdmin`; `/api/me` endpoint exposes identity to the client
- Admin tab hidden for regular members (only admin/owner see it); `/cars`, `/people`, `/payments` pages are admin-only
- Invite link flow: admin generates a 7-day token, member visits `/invite/[token]` to set their own password and gets auto-logged-in
- Env-var auth kept as a fallback so existing dev setups don't break

## Test plan
- [ ] Existing env-var login still works
- [ ] Person with `username` + `password_hash` can log in via DB auth
- [ ] Regular member: Admin tab not visible, `/cars` redirects to `/`
- [ ] Owner: Admin tab visible
- [ ] Admin generates invite → link copied to clipboard → member visits link, sets password, is logged in
- [ ] All 38 tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)