### PR TITLE
feat(mine-filter): All/Mine filter on trips, fuel, expenses

### DIFF
--- a/app/expenses/page.tsx
+++ b/app/expenses/page.tsx
@@ -7,6 +7,7 @@ import { GroupedList } from "@/components/grouped-list";
 import { Fab } from "@/components/fab";
 import { ExpenseForm } from "./expense-form";
 import { useExpenses, useCreateExpense, useUpdateExpense, useDeleteExpense } from "@/hooks/use-expenses";
+import { useMe } from "@/hooks/use-me";
 import type { Expense } from "@/types";
 import { paper, fontMono, fontSerif, fmtMoney, fmtYearMonth } from "@/lib/paper-theme";
 import { useT } from "@/components/locale-provider";
@@ -20,11 +21,18 @@ const sheetStyle: React.CSSProperties = {
 export default function ExpensesPage() {
   const t = useT();
   const { data: expenses = [], isLoading } = useExpenses();
+  const { data: me } = useMe();
   const createE = useCreateExpense();
   const updateE = useUpdateExpense();
   const deleteE = useDeleteExpense();
   const [adding, setAdding] = useState(false);
   const [editing, setEditing] = useState<Expense | null>(null);
+  const [filter, setFilter] = useState<"all" | "mine">("all");
+
+  const canFilter = me?.personId != null;
+  const visible = filter === "mine" && canFilter
+    ? expenses.filter((e) => e.person_id === me!.personId)
+    : expenses;
 
   if (isLoading) return (
     <div style={{ background: paper.paperDeep, minHeight: "100dvh" }}>
@@ -37,8 +45,30 @@ export default function ExpensesPage() {
     <div style={{ background: paper.paperDeep, minHeight: "100dvh", paddingBottom: 80 }}>
       <PageHeader title={t("page.expenses")} />
 
+      {canFilter && (
+        <div style={{ display: "flex", gap: 0, padding: "12px 16px 4px", borderBottom: `1px solid ${paper.paperDark}` }}>
+          {(["all", "mine"] as const).map((v) => (
+            <button
+              key={v}
+              onClick={() => setFilter(v)}
+              style={{
+                flex: 1, padding: "7px 0",
+                background: filter === v ? paper.ink : "transparent",
+                color: filter === v ? paper.paper : paper.inkDim,
+                border: `1.5px solid ${paper.ink}`,
+                borderRight: v === "all" ? "none" : undefined,
+                fontFamily: fontMono, fontSize: 10, fontWeight: 700, letterSpacing: 2,
+                textTransform: "uppercase", cursor: "pointer",
+              }}
+            >
+              {v === "all" ? t("filter.all") : t("filter.mine")}
+            </button>
+          ))}
+        </div>
+      )}
+
       <GroupedList
-        items={expenses}
+        items={visible}
         getKey={(e) => e.date.slice(0, 7)}
         getGroupLabel={(key) => fmtYearMonth(key + "-01")}
         getGroupTotal={(items) => items.reduce((s, e) => s + e.amount, 0)}
@@ -75,7 +105,7 @@ export default function ExpensesPage() {
         )}
       />
 
-      {expenses.length === 0 && (
+      {visible.length === 0 && (
         <div style={{ padding: "32px 20px", textAlign: "center", fontFamily: fontMono, fontSize: 11, color: paper.inkMute, letterSpacing: 1 }}>
           {t("state.empty_expenses")}
         </div>

--- a/app/fuel/page.tsx
+++ b/app/fuel/page.tsx
@@ -7,6 +7,7 @@ import { GroupedList } from "@/components/grouped-list";
 import { Fab } from "@/components/fab";
 import { FuelForm } from "./fuel-form";
 import { useFuelFillups, useCreateFuelFillup, useUpdateFuelFillup, useDeleteFuelFillup } from "@/hooks/use-fuel-fillups";
+import { useMe } from "@/hooks/use-me";
 import type { FuelFillup } from "@/types";
 import { paper, fontMono, fontSerif, fmtMoney, fmtYearMonth } from "@/lib/paper-theme";
 import { useT } from "@/components/locale-provider";
@@ -20,11 +21,18 @@ const sheetStyle: React.CSSProperties = {
 export default function FuelPage() {
   const t = useT();
   const { data: fillups = [], isLoading } = useFuelFillups();
+  const { data: me } = useMe();
   const createF = useCreateFuelFillup();
   const updateF = useUpdateFuelFillup();
   const deleteF = useDeleteFuelFillup();
   const [adding, setAdding] = useState(false);
   const [editing, setEditing] = useState<FuelFillup | null>(null);
+  const [filter, setFilter] = useState<"all" | "mine">("all");
+
+  const canFilter = me?.personId != null;
+  const visible = filter === "mine" && canFilter
+    ? fillups.filter((f) => f.person_id === me!.personId)
+    : fillups;
 
   if (isLoading) return (
     <div style={{ background: paper.paperDeep, minHeight: "100dvh" }}>
@@ -37,8 +45,30 @@ export default function FuelPage() {
     <div style={{ background: paper.paperDeep, minHeight: "100dvh", paddingBottom: 80 }}>
       <PageHeader title={t("page.fuel")} />
 
+      {canFilter && (
+        <div style={{ display: "flex", gap: 0, padding: "12px 16px 4px", borderBottom: `1px solid ${paper.paperDark}` }}>
+          {(["all", "mine"] as const).map((v) => (
+            <button
+              key={v}
+              onClick={() => setFilter(v)}
+              style={{
+                flex: 1, padding: "7px 0",
+                background: filter === v ? paper.ink : "transparent",
+                color: filter === v ? paper.paper : paper.inkDim,
+                border: `1.5px solid ${paper.ink}`,
+                borderRight: v === "all" ? "none" : undefined,
+                fontFamily: fontMono, fontSize: 10, fontWeight: 700, letterSpacing: 2,
+                textTransform: "uppercase", cursor: "pointer",
+              }}
+            >
+              {v === "all" ? t("filter.all") : t("filter.mine")}
+            </button>
+          ))}
+        </div>
+      )}
+
       <GroupedList
-        items={fillups}
+        items={visible}
         getKey={(f) => f.date.slice(0, 7)}
         getGroupLabel={(key) => fmtYearMonth(key + "-01")}
         getGroupTotal={(items) => items.reduce((s, f) => s + f.amount, 0)}
@@ -75,7 +105,7 @@ export default function FuelPage() {
         )}
       />
 
-      {fillups.length === 0 && (
+      {visible.length === 0 && (
         <div style={{ padding: "32px 20px", textAlign: "center", fontFamily: fontMono, fontSize: 11, color: paper.inkMute, letterSpacing: 1 }}>
           {t("state.empty_fuel")}
         </div>

--- a/app/trips/page.tsx
+++ b/app/trips/page.tsx
@@ -7,6 +7,7 @@ import { GroupedList } from "@/components/grouped-list";
 import { Fab } from "@/components/fab";
 import { TripForm } from "./trip-form";
 import { useTrips, useCreateTrip, useUpdateTrip, useDeleteTrip } from "@/hooks/use-trips";
+import { useMe } from "@/hooks/use-me";
 import type { Trip } from "@/types";
 import { paper, fontMono, fontSerif, fmtMoney, fmtYearMonth } from "@/lib/paper-theme";
 import { useT } from "@/components/locale-provider";
@@ -20,11 +21,18 @@ const sheetStyle: React.CSSProperties = {
 export default function TripsPage() {
   const t = useT();
   const { data: trips = [], isLoading } = useTrips();
+  const { data: me } = useMe();
   const createTrip = useCreateTrip();
   const updateTrip = useUpdateTrip();
   const deleteTrip = useDeleteTrip();
   const [adding, setAdding] = useState(false);
   const [editing, setEditing] = useState<Trip | null>(null);
+  const [filter, setFilter] = useState<"all" | "mine">("all");
+
+  const canFilter = me?.personId != null;
+  const visible = filter === "mine" && canFilter
+    ? trips.filter((tr) => tr.person_id === me!.personId)
+    : trips;
 
   if (isLoading) return (
     <div style={{ background: paper.paperDeep, minHeight: "100dvh" }}>
@@ -37,8 +45,30 @@ export default function TripsPage() {
     <div style={{ background: paper.paperDeep, minHeight: "100dvh", paddingBottom: 80 }}>
       <PageHeader title={t("page.trips")} />
 
+      {canFilter && (
+        <div style={{ display: "flex", gap: 0, padding: "12px 16px 4px", borderBottom: `1px solid ${paper.paperDark}` }}>
+          {(["all", "mine"] as const).map((v) => (
+            <button
+              key={v}
+              onClick={() => setFilter(v)}
+              style={{
+                flex: 1, padding: "7px 0",
+                background: filter === v ? paper.ink : "transparent",
+                color: filter === v ? paper.paper : paper.inkDim,
+                border: `1.5px solid ${paper.ink}`,
+                borderRight: v === "all" ? "none" : undefined,
+                fontFamily: fontMono, fontSize: 10, fontWeight: 700, letterSpacing: 2,
+                textTransform: "uppercase", cursor: "pointer",
+              }}
+            >
+              {v === "all" ? t("filter.all") : t("filter.mine")}
+            </button>
+          ))}
+        </div>
+      )}
+
       <GroupedList
-        items={trips}
+        items={visible}
         getKey={(trip) => trip.date.slice(0, 7)}
         getGroupLabel={(key) => fmtYearMonth(key + "-01")}
         getGroupTotal={(items) => items.reduce((s, trip) => s + trip.km, 0)}
@@ -77,7 +107,7 @@ export default function TripsPage() {
         )}
       />
 
-      {trips.length === 0 && (
+      {visible.length === 0 && (
         <div style={{ padding: "32px 20px", textAlign: "center", fontFamily: fontMono, fontSize: 11, color: paper.inkMute, letterSpacing: 1 }}>
           {t("state.empty_trips")}
         </div>

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -62,6 +62,10 @@ export const en: Messages = {
   "action.delete": "Delete",
   "action.see_all": "All →",
 
+  // Filter toggle
+  "filter.all": "All",
+  "filter.mine": "Mine",
+
   // Form labels
   "form.name": "Name *",
   "form.password": "Password",

--- a/lib/i18n/messages/nl.ts
+++ b/lib/i18n/messages/nl.ts
@@ -60,6 +60,10 @@ export const nl = {
   "action.delete": "Verwijderen",
   "action.see_all": "Alles →",
 
+  // Filter toggle
+  "filter.all": "Alle",
+  "filter.mine": "Van mij",
+
   // Form labels
   "form.name": "Naam *",
   "form.password": "Wachtwoord",


### PR DESCRIPTION
## Summary

- Adds `GET /api/me` endpoint returning `{ personId, personName, isAdmin }` from the iron-session
- Adds `useMe()` React Query hook (5-min stale time)
- Widens `SessionData` with `personId?`, `personName?`, `isAdmin?` (forward-compat with the auth branch)
- Trips, fuel and expenses pages each get an **Alle / Van mij** two-segment toggle
  - Toggle only renders when the session contains a `personId` (logged-in-as-person); anonymous sessions see the full list unchanged
  - Filtering is client-side by matching `record.person_id === me.personId`

## Test plan
- [ ] Login as a person with a `personId` in session → toggle appears on all three pages
- [ ] "Van mij" shows only the logged-in person's records
- [ ] "Alle" restores the full list
- [ ] No toggle shown when session has no `personId` (env-var auth fallback)
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)