### PR TITLE
feat(offline): Phase 1 — read-only offline support with SW caching & status indicator

### DIFF
--- a/app/api/health/route.test.ts
+++ b/app/api/health/route.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { GET, HEAD } from "./route";
+
+describe("GET /api/health", () => {
+  it("returns 200 with { ok: true }", async () => {
+    const res = GET();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("does not set any auth cookie", async () => {
+    const res = GET();
+    expect(res.headers.get("Set-Cookie")).toBeNull();
+  });
+});
+
+describe("HEAD /api/health", () => {
+  it("returns 200 with empty body", () => {
+    const res = HEAD();
+    expect(res.status).toBe(200);
+  });
+});

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  return NextResponse.json({ ok: true });
+}
+
+export function HEAD() {
+  return new NextResponse(null, { status: 200 });
+}

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -204,6 +204,7 @@ function CalendarContent() {
   );
 
   const handlePickDone = (carId: number, from: string, to: string) => {
+    if (!online) { toast.error(t("offline.mutation_blocked")); return; }
     setPrefillCarId(carId);
     setPrefillFrom(from);
     setPrefillTo(to);
@@ -269,6 +270,7 @@ function CalendarContent() {
           <span>{t("calendar.upcoming")}</span>
           <button
             onClick={() => {
+              if (!online) { toast.error(t("offline.mutation_blocked")); return; }
               setPrefillCarId(undefined);
               setPrefillFrom(undefined);
               setPrefillTo(undefined);
@@ -277,10 +279,11 @@ function CalendarContent() {
               router.push(`${pathname}?${params.toString()}`, { scroll: false });
             }}
             style={{
-              padding: "5px 12px", background: paper.ink, color: paper.paper,
-              border: "none", cursor: "pointer",
+              padding: "5px 12px", background: online ? paper.ink : paper.inkMute, color: paper.paper,
+              border: "none", cursor: online ? "pointer" : "default",
               fontFamily: fontMono, fontSize: 9, fontWeight: 700,
               letterSpacing: 1.5, textTransform: "uppercase",
+              opacity: online ? 1 : 0.45,
             }}
           >
             + {t("page.reservation_add")}

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -1,7 +1,9 @@
 "use client";
-import { Suspense, useMemo, useState } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { useOnlineState } from "@/lib/offline/online-state";
 import { PageHeader } from "@/components/page-header";
 import { ReservationForm } from "./reservation-form";
 import {
@@ -178,6 +180,16 @@ function CalendarContent() {
   const editing = !isLoading && editIdParam
     ? reservations.find((r) => r.id === Number(editIdParam)) ?? null
     : null;
+
+  // Refetch reservations whenever the new-reservation sheet opens online —
+  // the conflict warning needs to see the freshest server state.
+  const qc = useQueryClient();
+  const { online } = useOnlineState();
+  useEffect(() => {
+    if (sheet === "add" && online) {
+      qc.invalidateQueries({ queryKey: ["reservations"] });
+    }
+  }, [sheet, online, qc]);
 
   const [prefillCarId, setPrefillCarId] = useState<number | undefined>();
   const [prefillFrom, setPrefillFrom] = useState<string | undefined>();

--- a/app/calendar/reservation-form.tsx
+++ b/app/calendar/reservation-form.tsx
@@ -103,7 +103,13 @@ export function ReservationForm({ defaultValues, onSubmit, onCancel }: Props) {
   }
 
   return (
-    <form onSubmit={handleSubmit(handleFormSubmit)} style={{ background: paper.paperDeep }}>
+    <form
+      onSubmit={(e) => {
+        if (!online) { e.preventDefault(); toast.error(t("offline.mutation_blocked")); return; }
+        handleSubmit(handleFormSubmit)(e);
+      }}
+      style={{ background: paper.paperDeep }}
+    >
       {/* Top bar */}
       <div style={{
         display: "flex", alignItems: "center", justifyContent: "space-between",
@@ -118,16 +124,12 @@ export function ReservationForm({ defaultValues, onSubmit, onCancel }: Props) {
           border: "none", cursor: "pointer", color: paper.ink, padding: "0 4px", lineHeight: 1,
         }}>×</button>
         <div />
-        <button
-          type={online ? "submit" : "button"}
-          onClick={!online ? () => toast.error(t("offline.mutation_blocked")) : undefined}
-          style={{
-            fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 2,
-            textTransform: "uppercase", background: isAdmin ? paper.blue : paper.accent, color: "#fff",
-            border: "none", padding: "8px 14px", cursor: online ? "pointer" : "default",
-            opacity: online ? 1 : 0.45,
-          }}
-        >
+        <button type="submit" style={{
+          fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 2,
+          textTransform: "uppercase", background: isAdmin ? paper.blue : paper.accent, color: "#fff",
+          border: "none", padding: "8px 14px", cursor: online ? "pointer" : "default",
+          opacity: online ? 1 : 0.45,
+        }}>
           {isAdmin ? t("action.confirm_reservation") : t("action.request_reservation")}
         </button>
       </div>

--- a/app/calendar/reservation-form.tsx
+++ b/app/calendar/reservation-form.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect } from "react";
+import { toast } from "sonner";
 import { useForm, Controller } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -7,6 +8,7 @@ import { CarToggle } from "@/components/car-toggle";
 import { usePeople } from "@/hooks/use-people";
 import { useCars } from "@/hooks/use-cars";
 import { useMe } from "@/hooks/use-me";
+import { useOnlineState } from "@/lib/offline/online-state";
 import { useReservations } from "@/hooks/use-reservations";
 import type { Reservation, ReservationInput } from "@/types";
 import { useT, useLocale } from "@/components/locale-provider";
@@ -49,6 +51,7 @@ export function ReservationForm({ defaultValues, onSubmit, onCancel }: Props) {
   const { data: people = [] } = usePeople();
   const { data: cars = [] } = useCars();
   const { data: me } = useMe();
+  const { online } = useOnlineState();
   const { data: reservations = [] } = useReservations();
   const isAdmin = me?.isAdmin ?? false;
   const today = new Date().toISOString().slice(0, 10);
@@ -115,11 +118,16 @@ export function ReservationForm({ defaultValues, onSubmit, onCancel }: Props) {
           border: "none", cursor: "pointer", color: paper.ink, padding: "0 4px", lineHeight: 1,
         }}>×</button>
         <div />
-        <button type="submit" style={{
-          fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 2,
-          textTransform: "uppercase", background: isAdmin ? paper.blue : paper.accent, color: "#fff",
-          border: "none", padding: "8px 14px", cursor: "pointer",
-        }}>
+        <button
+          type={online ? "submit" : "button"}
+          onClick={!online ? () => toast.error(t("offline.mutation_blocked")) : undefined}
+          style={{
+            fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 2,
+            textTransform: "uppercase", background: isAdmin ? paper.blue : paper.accent, color: "#fff",
+            border: "none", padding: "8px 14px", cursor: online ? "pointer" : "default",
+            opacity: online ? 1 : 0.45,
+          }}
+        >
           {isAdmin ? t("action.confirm_reservation") : t("action.request_reservation")}
         </button>
       </div>

--- a/app/expenses/expense-form.tsx
+++ b/app/expenses/expense-form.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect } from "react";
+import { toast } from "sonner";
 import { useForm, Controller } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -7,6 +8,7 @@ import { CarToggle } from "@/components/car-toggle";
 import { usePeople } from "@/hooks/use-people";
 import { useCars } from "@/hooks/use-cars";
 import { useMe } from "@/hooks/use-me";
+import { useOnlineState } from "@/lib/offline/online-state";
 import type { Expense, ExpenseCategory, ExpenseInput } from "@/types";
 import { useT } from "@/components/locale-provider";
 import { paper, fontMono, fontSerif } from "@/lib/paper-theme";
@@ -46,6 +48,7 @@ export function ExpenseForm({ defaultValues, onSubmit, onCancel, onDelete }: Pro
   const { data: people = [] } = usePeople();
   const { data: cars = [] } = useCars();
   const { data: me } = useMe();
+  const { online } = useOnlineState();
   const isAddMode = !defaultValues?.id;
   const isAdmin = me?.isAdmin ?? false;
 
@@ -88,11 +91,16 @@ export function ExpenseForm({ defaultValues, onSubmit, onCancel, onDelete }: Pro
         <div style={{ fontFamily: fontMono, fontSize: 10, fontWeight: 700, letterSpacing: 3, color: paper.inkDim, textTransform: "uppercase" }}>
           📋 {t("form.extra_cost")}
         </div>
-        <button type="submit" style={{
-          fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 2,
-          textTransform: "uppercase", background: paper.inkDim, color: "#fff",
-          border: "none", padding: "8px 14px", cursor: "pointer",
-        }}>
+        <button
+          type={online ? "submit" : "button"}
+          onClick={!online ? () => toast.error(t("offline.mutation_blocked")) : undefined}
+          style={{
+            fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 2,
+            textTransform: "uppercase", background: paper.inkDim, color: "#fff",
+            border: "none", padding: "8px 14px", cursor: online ? "pointer" : "default",
+            opacity: online ? 1 : 0.45,
+          }}
+        >
           {t("action.save_cost")}
         </button>
       </div>

--- a/app/expenses/expense-form.tsx
+++ b/app/expenses/expense-form.tsx
@@ -74,7 +74,13 @@ export function ExpenseForm({ defaultValues, onSubmit, onCancel, onDelete }: Pro
   }, [me, isAddMode, setValue, getValues]);
 
   return (
-    <form onSubmit={handleSubmit(onSubmit as any)} style={{ background: paper.paperDeep }}>
+    <form
+      onSubmit={(e) => {
+        if (!online) { e.preventDefault(); toast.error(t("offline.mutation_blocked")); return; }
+        handleSubmit(onSubmit as any)(e);
+      }}
+      style={{ background: paper.paperDeep }}
+    >
       {/* Top bar */}
       <div style={{
         display: "flex", alignItems: "center", justifyContent: "space-between",
@@ -91,16 +97,12 @@ export function ExpenseForm({ defaultValues, onSubmit, onCancel, onDelete }: Pro
         <div style={{ fontFamily: fontMono, fontSize: 10, fontWeight: 700, letterSpacing: 3, color: paper.inkDim, textTransform: "uppercase" }}>
           📋 {t("form.extra_cost")}
         </div>
-        <button
-          type={online ? "submit" : "button"}
-          onClick={!online ? () => toast.error(t("offline.mutation_blocked")) : undefined}
-          style={{
-            fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 2,
-            textTransform: "uppercase", background: paper.inkDim, color: "#fff",
-            border: "none", padding: "8px 14px", cursor: online ? "pointer" : "default",
-            opacity: online ? 1 : 0.45,
-          }}
-        >
+        <button type="submit" style={{
+          fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 2,
+          textTransform: "uppercase", background: paper.inkDim, color: "#fff",
+          border: "none", padding: "8px 14px", cursor: online ? "pointer" : "default",
+          opacity: online ? 1 : 0.45,
+        }}>
           {t("action.save_cost")}
         </button>
       </div>

--- a/app/fuel/fuel-form.tsx
+++ b/app/fuel/fuel-form.tsx
@@ -108,7 +108,13 @@ export function FuelForm({ defaultValues, onSubmit, onCancel, onDelete }: Props)
   }
 
   return (
-    <form onSubmit={handleSubmit(handleSubmitForm)} style={{ background: paper.paperDeep }}>
+    <form
+      onSubmit={(e) => {
+        if (!online) { e.preventDefault(); toast.error(t("offline.mutation_blocked")); return; }
+        handleSubmit(handleSubmitForm)(e);
+      }}
+      style={{ background: paper.paperDeep }}
+    >
       {/* Top bar */}
       <div style={{
         display: "flex", alignItems: "center", justifyContent: "space-between",
@@ -125,16 +131,12 @@ export function FuelForm({ defaultValues, onSubmit, onCancel, onDelete }: Props)
         <div style={{ fontFamily: fontMono, fontSize: 10, fontWeight: 700, letterSpacing: 3, color: paper.inkDim, textTransform: "uppercase" }}>
           ⛽ {t("form.fuel_receipt")}
         </div>
-        <button
-          type={online ? "submit" : "button"}
-          onClick={!online ? () => toast.error(t("offline.mutation_blocked")) : undefined}
-          style={{
-            fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 2,
-            textTransform: "uppercase", background: paper.green, color: "#fff",
-            border: "none", padding: "8px 14px", cursor: online ? "pointer" : "default",
-            opacity: online ? 1 : 0.45,
-          }}
-        >
+        <button type="submit" style={{
+          fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 2,
+          textTransform: "uppercase", background: paper.green, color: "#fff",
+          border: "none", padding: "8px 14px", cursor: online ? "pointer" : "default",
+          opacity: online ? 1 : 0.45,
+        }}>
           {t("action.save_receipt")}
         </button>
       </div>

--- a/app/fuel/fuel-form.tsx
+++ b/app/fuel/fuel-form.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect } from "react";
+import { toast } from "sonner";
 import { useForm, Controller } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -11,6 +12,7 @@ import { usePeople } from "@/hooks/use-people";
 import { useCars } from "@/hooks/use-cars";
 import { useLastCarState } from "@/hooks/use-car-state";
 import { useMe } from "@/hooks/use-me";
+import { useOnlineState } from "@/lib/offline/online-state";
 import type { FuelFillup, FuelFillupInput } from "@/types";
 import { t } from "@/lib/i18n";
 import { paper, fontMono, fontSerif } from "@/lib/paper-theme";
@@ -49,6 +51,7 @@ export function FuelForm({ defaultValues, onSubmit, onCancel, onDelete }: Props)
   const { data: people = [] } = usePeople();
   const { data: cars = [] } = useCars();
   const { data: me } = useMe();
+  const { online } = useOnlineState();
   const isAddMode = !defaultValues?.id;
   const isAdmin = me?.isAdmin ?? false;
 
@@ -122,11 +125,16 @@ export function FuelForm({ defaultValues, onSubmit, onCancel, onDelete }: Props)
         <div style={{ fontFamily: fontMono, fontSize: 10, fontWeight: 700, letterSpacing: 3, color: paper.inkDim, textTransform: "uppercase" }}>
           ⛽ {t("form.fuel_receipt")}
         </div>
-        <button type="submit" style={{
-          fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 2,
-          textTransform: "uppercase", background: paper.green, color: "#fff",
-          border: "none", padding: "8px 14px", cursor: "pointer",
-        }}>
+        <button
+          type={online ? "submit" : "button"}
+          onClick={!online ? () => toast.error(t("offline.mutation_blocked")) : undefined}
+          style={{
+            fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 2,
+            textTransform: "uppercase", background: paper.green, color: "#fff",
+            border: "none", padding: "8px 14px", cursor: online ? "pointer" : "default",
+            opacity: online ? 1 : 0.45,
+          }}
+        >
           {t("action.save_receipt")}
         </button>
       </div>

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -2,13 +2,16 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "sonner";
 import { useState } from "react";
+import { OnlineStateProvider } from "@/lib/offline/online-state";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [client] = useState(() => new QueryClient());
   return (
     <QueryClientProvider client={client}>
-      {children}
-      <Toaster position="bottom-center" />
+      <OnlineStateProvider>
+        {children}
+        <Toaster position="bottom-center" />
+      </OnlineStateProvider>
     </QueryClientProvider>
   );
 }

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,14 +1,31 @@
 "use client";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
 import { Toaster } from "sonner";
 import { useState } from "react";
 import { OnlineStateProvider } from "@/lib/offline/online-state";
+import { useBootPrewarm } from "@/lib/offline/prewarm";
+
+function BootPrewarm() {
+  // useMe is the auth signal. Read it here so prewarm gates on auth.
+  const { data, isFetched } = useQuery<{ personId: number | null } | null>({
+    queryKey: ["me"],
+    queryFn: async () => {
+      const res = await fetch("/api/me");
+      if (!res.ok) return null;
+      return res.json();
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+  useBootPrewarm(isFetched && data?.personId != null);
+  return null;
+}
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [client] = useState(() => new QueryClient());
   return (
     <QueryClientProvider client={client}>
       <OnlineStateProvider>
+        <BootPrewarm />
         {children}
         <Toaster position="bottom-center" />
       </OnlineStateProvider>

--- a/app/trips/trip-form.tsx
+++ b/app/trips/trip-form.tsx
@@ -4,6 +4,7 @@ import { useForm, Controller } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { CarToggle } from "@/components/car-toggle";
 import { LocationPicker } from "@/components/location-picker";
 import { calcTripAmount } from "@/lib/formulas";
@@ -132,11 +133,16 @@ export function TripForm({ defaultValues, onSubmit, onCancel, onDelete }: Props)
         <div style={{ fontFamily: fontMono, fontSize: 10, fontWeight: 700, letterSpacing: 3, color: paper.inkDim, textTransform: "uppercase" }}>
           ① {t("form.log_trip")}
         </div>
-        <button type="submit" style={{
-          fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 2,
-          textTransform: "uppercase", background: paper.accent, color: "#fff",
-          border: "none", padding: "8px 14px", cursor: "pointer",
-        }}>
+        <button
+          type={online ? "submit" : "button"}
+          onClick={!online ? () => toast.error(t("offline.mutation_blocked")) : undefined}
+          style={{
+            fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 2,
+            textTransform: "uppercase", background: paper.accent, color: "#fff",
+            border: "none", padding: "8px 14px", cursor: online ? "pointer" : "default",
+            opacity: online ? 1 : 0.45,
+          }}
+        >
           {t("action.save_trip")}
         </button>
       </div>

--- a/app/trips/trip-form.tsx
+++ b/app/trips/trip-form.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 import { useForm, Controller } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
+import { useQueryClient } from "@tanstack/react-query";
 import { CarToggle } from "@/components/car-toggle";
 import { LocationPicker } from "@/components/location-picker";
 import { calcTripAmount } from "@/lib/formulas";
@@ -10,6 +11,7 @@ import { usePeople } from "@/hooks/use-people";
 import { useCars } from "@/hooks/use-cars";
 import { useLastCarState } from "@/hooks/use-car-state";
 import { useMe } from "@/hooks/use-me";
+import { useOnlineState } from "@/lib/offline/online-state";
 import type { Trip } from "@/types";
 import { t } from "@/lib/i18n";
 import { paper, fontMono, fontSerif, fmtMoney } from "@/lib/paper-theme";
@@ -80,6 +82,16 @@ export function TripForm({ defaultValues, onSubmit, onCancel, onDelete }: Props)
   const amount = shortAmount + longAmount;
 
   const { data: lastState } = useLastCarState(carId);
+  const qc = useQueryClient();
+  const { online } = useOnlineState();
+
+  // Force a fresh fetch of the selected car's last state whenever the form
+  // opens online or the car changes. Stale start_km is the one offline-related
+  // staleness that can corrupt data, so we always re-pull when we can.
+  useEffect(() => {
+    if (!isAddMode || !carId || !online) return;
+    qc.invalidateQueries({ queryKey: ["car-state", carId] });
+  }, [isAddMode, carId, online, qc]);
 
   useEffect(() => {
     if (!isAddMode || !carId || !lastState) return;
@@ -194,6 +206,14 @@ export function TripForm({ defaultValues, onSubmit, onCancel, onDelete }: Props)
                 if (!current || Number(current) === 0) setValue("end_odometer", startVal);
               }}
             />
+            {!online && isAddMode && (
+              <div style={{
+                fontFamily: fontMono, fontSize: 8, color: paper.amber,
+                letterSpacing: 1, marginTop: 2, textTransform: "uppercase",
+              }}>
+                {t("form.offline_start_km_hint")}
+              </div>
+            )}
           </div>
           <div style={{ textAlign: "center", flexShrink: 0, padding: "0 8px" }}>
             <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkMute, letterSpacing: 1, marginBottom: 2 }}>

--- a/app/trips/trip-form.tsx
+++ b/app/trips/trip-form.tsx
@@ -115,7 +115,13 @@ export function TripForm({ defaultValues, onSubmit, onCancel, onDelete }: Props)
   const pctLong  = Math.round(discLong * 100);
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)} style={{ background: paper.paperDeep }}>
+    <form
+      onSubmit={(e) => {
+        if (!online) { e.preventDefault(); toast.error(t("offline.mutation_blocked")); return; }
+        handleSubmit(onSubmit)(e);
+      }}
+      style={{ background: paper.paperDeep }}
+    >
       {/* Top bar */}
       <div style={{
         display: "flex", alignItems: "center", justifyContent: "space-between",
@@ -133,16 +139,12 @@ export function TripForm({ defaultValues, onSubmit, onCancel, onDelete }: Props)
         <div style={{ fontFamily: fontMono, fontSize: 10, fontWeight: 700, letterSpacing: 3, color: paper.inkDim, textTransform: "uppercase" }}>
           ① {t("form.log_trip")}
         </div>
-        <button
-          type={online ? "submit" : "button"}
-          onClick={!online ? () => toast.error(t("offline.mutation_blocked")) : undefined}
-          style={{
-            fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 2,
-            textTransform: "uppercase", background: paper.accent, color: "#fff",
-            border: "none", padding: "8px 14px", cursor: online ? "pointer" : "default",
-            opacity: online ? 1 : 0.45,
-          }}
-        >
+        <button type="submit" style={{
+          fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 2,
+          textTransform: "uppercase", background: paper.accent, color: "#fff",
+          border: "none", padding: "8px 14px", cursor: online ? "pointer" : "default",
+          opacity: online ? 1 : 0.45,
+        }}>
           {t("action.save_trip")}
         </button>
       </div>

--- a/components/bottom-tab-bar.tsx
+++ b/components/bottom-tab-bar.tsx
@@ -1,9 +1,11 @@
 "use client";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { toast } from "sonner";
 import { paper, fontMono } from "@/lib/paper-theme";
 import { useT } from "@/components/locale-provider";
 import { useMe } from "@/hooks/use-me";
+import { useOnlineState } from "@/lib/offline/online-state";
 
 const BASE_TABS = [
   { href: "/",         labelKey: "nav.dashboard" as const,        icon: "◉" },
@@ -19,6 +21,7 @@ export function BottomTabBar() {
   const t = useT();
   const pathname = usePathname();
   const { data: me } = useMe();
+  const { online } = useOnlineState();
 
   if (pathname === "/login" || pathname.startsWith("/invite")) return null;
 
@@ -43,11 +46,16 @@ export function BottomTabBar() {
     >
       {tabs.map(({ href, labelKey, icon }) => {
         const active = href === "/" ? pathname === "/" : pathname.startsWith(href);
+        const offlineBlocked = !online && href === "/admin";
         return (
           <Link
             key={href}
-            href={href}
+            href={offlineBlocked ? "#" : href}
             aria-current={active ? "page" : undefined}
+            onClick={offlineBlocked ? (e) => {
+              e.preventDefault();
+              toast.error(t("offline.admin_unavailable"));
+            } : undefined}
             style={{
               flex: 1,
               padding: "10px 2px 12px",
@@ -57,10 +65,11 @@ export function BottomTabBar() {
               gap: 3,
               fontFamily: fontMono,
               background: active ? paper.ink : "transparent",
-              color: active ? paper.paper : paper.ink,
+              color: active ? paper.paper : offlineBlocked ? paper.inkMute : paper.ink,
               textDecoration: "none",
               minWidth: 0,
-              cursor: "pointer",
+              cursor: offlineBlocked ? "default" : "pointer",
+              opacity: offlineBlocked ? 0.45 : 1,
             }}
           >
             <span style={{ fontSize: 15, lineHeight: 1 }}>{icon}</span>

--- a/components/fab.tsx
+++ b/components/fab.tsx
@@ -1,7 +1,9 @@
 "use client";
 import { useState } from "react";
+import { toast } from "sonner";
 import { paper, fontMono } from "@/lib/paper-theme";
 import { t } from "@/lib/i18n";
+import { useOnlineState } from "@/lib/offline/online-state";
 
 const CHIT_DEFS = [
   { key: "expense", labelKey: "fab.expense" as const, emoji: "🧾", rotate:  2 },
@@ -17,9 +19,14 @@ interface Props {
 }
 
 export function Fab({ onClick, label }: Props) {
+  const { online } = useOnlineState();
+  const handleClick = () => {
+    if (!online) { toast.error(t("offline.mutation_blocked")); return; }
+    onClick();
+  };
   return (
     <button
-      onClick={onClick}
+      onClick={handleClick}
       aria-label={label ?? t("action.add")}
       style={{
         position: "fixed",
@@ -27,11 +34,11 @@ export function Fab({ onClick, label }: Props) {
         bottom: 86,
         width: 56,
         height: 56,
-        background: paper.ink,
+        background: online ? paper.ink : paper.inkMute,
         color: paper.paper,
         border: "none",
         borderRadius: 0,
-        cursor: "pointer",
+        cursor: online ? "pointer" : "default",
         fontFamily: fontMono,
         fontSize: 28,
         fontWeight: 700,
@@ -41,6 +48,7 @@ export function Fab({ onClick, label }: Props) {
         alignItems: "center",
         justifyContent: "center",
         zIndex: 20,
+        opacity: online ? 1 : 0.45,
       }}
     >
       +
@@ -50,6 +58,7 @@ export function Fab({ onClick, label }: Props) {
 
 export function MultiFab({ onPick }: { onPick: (action: string) => void }) {
   const [open, setOpen] = useState(false);
+  const { online } = useOnlineState();
 
   return (
     <div style={{
@@ -104,14 +113,17 @@ export function MultiFab({ onPick }: { onPick: (action: string) => void }) {
       ))}
 
       <button
-        onClick={() => setOpen((o) => !o)}
+        onClick={() => {
+          if (!online) { toast.error(t("offline.mutation_blocked")); return; }
+          setOpen((o) => !o);
+        }}
         style={{
           width: 60,
           height: 60,
-          background: paper.ink,
+          background: online ? paper.ink : paper.inkMute,
           color: paper.paper,
           border: "none",
-          cursor: "pointer",
+          cursor: online ? "pointer" : "default",
           fontFamily: fontMono,
           fontSize: 34,
           fontWeight: 700,
@@ -122,6 +134,7 @@ export function MultiFab({ onPick }: { onPick: (action: string) => void }) {
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
+          opacity: online ? 1 : 0.45,
         }}
       >
         +

--- a/components/offline-badge.tsx
+++ b/components/offline-badge.tsx
@@ -1,0 +1,39 @@
+"use client";
+import { useOnlineState } from "@/lib/offline/online-state";
+import { paper, fontMono } from "@/lib/paper-theme";
+import { useT } from "@/components/locale-provider";
+
+export function OfflineBadge() {
+  const t = useT();
+  const { online, staleness } = useOnlineState();
+
+  if (online) return null;
+
+  const isStale = staleness !== "fresh";
+  const color = isStale ? paper.amber : paper.inkDim;
+  const tooltip = isStale ? t("offline.tooltip_stale") : t("offline.tooltip_fresh");
+
+  return (
+    <span
+      role="status"
+      aria-live="polite"
+      title={tooltip}
+      style={{
+        padding: "3px 8px",
+        fontFamily: fontMono,
+        fontSize: 9,
+        fontWeight: 700,
+        letterSpacing: 1.5,
+        textTransform: "uppercase",
+        background: "transparent",
+        color,
+        border: `1.5px solid ${color}`,
+        whiteSpace: "nowrap",
+        lineHeight: 1.4,
+      }}
+    >
+      {t("offline.label")}
+      {isStale && ` · ${t("offline.stale_suffix")}`}
+    </span>
+  );
+}

--- a/components/page-header.tsx
+++ b/components/page-header.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "next/navigation";
 import { paper, fontMono, fontSerif } from "@/lib/paper-theme";
 import { useT } from "@/components/locale-provider";
 import { LangSwitcher } from "./lang-switcher";
+import { OfflineBadge } from "./offline-badge";
 
 interface Props {
   title: string;
@@ -46,6 +47,7 @@ export function PageHeader({ title, subtitle, right }: Props) {
           {t("brand.tagline")}
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <OfflineBadge />
           {right}
           <LangSwitcher />
           <button

--- a/docs/superpowers/plans/2026-04-27-offline-phase-1-read-only-browsing.md
+++ b/docs/superpowers/plans/2026-04-27-offline-phase-1-read-only-browsing.md
@@ -1,0 +1,964 @@
+# Offline Phase 1 — Read-Only Browsing & Status Indicator
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow the app to be opened, navigated, and read fully offline after a single online visit, with a clear staleness-aware status indicator in the page header.
+
+**Architecture:** Three layered freshness mechanisms — (1) the service worker uses `StaleWhileRevalidate` for all data API GETs so cached responses are served instantly while the network refreshes in the background; (2) a boot-time React Query `prefetchQuery` fan-out warms every critical endpoint within a few seconds of app start; (3) write-path forms (`Add Trip`, `Add Reservation`) refetch their dependency data on mount when online so users committing data always work from fresh server state. A new React context tracks online/offline transitions and the cache age, driving a 3-state badge in the header.
+
+**Tech Stack:** Next.js 15 App Router · `@ducanh2912/next-pwa` (Workbox runtime caching) · React Query v5 · React 19 context · vitest
+
+**Closes:** Issue #8
+
+**Branch:** `feature/offline-phase-1`
+
+---
+
+## Architectural decisions (locked-in)
+
+- **Cache strategy:** `StaleWhileRevalidate` for `/api/*` GETs (excluding `/api/auth/*` and `/api/me`, which stay `NetworkFirst` so auth state isn't stale).
+- **Prewarm trigger:** App mount, after auth confirmed (`useMe` returns a user). Fires once per session in parallel.
+- **Stale threshold:** `dataUpdatedAt` minimum across critical queries; `< 1h` = fresh, `≥ 1h` = stale.
+- **Offline detection:** Browser `online`/`offline` events for instant transitions; periodic 30s heartbeat (`HEAD /api/health`) for captive-portal correction.
+- **Indicator placement:** `PageHeader`'s `right` slot, visually before `LangSwitcher`.
+- **Form-open refetch scope:** Only forms whose correctness depends on freshness (`Add Trip` → `lastCarState`; `Add Reservation` → `reservations`). Fuel/Expenses do not need this.
+- **No new client state library:** Use React Query's existing cache + a thin React context for online/staleness. Do not introduce zustand/jotai/etc.
+
+---
+
+## File Structure
+
+**New files:**
+- `app/api/health/route.ts` — minimal unauthenticated GET endpoint for heartbeat checks.
+- `lib/offline/online-state.tsx` — React context, hooks, and `OnlineStateProvider`.
+- `lib/offline/online-state.test.ts` — unit tests for the state-machine logic (extracted to a pure function).
+- `lib/offline/prewarm.ts` — boot-time prefetch helper (`prewarmCriticalEndpoints`) and `useBootPrewarm` hook.
+- `lib/offline/prewarm.test.ts` — unit tests using a real `QueryClient` and `fetch` mock.
+- `components/offline-badge.tsx` — header indicator (3 states for Phase 1).
+
+**Modified files:**
+- `next.config.ts` — add `workboxOptions.runtimeCaching` rules for the API endpoints.
+- `app/providers.tsx` — wrap children in `OnlineStateProvider`, mount `useBootPrewarm`.
+- `components/page-header.tsx` — render `<OfflineBadge />` to the left of `LangSwitcher`.
+- `app/trips/trip-form.tsx` (or wherever the `Add Trip` form lives) — refetch `useLastCarState(carId)` on mount when online.
+- `app/calendar/page.tsx` (the `?action=reserve` path) — refetch reservations on form mount when online.
+- `lib/i18n/messages/nl.ts`, `lib/i18n/messages/en.ts` — add 6 new keys for the indicator and form staleness hint.
+
+**Tests:**
+- `lib/offline/online-state.test.ts`
+- `lib/offline/prewarm.test.ts`
+- `app/api/health/route.test.ts` (smoke test)
+
+---
+
+## Build sequence
+
+Phase 1 is structured so each task produces working code. Tasks 1–3 establish the runtime state machine; Task 4 flips the cache strategy; Task 5–6 add prewarm; Task 7–8 add the visible indicator; Task 9–10 protect write paths; Task 11 is QA. Order matters because Task 8 depends on Task 7's component, and Task 9–10 depend on Task 2's `useOnlineState` hook.
+
+---
+
+### Task 1: Health endpoint
+
+**Files:**
+- Create: `app/api/health/route.ts`
+- Test: `app/api/health/route.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// app/api/health/route.test.ts
+import { describe, it, expect } from "vitest";
+import { GET } from "./route";
+
+describe("GET /api/health", () => {
+  it("returns 200 with { ok: true }", async () => {
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("does not require auth (no Set-Cookie or auth headers)", async () => {
+    const res = await GET();
+    expect(res.headers.get("Set-Cookie")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- lib/offline app/api/health 2>&1 | tail -20`
+Expected: FAIL — `Cannot find module './route'`
+
+- [ ] **Step 3: Implement the route**
+
+```ts
+// app/api/health/route.ts
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  return NextResponse.json({ ok: true });
+}
+```
+
+- [ ] **Step 4: Update middleware to whitelist this endpoint**
+
+Read `middleware.ts` and add `/api/health` to the public-paths list (alongside `/api/auth/*`, `/manifest.json`, `/sw.js`). Exact pattern depends on the existing matcher; the route must respond 200 even without a session cookie.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm test -- app/api/health`
+Expected: PASS (2/2)
+
+- [ ] **Step 6: Manual smoke test**
+
+Run dev server, then in another terminal:
+```bash
+curl -i http://localhost:3000/api/health
+```
+Expected: `HTTP/1.1 200 OK`, body `{"ok":true}`, no `Set-Cookie`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/api/health/route.ts app/api/health/route.test.ts middleware.ts
+git commit -m "feat(api): add /api/health unauthenticated heartbeat endpoint"
+```
+
+---
+
+### Task 2: Online state — pure logic + tests
+
+The state machine has three observable values: `online: boolean`, `lastSyncAt: number | null`, and `isStale: boolean`. We extract the calculation into a pure function so it's trivially testable in `node` env (no DOM needed).
+
+**Files:**
+- Create: `lib/offline/online-state.tsx`
+- Create: `lib/offline/online-state.test.ts`
+
+- [ ] **Step 1: Write failing tests for the pure helpers**
+
+```ts
+// lib/offline/online-state.test.ts
+import { describe, it, expect } from "vitest";
+import { computeStaleness, STALE_THRESHOLD_MS } from "./online-state";
+
+describe("computeStaleness", () => {
+  it("returns 'fresh' when sync was within threshold", () => {
+    const now = 1_700_000_000_000;
+    expect(computeStaleness(now - 60_000, now)).toBe("fresh");
+  });
+
+  it("returns 'stale' when sync was older than threshold", () => {
+    const now = 1_700_000_000_000;
+    expect(computeStaleness(now - STALE_THRESHOLD_MS - 1, now)).toBe("stale");
+  });
+
+  it("returns 'unknown' when never synced", () => {
+    expect(computeStaleness(null, 1_700_000_000_000)).toBe("unknown");
+  });
+
+  it("treats exact threshold boundary as 'fresh'", () => {
+    const now = 1_700_000_000_000;
+    expect(computeStaleness(now - STALE_THRESHOLD_MS, now)).toBe("fresh");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- lib/offline/online-state`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement minimal helpers + context skeleton**
+
+```tsx
+// lib/offline/online-state.tsx
+"use client";
+import { createContext, useContext, useEffect, useRef, useState, useCallback } from "react";
+
+export const STALE_THRESHOLD_MS = 60 * 60 * 1000; // 1 hour
+const HEARTBEAT_INTERVAL_MS = 30 * 1000;          // 30 seconds
+const HEARTBEAT_TIMEOUT_MS = 5 * 1000;            // 5 seconds
+
+export type Staleness = "fresh" | "stale" | "unknown";
+
+export function computeStaleness(lastSyncAt: number | null, now: number): Staleness {
+  if (lastSyncAt === null) return "unknown";
+  return now - lastSyncAt <= STALE_THRESHOLD_MS ? "fresh" : "stale";
+}
+
+export interface OnlineState {
+  online: boolean;
+  lastSyncAt: number | null;
+  staleness: Staleness;
+  markSynced: () => void;
+}
+
+const Ctx = createContext<OnlineState | null>(null);
+
+export function useOnlineState(): OnlineState {
+  const v = useContext(Ctx);
+  if (!v) throw new Error("useOnlineState must be used inside OnlineStateProvider");
+  return v;
+}
+
+async function heartbeat(): Promise<boolean> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), HEARTBEAT_TIMEOUT_MS);
+  try {
+    const res = await fetch("/api/health", { method: "HEAD", signal: ctrl.signal, cache: "no-store" });
+    return res.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function OnlineStateProvider({ children }: { children: React.ReactNode }) {
+  const [online, setOnline] = useState<boolean>(() =>
+    typeof navigator === "undefined" ? true : navigator.onLine
+  );
+  const [lastSyncAt, setLastSyncAt] = useState<number | null>(null);
+  const [now, setNow] = useState(() => Date.now());
+
+  const markSynced = useCallback(() => setLastSyncAt(Date.now()), []);
+
+  useEffect(() => {
+    const onUp = () => setOnline(true);
+    const onDown = () => setOnline(false);
+    window.addEventListener("online", onUp);
+    window.addEventListener("offline", onDown);
+    return () => {
+      window.removeEventListener("online", onUp);
+      window.removeEventListener("offline", onDown);
+    };
+  }, []);
+
+  // Heartbeat: validates that we actually have connectivity (catches captive portals).
+  useEffect(() => {
+    if (!online) return;
+    let cancelled = false;
+    const id = setInterval(async () => {
+      const ok = await heartbeat();
+      if (!cancelled) setOnline(ok);
+    }, HEARTBEAT_INTERVAL_MS);
+    return () => { cancelled = true; clearInterval(id); };
+  }, [online]);
+
+  // Tick `now` once a minute so staleness updates without remounts.
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 60_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const value: OnlineState = {
+    online,
+    lastSyncAt,
+    staleness: computeStaleness(lastSyncAt, now),
+    markSynced,
+  };
+
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- lib/offline/online-state`
+Expected: PASS (4/4)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/offline/online-state.tsx lib/offline/online-state.test.ts
+git commit -m "feat(offline): online-state context with heartbeat and staleness"
+```
+
+---
+
+### Task 3: Wire OnlineStateProvider into the app
+
+**Files:**
+- Modify: `app/providers.tsx`
+
+- [ ] **Step 1: Wrap Providers with OnlineStateProvider**
+
+```tsx
+// app/providers.tsx
+"use client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Toaster } from "sonner";
+import { useState } from "react";
+import { OnlineStateProvider } from "@/lib/offline/online-state";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const [client] = useState(() => new QueryClient());
+  return (
+    <QueryClientProvider client={client}>
+      <OnlineStateProvider>
+        {children}
+        <Toaster position="bottom-center" />
+      </OnlineStateProvider>
+    </QueryClientProvider>
+  );
+}
+```
+
+- [ ] **Step 2: Verify nothing breaks**
+
+Run: `npm test`
+Expected: all existing tests pass.
+
+Run: `npm run dev` and load `/` — page should load normally; no console errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/providers.tsx
+git commit -m "feat(offline): wire OnlineStateProvider into app shell"
+```
+
+---
+
+### Task 4: Switch SW runtime caching to StaleWhileRevalidate for data APIs
+
+This is the load-bearing change. The current SW uses `NetworkFirst` for `/api/*` (10s timeout, then cache). We swap to `StaleWhileRevalidate` for *data* endpoints so cached data is served instantly. Auth and identity endpoints stay `NetworkFirst` so the user can't get stuck logged-in after their session is revoked.
+
+**Files:**
+- Modify: `next.config.ts`
+
+- [ ] **Step 1: Add explicit runtime caching rules**
+
+```ts
+// next.config.ts
+import type { NextConfig } from "next";
+import withPWAInit from "@ducanh2912/next-pwa";
+
+const withPWA = withPWAInit({
+  dest: "public",
+  register: true,
+  workboxOptions: {
+    skipWaiting: true,
+    importScripts: ["/sw-helpers.js"],
+    runtimeCaching: [
+      // Auth & identity — must always reflect latest server state.
+      {
+        urlPattern: ({ url }) =>
+          url.pathname === "/api/me" || url.pathname.startsWith("/api/auth/"),
+        handler: "NetworkFirst",
+        options: {
+          cacheName: "api-auth",
+          networkTimeoutSeconds: 5,
+          expiration: { maxEntries: 8, maxAgeSeconds: 60 * 60 },
+        },
+      },
+      // Health endpoint — never cache (used as a heartbeat).
+      {
+        urlPattern: ({ url }) => url.pathname === "/api/health",
+        handler: "NetworkOnly",
+      },
+      // Data APIs — serve cache instantly, refresh in background.
+      {
+        urlPattern: ({ url, request, sameOrigin }) =>
+          sameOrigin && request.method === "GET" && url.pathname.startsWith("/api/"),
+        handler: "StaleWhileRevalidate",
+        options: {
+          cacheName: "api-data",
+          expiration: { maxEntries: 64, maxAgeSeconds: 7 * 24 * 60 * 60 },
+        },
+      },
+    ],
+  },
+  disable: process.env.NODE_ENV === "development",
+  publicExcludes: ["!icons/source.svg"],
+});
+
+const nextConfig: NextConfig = {
+  output: "standalone",
+  serverExternalPackages: ["better-sqlite3"],
+  async rewrites() {
+    return [
+      { source: "/uploads/:path*", destination: "/api/static/:path*" },
+    ];
+  },
+};
+
+export default withPWA(nextConfig);
+```
+
+- [ ] **Step 2: Verify the SW regenerates**
+
+```bash
+rm -rf .next public/sw.js public/workbox-*.js
+npm run build 2>&1 | tail -20
+ls public/sw.js public/workbox-*.js
+grep -c "StaleWhileRevalidate" public/sw.js
+```
+Expected: build succeeds, `sw.js` regenerated, contains `StaleWhileRevalidate`.
+
+- [ ] **Step 3: Manual offline test (must pass before continuing)**
+
+```bash
+npm run start  # production server, SW is active
+```
+
+In Chrome with a fresh profile or incognito + DevTools:
+1. Visit `http://localhost:3000/`, log in
+2. Navigate to `/trips`, `/fuel`, `/expenses`, `/calendar`
+3. DevTools → Application → Service Workers → tick **Offline**
+4. Click each tab in the bottom bar — every list should still render
+5. Click a trip in the list — the edit sheet should open with correct data
+
+If any tab shows `ERR_FAILED`, the SW config is wrong; fix before proceeding.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add next.config.ts
+git commit -m "feat(pwa): StaleWhileRevalidate for data APIs, NetworkFirst for auth"
+```
+
+---
+
+### Task 5: Boot-time prewarm helper
+
+**Files:**
+- Create: `lib/offline/prewarm.ts`
+- Create: `lib/offline/prewarm.test.ts`
+
+The prewarm function takes a `QueryClient` and a list of endpoint specs, fires them in parallel via `prefetchQuery`, and resolves when all complete (or fail). Test it with a fake fetcher.
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+// lib/offline/prewarm.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { QueryClient } from "@tanstack/react-query";
+import { prewarmCriticalEndpoints, CRITICAL_ENDPOINTS } from "./prewarm";
+
+describe("prewarmCriticalEndpoints", () => {
+  it("calls fetcher for every critical endpoint in parallel", async () => {
+    const fetcher = vi.fn().mockResolvedValue([]);
+    const qc = new QueryClient();
+    await prewarmCriticalEndpoints(qc, fetcher);
+    expect(fetcher).toHaveBeenCalledTimes(CRITICAL_ENDPOINTS.length);
+    for (const ep of CRITICAL_ENDPOINTS) {
+      expect(fetcher).toHaveBeenCalledWith(ep.url);
+    }
+  });
+
+  it("does not throw when an individual fetch fails", async () => {
+    const fetcher = vi.fn().mockImplementation((url: string) =>
+      url.includes("trips") ? Promise.reject(new Error("boom")) : Promise.resolve([])
+    );
+    const qc = new QueryClient();
+    await expect(prewarmCriticalEndpoints(qc, fetcher)).resolves.toBeDefined();
+  });
+
+  it("populates the QueryClient cache for successful fetches", async () => {
+    const fetcher = vi.fn().mockResolvedValue([{ id: 1 }]);
+    const qc = new QueryClient();
+    await prewarmCriticalEndpoints(qc, fetcher);
+    const tripsState = qc.getQueryState(["trips"]);
+    expect(tripsState?.data).toEqual([{ id: 1 }]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm test -- lib/offline/prewarm`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement prewarm**
+
+```ts
+// lib/offline/prewarm.ts
+"use client";
+import { useEffect, useRef } from "react";
+import type { QueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
+import { useOnlineState } from "./online-state";
+
+export interface CriticalEndpoint {
+  queryKey: readonly unknown[];
+  url: string;
+}
+
+export const CRITICAL_ENDPOINTS: readonly CriticalEndpoint[] = [
+  { queryKey: ["dashboard"],     url: "/api/dashboard" },
+  { queryKey: ["trips"],         url: "/api/trips" },
+  { queryKey: ["fuel"],          url: "/api/fuel" },
+  { queryKey: ["expenses"],      url: "/api/expenses" },
+  { queryKey: ["reservations"],  url: "/api/reservations" },
+  { queryKey: ["people"],        url: "/api/people" },
+  { queryKey: ["cars"],          url: "/api/cars" },
+] as const;
+
+export type Fetcher = (url: string) => Promise<unknown>;
+
+export async function prewarmCriticalEndpoints(
+  qc: QueryClient,
+  fetcher: Fetcher = defaultFetcher
+): Promise<PromiseSettledResult<unknown>[]> {
+  const tasks = CRITICAL_ENDPOINTS.map((ep) =>
+    qc.prefetchQuery({ queryKey: ep.queryKey, queryFn: () => fetcher(ep.url) })
+      .then(() => qc.getQueryData(ep.queryKey))
+  );
+  return Promise.allSettled(tasks);
+}
+
+async function defaultFetcher(url: string): Promise<unknown> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`${url} → ${res.status}`);
+  return res.json();
+}
+
+export function useBootPrewarm(authReady: boolean) {
+  const qc = useQueryClient();
+  const { online, markSynced } = useOnlineState();
+  const ranRef = useRef(false);
+
+  useEffect(() => {
+    if (ranRef.current) return;
+    if (!authReady || !online) return;
+    ranRef.current = true;
+    prewarmCriticalEndpoints(qc).then((results) => {
+      const anyOk = results.some((r) => r.status === "fulfilled");
+      if (anyOk) markSynced();
+    });
+  }, [authReady, online, qc, markSynced]);
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npm test -- lib/offline/prewarm`
+Expected: PASS (3/3).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/offline/prewarm.ts lib/offline/prewarm.test.ts
+git commit -m "feat(offline): boot-time prewarm of critical API endpoints"
+```
+
+---
+
+### Task 6: Mount the prewarm hook
+
+**Files:**
+- Modify: `app/providers.tsx`
+
+The hook needs `authReady = true`, which means a successful `useMe` call. Mount it inside an inner client component so it has access to context.
+
+- [ ] **Step 1: Add a `BootPrewarm` mounter inside `Providers`**
+
+```tsx
+// app/providers.tsx
+"use client";
+import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
+import { Toaster } from "sonner";
+import { useState } from "react";
+import { OnlineStateProvider } from "@/lib/offline/online-state";
+import { useBootPrewarm } from "@/lib/offline/prewarm";
+
+function BootPrewarm() {
+  // useMe is the auth signal. Read it here so prewarm gates on auth.
+  const { data, isFetched } = useQuery<{ personId: number | null } | null>({
+    queryKey: ["me"],
+    queryFn: async () => {
+      const res = await fetch("/api/me");
+      if (!res.ok) return null;
+      return res.json();
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+  useBootPrewarm(isFetched && data?.personId != null);
+  return null;
+}
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const [client] = useState(() => new QueryClient());
+  return (
+    <QueryClientProvider client={client}>
+      <OnlineStateProvider>
+        <BootPrewarm />
+        {children}
+        <Toaster position="bottom-center" />
+      </OnlineStateProvider>
+    </QueryClientProvider>
+  );
+}
+```
+
+- [ ] **Step 2: Manual verification**
+
+Run `npm run dev`. Log in. Open DevTools → Network → filter `/api/`. Within ~1s of dashboard load you should see GETs to `/api/trips`, `/api/fuel`, `/api/expenses`, `/api/reservations`, `/api/people`, `/api/cars` (in addition to whatever the dashboard itself triggered).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/providers.tsx
+git commit -m "feat(offline): trigger boot-time prewarm after auth resolved"
+```
+
+---
+
+### Task 7: Offline badge component (3 states)
+
+Three states for Phase 1: `null` (online + fresh, render nothing), `offline-fresh` (grey), `offline-stale` (amber). Pure presentational — receives state via `useOnlineState`.
+
+**Files:**
+- Create: `components/offline-badge.tsx`
+- Modify: `lib/i18n/messages/nl.ts`, `lib/i18n/messages/en.ts`
+
+- [ ] **Step 1: Add i18n keys**
+
+```ts
+// lib/i18n/messages/nl.ts (add to the export map)
+"offline.label": "OFFLINE",
+"offline.stale_suffix": "ouder dan 1u",
+"offline.tooltip_fresh": "Je bent offline. Gegevens zijn recent gesynchroniseerd.",
+"offline.tooltip_stale": "Je bent offline en de gegevens zijn ouder dan een uur.",
+```
+
+```ts
+// lib/i18n/messages/en.ts
+"offline.label": "OFFLINE",
+"offline.stale_suffix": "data >1h old",
+"offline.tooltip_fresh": "You are offline. Data was recently synced.",
+"offline.tooltip_stale": "You are offline and the data is over an hour old.",
+```
+
+- [ ] **Step 2: Implement the badge**
+
+```tsx
+// components/offline-badge.tsx
+"use client";
+import { useOnlineState } from "@/lib/offline/online-state";
+import { paper, fontMono } from "@/lib/paper-theme";
+import { useT } from "@/components/locale-provider";
+
+export function OfflineBadge() {
+  const t = useT();
+  const { online, staleness } = useOnlineState();
+
+  if (online) return null;
+
+  const isStale = staleness === "stale" || staleness === "unknown";
+  const color = isStale ? paper.amber : paper.inkDim;
+  const tooltip = isStale ? t("offline.tooltip_stale") : t("offline.tooltip_fresh");
+
+  return (
+    <span
+      role="status"
+      aria-live="polite"
+      title={tooltip}
+      style={{
+        padding: "3px 8px",
+        fontFamily: fontMono,
+        fontSize: 9,
+        fontWeight: 700,
+        letterSpacing: 1.5,
+        textTransform: "uppercase",
+        background: "transparent",
+        color,
+        border: `1.5px solid ${color}`,
+        whiteSpace: "nowrap",
+        lineHeight: 1.4,
+      }}
+    >
+      {t("offline.label")}{isStale && ` · ${t("offline.stale_suffix")}`}
+    </span>
+  );
+}
+```
+
+- [ ] **Step 3: Manual smoke test**
+
+Run dev, log in, open `/`. DevTools → Network → set throttling to **Offline**. Within a second the page header gains the `OFFLINE` badge. Restore network — badge disappears.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/offline-badge.tsx lib/i18n/messages/nl.ts lib/i18n/messages/en.ts
+git commit -m "feat(offline): header badge with fresh/stale states"
+```
+
+---
+
+### Task 8: Wire badge into PageHeader
+
+**Files:**
+- Modify: `components/page-header.tsx`
+
+The badge goes into the existing `right` slot of the header, before `LangSwitcher`.
+
+- [ ] **Step 1: Add OfflineBadge to header**
+
+```tsx
+// components/page-header.tsx — change the right-side cluster
+import { OfflineBadge } from "./offline-badge";
+
+// inside the header JSX, replace:
+//   <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+//     {right}
+//     <LangSwitcher />
+//     <button onClick={handleLogout} ...>⏻</button>
+//   </div>
+// with:
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <OfflineBadge />
+          {right}
+          <LangSwitcher />
+          <button
+            onClick={handleLogout}
+            title={t("nav.logout")}
+            style={{ /* unchanged */ }}
+          >
+            ⏻
+          </button>
+        </div>
+```
+
+- [ ] **Step 2: Manual verification on every page**
+
+Run dev, log in, toggle DevTools offline mode, visit each page. Badge should appear/disappear consistently across `/`, `/trips`, `/fuel`, `/expenses`, `/calendar`, `/admin`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/page-header.tsx
+git commit -m "feat(offline): show OfflineBadge in every page header"
+```
+
+---
+
+### Task 9: Trip form — refetch lastCarState on mount when online
+
+**Files:**
+- Modify: the trip form file (likely `app/trips/trip-form.tsx`)
+
+First find the form. The plan assumes it uses a hook like `useLastCarState(carId)` to populate `start_odometer`. Confirm by inspecting before editing.
+
+- [ ] **Step 1: Locate the trip form and its dependency hook**
+
+Run:
+```bash
+grep -rn "last-state\|lastCarState\|useLastState" app/ hooks/ --include="*.tsx" --include="*.ts"
+```
+
+Identify the file that opens the `Add Trip` form and the hook it calls. The form file path goes into "Files: Modify" above.
+
+- [ ] **Step 2: Add a freshening effect inside the form component**
+
+Append this hook usage to the form's top-level effects (just below existing hook calls):
+
+```tsx
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useOnlineState } from "@/lib/offline/online-state";
+
+// inside the form component:
+const qc = useQueryClient();
+const { online } = useOnlineState();
+
+useEffect(() => {
+  if (!online) return;
+  if (carId == null) return;
+  // Force a fresh fetch of the car's last state — overrides any staleTime.
+  qc.invalidateQueries({ queryKey: ["lastCarState", carId] });
+}, [online, carId, qc]);
+```
+
+If the existing query key shape differs (e.g. `["cars", carId, "lastState"]`), adapt the key. Confirm the exact key by reading the hook found in Step 1.
+
+- [ ] **Step 3: Add a small "last synced" hint when offline**
+
+In the form, near the `start_odometer` input, render a hint when offline:
+
+```tsx
+import { useT } from "@/components/locale-provider";
+
+// new i18n keys (add in nl.ts and en.ts):
+//   "form.offline_start_km_hint": "Offline — start KM is van laatste sync."
+//   "form.offline_start_km_hint": "Offline — start KM is from last sync."
+
+// near the start_odometer input:
+{!online && (
+  <div style={{
+    fontFamily: fontMono, fontSize: 9, color: paper.amber,
+    letterSpacing: 1, marginTop: 2, textTransform: "uppercase",
+  }}>
+    {t("form.offline_start_km_hint")}
+  </div>
+)}
+```
+
+- [ ] **Step 4: Manual verification**
+
+Run dev, log a trip with car X, save. Wait long enough that staleTime expires for `lastCarState` (or just open the form). Verify the network panel shows a `GET /api/cars/X/last-state` *every time* the form opens, not just the first.
+
+Then: go offline (DevTools), open form — request fails, `start_odometer` falls back to cached value, hint message visible.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add <trip-form-file> lib/i18n/messages/nl.ts lib/i18n/messages/en.ts
+git commit -m "feat(offline): refetch lastCarState on trip form open + offline hint"
+```
+
+---
+
+### Task 10: Reservation form — refetch reservations on mount when online
+
+**Files:**
+- Modify: `app/calendar/page.tsx` (the `?action=reserve` flow)
+
+Same pattern: when the new-reservation sheet opens (controlled by `searchParams.get("action") === "reserve"` per the deep-linking work), force a refetch of `["reservations"]` if online.
+
+- [ ] **Step 1: Add the freshening effect to the reservation flow**
+
+Inside the calendar page's content component, near where the sheet opens:
+
+```tsx
+const qc = useQueryClient();
+const { online } = useOnlineState();
+const sheetOpen = searchParams.get("action") === "reserve";
+
+useEffect(() => {
+  if (!sheetOpen || !online) return;
+  qc.invalidateQueries({ queryKey: ["reservations"] });
+}, [sheetOpen, online, qc]);
+```
+
+- [ ] **Step 2: Manual verification**
+
+Open calendar, click `Reserveer` to open the sheet. Network tab should show a `GET /api/reservations` even if the list was already loaded. Toggle offline and reopen the sheet — no new request, existing conflict warning still works against cached data.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/calendar/page.tsx
+git commit -m "feat(offline): refetch reservations on new-reservation sheet open"
+```
+
+---
+
+### Task 11: End-to-end manual QA
+
+**Files:** none — this is verification.
+
+- [ ] **Step 1: Cold-start prewarm verification**
+
+```bash
+npm run build && npm run start
+```
+
+In Chrome incognito:
+1. Visit `http://localhost:3000`, log in
+2. Network tab → filter `/api/`
+3. Within 2s of dashboard load: GETs to `/api/me`, `/api/dashboard`, `/api/trips`, `/api/fuel`, `/api/expenses`, `/api/reservations`, `/api/people`, `/api/cars` should all appear
+4. DevTools → Application → Cache Storage → `api-data` should contain entries for all of the above
+
+- [ ] **Step 2: Offline browsing verification**
+
+Same session, after step 1:
+1. DevTools → Application → Service Workers → tick **Offline**
+2. Click each bottom-tab: dashboard, trips, fuel, calendar, expenses → all render
+3. Click an existing trip → edit sheet opens with full data
+4. Click an existing fuel-up → edit sheet opens
+5. Click an expense → sheet opens
+6. Click a calendar reservation → edit sheet opens
+7. Header shows `OFFLINE` (grey, not amber, since cache is fresh)
+
+- [ ] **Step 3: Stale-cache verification**
+
+To force the `OFFLINE · ouder dan 1u` state without waiting an hour, in DevTools console:
+```js
+// Bypass: temporarily lower the threshold by hot-replacing the constant in dev tools, or
+// simulate by visiting in an incognito window with a stored old `lastSyncAt` in React DevTools.
+```
+Practical alternative: temporarily change `STALE_THRESHOLD_MS` to `60_000` (1 min), wait 90s while offline, confirm amber appears, then revert.
+
+- [ ] **Step 4: Form refetch verification**
+
+Online: open Add Trip form → see `GET /api/cars/X/last-state` in network. Close form, change one byte in the seed data via direct DB edit. Re-open form → updated value shown.
+
+- [ ] **Step 5: Heartbeat verification**
+
+Online, open the page. Every 30s a `HEAD /api/health` request should appear. Take the network down at the OS level (not just DevTools) — within 30s the heartbeat fails and the badge transitions to OFFLINE without needing the browser's `offline` event.
+
+- [ ] **Step 6: Note any regressions in TodoWrite and address them before PR**
+
+---
+
+### Task 12: Open the PR
+
+**Files:** none — this is the workflow handoff.
+
+- [ ] **Step 1: Run the full test suite once more**
+
+```bash
+npm test
+```
+Expected: all green.
+
+- [ ] **Step 2: Push and PR**
+
+```bash
+git push -u origin feature/offline-phase-1
+gh pr create --title "feat(offline): Phase 1 — read-only offline browsing" --body "$(cat <<'EOF'
+## Summary
+- Switches data API caching from NetworkFirst to StaleWhileRevalidate
+- Boot-time parallel prewarm of all critical endpoints after auth
+- Header badge with fresh/stale offline states + heartbeat-validated online detection
+- Form-open refetch for trip and reservation forms (start_km / conflict freshness)
+
+Closes #8.
+
+## Test plan
+- [ ] First visit + login: all critical endpoints appear in Network within 2s
+- [ ] Toggle DevTools offline → all list pages still render with data
+- [ ] Toggle DevTools offline → detail/edit sheets open correctly
+- [ ] Header badge appears when offline, disappears when online
+- [ ] Stale state (amber) shows when cache age > 1h
+- [ ] Heartbeat detects captive-portal-style failures within 30s
+- [ ] All 41+ existing tests still pass
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Review and merge**
+
+After self-review, merge to main. Trigger Docker build. Pull on VPS:
+```bash
+ssh root@100.86.173.115 "cd /opt/dockge/stacks/autodelen && docker compose pull && docker compose up -d"
+```
+
+---
+
+## Self-review checklist (run after writing the plan)
+
+- [x] **Spec coverage:** Every Phase-1 acceptance criterion in issue #8 maps to a task (prewarm → 5/6, indicator → 7/8, details fix → 4, write-path freshness → 9/10, online indicator → 7/8).
+- [x] **No placeholders:** Every step has either real code, an exact command, or an explicit local-discovery instruction with the grep needed.
+- [x] **Type consistency:** `OnlineState`, `Staleness`, `CriticalEndpoint`, `Fetcher` declared once in their owning files and referenced consistently.
+- [x] **Test environment:** vitest's default `node` env handles every test in this plan; no jsdom-only assertions are made (component tests are deferred to manual QA, which is acknowledged).
+- [x] **Idempotency of tasks:** every task either creates new files or makes additive changes; no task depends on uncommitted state from another.
+
+---
+
+## Risks & mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| `runtimeCaching` config syntax differs from `@ducanh2912/next-pwa` v10 | Medium | Task 4 Step 2 verifies SW regenerates and contains `StaleWhileRevalidate`. If syntax wrong, fix before merging. |
+| RSC payload for detail sheets isn't covered by `/api/*` rule | Medium | Task 11 Step 2 explicitly tests detail-sheet offline behavior. If broken, add a route for `?_rsc=` pattern in next.config. |
+| Heartbeat creates noise in production logs | Low | `/api/health` is intentionally tiny; can be filtered in log aggregator if needed. 30s × users is small at this scale. |
+| `useBootPrewarm` runs before SW activates on first visit | Low | First prewarm goes to network anyway; subsequent ones use SW cache. Acceptable. |
+| Stale threshold of 1h is wrong for the user base | Low | One-line constant; tweak after observation. |

--- a/docs/superpowers/plans/2026-04-27-offline-phase-2-write-queue-and-sync.md
+++ b/docs/superpowers/plans/2026-04-27-offline-phase-2-write-queue-and-sync.md
@@ -20,7 +20,19 @@
 
 - **ID strategy:** Server keeps integer autoincrement `id` as the primary key (don't break existing FK relationships). Add `client_id TEXT UNIQUE` as a secondary identifier for idempotency. Optimistic rows use the `client_id` as their React Query identity until the real `id` arrives.
 - **Conflict policy:** Last-write-wins, with a soft check. Each mutable row has `updated_at`. Client sends `If-Unmodified-Since`-style header (`X-Expected-Updated-At`) on PUT. If server's `updated_at` is newer, return 409. On 409, drop the queued item and toast the user. No automatic merge.
-- **Mutation scope:** `trips`, `fuel_fillups`, `expenses`, `reservations`. `people` and `cars` are admin-only and rarer — out of scope for Phase 2 (admin can be required to be online; document this).
+- **Mutation scope (priority-ordered):**
+  - **Primary — full offline write support:**
+    - `trips` — the highest-frequency action; logging a trip in the field is the canonical offline use case.
+    - `fuel_fillups` — second-most-frequent; often filled in at the pump where signal is unreliable.
+  - **Secondary — full offline write support:**
+    - `expenses` — member-initiated extra-cost logging.
+    - `reservations` — booking the car for a future window (the create/edit/delete flow only).
+  - **Read-only offline (writes require connection):**
+    - **Reservation status changes** (admin confirm/reject) — confirming a booking offline could mislead users about availability.
+    - **Admin screens** under `/admin/*` (inbox, member management, settlement, payouts, hygiene gap-assignment, owner break-even tooling).
+    - **Owner screens** (car management, fixed costs, price history, expected-km).
+    - **People & cars CRUD** (admin-only forms).
+  - **Rationale:** the offline experience targets the *member* in the field. Admin and owner workflows are deliberate and benefit from the consistency of a live server; making them write-offline introduces failure modes (e.g. queued reservation confirms creating phantom availability) that aren't worth the complexity for a use case that almost always happens at a desk.
 - **Library choices:** `idb` (5 KB, well-maintained, typed wrapper). No Dexie, no Replicache, no full sync engine.
 - **Drain trigger:** primary path is the `online` event (works in all browsers). Background Sync API is registered as a fallback for cases where the tab is closed before reconnect; we accept that Safari ignores Background Sync.
 - **No background fetcher worker:** the drainer runs in the page context, not the SW. Simpler, easier to reason about React Query invalidation. The only thing the SW does is fire the Background Sync event back to a focused client.
@@ -65,15 +77,20 @@
 
 ## Build sequence
 
-This is a thicker plan than Phase 1. Order matters:
+This is a thicker plan than Phase 1. Order matters and follows the priority pattern (trips → fuel → expenses → reservations) so the high-value member workflows are working end-to-end before we touch the secondary ones:
 
 1. **Schema first** (Task 1–2) so server can be built against it.
-2. **Server idempotency** (Task 3–6) — one resource at a time, fully tested.
-3. **Client UUID** + **outbox** + **sync engine** (Task 7–10) — the offline machinery, still without UI hooks.
-4. **Mutation hooks integration** (Task 11–14) — one entity at a time.
-5. **UI feedback** (Task 15–16) — pending badge in lists, queued count in offline badge.
-6. **End-to-end QA** (Task 17).
-7. **PR** (Task 18).
+2. **Server idempotency, primary scope** (Task 3–4) — trips end-to-end (POST idempotent, PUT conflict-checked, DELETE idempotent), fully tested.
+3. **Server idempotency, primary scope cont.** (Task 5) — fuel, mirror of trips.
+4. **Server idempotency, secondary scope** (Task 6) — expenses + reservations (member create/edit/delete only; the `/api/reservations/[id]/status` admin endpoint stays untouched and online-only).
+5. **Client UUID** + **outbox** + **sync engine** (Task 7–10) — the offline machinery, still without UI hooks.
+6. **Mutation hooks, primary scope** (Task 11–12) — trips, then fuel. After Task 12 the highest-value offline path is shippable on its own if needed.
+7. **Mutation hooks, secondary scope** (Task 13–14) — expenses, reservations.
+8. **UI feedback** (Task 15–16) — pending badge in lists, queued count in offline badge.
+9. **End-to-end QA** (Task 17).
+10. **PR** (Task 18).
+
+If at any point this branch grows uncomfortably large, it's safe to ship after Task 12 (primary scope only), open #20 follow-up issues for secondary scope, and merge in two waves. The architectural pieces (outbox, drainer, optimistic helpers) don't change between waves.
 
 ---
 
@@ -1472,6 +1489,7 @@ Watch for the migration to apply on container start. Verify on production by add
 
 - **Multi-device sync / real-time:** out of scope; this is single-device offline.
 - **CRDT-based merging:** unnecessary at this concurrency level.
-- **Admin operations offline (cars, members):** require online connectivity. Document in user help text.
-- **Reservation status changes offline:** the social contract here is that confirming a reservation should be deliberate and online; queueing confirms could mislead users.
+- **Admin & owner offline writes:** all `/admin/*` workflows (inbox, settlement, payouts, hygiene gap-assignment, member CRUD, car CRUD, fixed-cost editing, price history) require connectivity. Surface this as a polite hint in the page header when an admin opens an admin screen offline (e.g. `OFFLINE — admin features require connection`).
+- **Reservation status changes offline:** confirming or rejecting a booking is an admin action with cross-member visibility consequences; queueing it could mislead users about availability.
 - **Outbox eviction / age-based GC:** can be added later as a maintenance hook; not needed in Phase 2.
+- **Per-resource priority differences in the runtime:** all four scoped resources share the same outbox, drainer, and optimistic helpers. The "primary vs secondary" split only governs *implementation order*, not runtime behavior.

--- a/docs/superpowers/plans/2026-04-27-offline-phase-2-write-queue-and-sync.md
+++ b/docs/superpowers/plans/2026-04-27-offline-phase-2-write-queue-and-sync.md
@@ -1,0 +1,1477 @@
+# Offline Phase 2 — Write Queue, Optimistic UI & Background Sync
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make add/edit/delete operations work offline by queueing them locally, applying them optimistically to the UI, and replaying them to the server when connectivity returns — without producing duplicates or silent data loss.
+
+**Architecture:** Three-layer write pipeline. (1) **Server contract:** every mutable table gains a `client_id TEXT UNIQUE` column for idempotent inserts and an `updated_at` column for last-write-wins conflict checks. POST endpoints accept an optional `client_id`; PUT/DELETE endpoints become idempotent by construction. (2) **Client outbox:** a tiny IndexedDB-backed FIFO queue (via the `idb` library) stores pending mutations with their `client_id`, method, URL, body, and queue timestamp. Mutations write to the outbox *and* React Query's cache (optimistic update) on commit. (3) **Sync engine:** a singleton drainer fires on `online` events and on Background Sync API tags, replaying queued items in order. Successful replays remove from the outbox and reconcile React Query cache with the server response. Conflicts (HTTP 409) drop with a toast.
+
+**Tech Stack:** Next.js 15 App Router · better-sqlite3 migrations · `idb` (^8) for typed IndexedDB · React Query v5 mutations · Workbox Background Sync API
+
+**Depends on:** Issue #8 (Phase 1) merged.
+
+**Closes:** Issue #20
+
+**Branch:** `feature/offline-phase-2`
+
+---
+
+## Architectural decisions (locked-in)
+
+- **ID strategy:** Server keeps integer autoincrement `id` as the primary key (don't break existing FK relationships). Add `client_id TEXT UNIQUE` as a secondary identifier for idempotency. Optimistic rows use the `client_id` as their React Query identity until the real `id` arrives.
+- **Conflict policy:** Last-write-wins, with a soft check. Each mutable row has `updated_at`. Client sends `If-Unmodified-Since`-style header (`X-Expected-Updated-At`) on PUT. If server's `updated_at` is newer, return 409. On 409, drop the queued item and toast the user. No automatic merge.
+- **Mutation scope:** `trips`, `fuel_fillups`, `expenses`, `reservations`. `people` and `cars` are admin-only and rarer — out of scope for Phase 2 (admin can be required to be online; document this).
+- **Library choices:** `idb` (5 KB, well-maintained, typed wrapper). No Dexie, no Replicache, no full sync engine.
+- **Drain trigger:** primary path is the `online` event (works in all browsers). Background Sync API is registered as a fallback for cases where the tab is closed before reconnect; we accept that Safari ignores Background Sync.
+- **No background fetcher worker:** the drainer runs in the page context, not the SW. Simpler, easier to reason about React Query invalidation. The only thing the SW does is fire the Background Sync event back to a focused client.
+- **UI feel:** every queued create/update appears in the list immediately with a subtle "pending" indicator (italic + small `↻` glyph). On successful sync the indicator clears. On conflict it briefly flashes red before being removed.
+
+---
+
+## File Structure
+
+**New files:**
+- `migrations/0003_add_client_id_and_updated_at.sql` — schema migration.
+- `lib/offline/outbox.ts` — IndexedDB wrapper (`enqueue`, `peek`, `drain`, `remove`, `count`, `list`).
+- `lib/offline/outbox.test.ts` — uses `fake-indexeddb` to test queue operations end-to-end.
+- `lib/offline/sync-engine.ts` — drainer logic + `useSyncEngine` hook + Background Sync registration.
+- `lib/offline/sync-engine.test.ts` — drainer unit tests with a mock fetcher.
+- `lib/offline/uuid.ts` — thin wrapper around `crypto.randomUUID()` with a Node fallback for tests.
+- `lib/offline/optimistic.ts` — helpers for optimistic React Query cache mutations (insert pending row, replace on success, remove on rollback).
+- `components/pending-badge.tsx` — small `↻` glyph component used in list rows.
+
+**Modified files:**
+- `lib/db/migrate.ts` — no change (it auto-discovers migrations) but verify.
+- `app/api/trips/route.ts` (POST) — accept optional `client_id`, return existing record on duplicate.
+- `app/api/trips/[id]/route.ts` (PUT, DELETE) — verify `X-Expected-Updated-At`, idempotent delete.
+- Same trio for `fuel_fillups`, `expenses`, `reservations` (12 endpoints total).
+- `lib/queries/*.ts` — return `client_id` and `updated_at` in SELECT projections.
+- `types/index.ts` (or wherever shared types live) — add `client_id`, `updated_at` to entity interfaces.
+- `hooks/use-trips.ts`, `hooks/use-fuel.ts`, `hooks/use-expenses.ts`, `hooks/use-reservations.ts` — wrap mutations in `enqueueOnFailure` + optimistic update.
+- `lib/offline/online-state.tsx` — extend context with `pendingCount`, expose a setter for the sync engine to update.
+- `components/offline-badge.tsx` — extend to 4-state model: hidden / offline-fresh / offline-stale / queued-count.
+- `lib/i18n/messages/{nl,en}.ts` — new keys for queue UI and conflict toasts.
+- `app/providers.tsx` — mount `useSyncEngine`.
+- The four list pages (`/trips`, `/fuel`, `/expenses`, `/calendar`) — render `<PendingBadge />` on rows whose `id < 0` (sentinel) or have `_pending: true`.
+
+**Tests:**
+- `lib/offline/outbox.test.ts`
+- `lib/offline/sync-engine.test.ts`
+- `lib/offline/optimistic.test.ts`
+- `lib/__tests__/migration_0003.test.ts` — verifies the new schema, idempotent inserts via `client_id`.
+- `lib/__tests__/api_idempotency.test.ts` — POST same `client_id` twice, expect a single row.
+
+---
+
+## Build sequence
+
+This is a thicker plan than Phase 1. Order matters:
+
+1. **Schema first** (Task 1–2) so server can be built against it.
+2. **Server idempotency** (Task 3–6) — one resource at a time, fully tested.
+3. **Client UUID** + **outbox** + **sync engine** (Task 7–10) — the offline machinery, still without UI hooks.
+4. **Mutation hooks integration** (Task 11–14) — one entity at a time.
+5. **UI feedback** (Task 15–16) — pending badge in lists, queued count in offline badge.
+6. **End-to-end QA** (Task 17).
+7. **PR** (Task 18).
+
+---
+
+### Task 1: Migration — `client_id` and `updated_at` columns
+
+**Files:**
+- Create: `migrations/0003_add_client_id_and_updated_at.sql`
+- Test: `lib/__tests__/migration_0003.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// lib/__tests__/migration_0003.test.ts
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../db/migrate";
+
+describe("migration 0003", () => {
+  it("adds client_id and updated_at to trips", () => {
+    const db = new Database(":memory:");
+    runMigrations(db);
+    const cols = db.prepare("PRAGMA table_info(trips)").all() as { name: string }[];
+    const names = cols.map((c) => c.name);
+    expect(names).toContain("client_id");
+    expect(names).toContain("updated_at");
+  });
+
+  it("adds the same columns to fuel_fillups, expenses, reservations", () => {
+    const db = new Database(":memory:");
+    runMigrations(db);
+    for (const t of ["fuel_fillups", "expenses", "reservations"]) {
+      const cols = db.prepare(`PRAGMA table_info(${t})`).all() as { name: string }[];
+      const names = cols.map((c) => c.name);
+      expect(names, `${t} missing client_id`).toContain("client_id");
+      expect(names, `${t} missing updated_at`).toContain("updated_at");
+    }
+  });
+
+  it("enforces UNIQUE on client_id per table", () => {
+    const db = new Database(":memory:");
+    runMigrations(db);
+    // seed
+    db.exec("INSERT INTO people (id,name) VALUES (1,'P')");
+    db.exec("INSERT INTO cars (id,short,name,price_per_km) VALUES (1,'X','c',0.2)");
+    db.prepare(
+      "INSERT INTO trips (person_id,car_id,date,start_odometer,end_odometer,km,amount,client_id) VALUES (?,?,?,?,?,?,?,?)"
+    ).run(1, 1, "2026-01-01", 0, 0, 0, 0, "abc");
+    expect(() =>
+      db.prepare(
+        "INSERT INTO trips (person_id,car_id,date,start_odometer,end_odometer,km,amount,client_id) VALUES (?,?,?,?,?,?,?,?)"
+      ).run(1, 1, "2026-01-02", 0, 0, 0, 0, "abc")
+    ).toThrow(/UNIQUE/i);
+  });
+
+  it("populates updated_at with a default of CURRENT_TIMESTAMP on insert", () => {
+    const db = new Database(":memory:");
+    runMigrations(db);
+    db.exec("INSERT INTO people (id,name) VALUES (1,'P')");
+    db.exec("INSERT INTO cars (id,short,name,price_per_km) VALUES (1,'X','c',0.2)");
+    db.prepare(
+      "INSERT INTO trips (person_id,car_id,date,start_odometer,end_odometer,km,amount) VALUES (?,?,?,?,?,?,?)"
+    ).run(1, 1, "2026-01-01", 0, 0, 0, 0);
+    const row = db.prepare("SELECT updated_at FROM trips LIMIT 1").get() as { updated_at: string };
+    expect(row.updated_at).toMatch(/\d{4}-\d{2}-\d{2}/);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm test -- migration_0003`
+Expected: FAIL — columns don't exist.
+
+- [ ] **Step 3: Write the migration SQL**
+
+```sql
+-- migrations/0003_add_client_id_and_updated_at.sql
+
+ALTER TABLE trips         ADD COLUMN client_id TEXT;
+ALTER TABLE fuel_fillups  ADD COLUMN client_id TEXT;
+ALTER TABLE expenses      ADD COLUMN client_id TEXT;
+ALTER TABLE reservations  ADD COLUMN client_id TEXT;
+
+ALTER TABLE trips         ADD COLUMN updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE fuel_fillups  ADD COLUMN updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE expenses      ADD COLUMN updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE reservations  ADD COLUMN updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_trips_client_id        ON trips(client_id)        WHERE client_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_fuel_fillups_client_id ON fuel_fillups(client_id) WHERE client_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_expenses_client_id     ON expenses(client_id)     WHERE client_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_reservations_client_id ON reservations(client_id) WHERE client_id IS NOT NULL;
+
+CREATE TRIGGER IF NOT EXISTS trg_trips_updated_at        AFTER UPDATE ON trips        FOR EACH ROW BEGIN UPDATE trips        SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id; END;
+CREATE TRIGGER IF NOT EXISTS trg_fuel_fillups_updated_at AFTER UPDATE ON fuel_fillups FOR EACH ROW BEGIN UPDATE fuel_fillups SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id; END;
+CREATE TRIGGER IF NOT EXISTS trg_expenses_updated_at     AFTER UPDATE ON expenses     FOR EACH ROW BEGIN UPDATE expenses     SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id; END;
+CREATE TRIGGER IF NOT EXISTS trg_reservations_updated_at AFTER UPDATE ON reservations FOR EACH ROW BEGIN UPDATE reservations SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id; END;
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npm test -- migration_0003`
+Expected: PASS (4/4).
+Run: `npm test` — all existing migration tests should still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add migrations/0003_add_client_id_and_updated_at.sql lib/__tests__/migration_0003.test.ts
+git commit -m "feat(db): add client_id and updated_at columns for offline sync"
+```
+
+---
+
+### Task 2: Update query types and SELECT projections
+
+**Files:**
+- Modify: `types/index.ts` (or whichever file declares the entity types)
+- Modify: every `lib/queries/*.ts` that returns these entities
+
+- [ ] **Step 1: Add fields to entity interfaces**
+
+```ts
+// types/index.ts (find each interface and add the two fields)
+export interface Trip {
+  // ... existing fields
+  client_id: string | null;
+  updated_at: string;
+}
+// repeat for FuelFillup, Expense, Reservation
+```
+
+- [ ] **Step 2: Add fields to every SELECT that returns these entities**
+
+Find each SELECT for `trips`, `fuel_fillups`, `expenses`, `reservations`. Add `client_id, updated_at` to the column list. Use:
+
+```bash
+grep -rn "FROM trips\|FROM fuel_fillups\|FROM expenses\|FROM reservations" lib/queries/
+```
+
+Modify each query so the returned shape matches the new interface.
+
+- [ ] **Step 3: Run all tests**
+
+```bash
+npm test
+```
+Expected: existing tests still pass; type errors in TS surface and are fixed in the same step.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add types lib/queries
+git commit -m "feat(api): include client_id and updated_at in entity projections"
+```
+
+---
+
+### Task 3: API — POST `/api/trips` accepts client_id idempotently
+
+**Files:**
+- Modify: `app/api/trips/route.ts`
+- Test: `lib/__tests__/api_idempotency.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// lib/__tests__/api_idempotency.test.ts
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../db/migrate";
+import { createTrip } from "../queries/trips"; // <-- adjust import path
+
+describe("createTrip idempotency", () => {
+  it("returns the same row for repeated client_id (no duplicate insert)", () => {
+    const db = new Database(":memory:");
+    runMigrations(db);
+    db.exec("INSERT INTO people (id,name) VALUES (1,'P')");
+    db.exec("INSERT INTO cars (id,short,name,price_per_km) VALUES (1,'X','c',0.2)");
+
+    const input = {
+      person_id: 1, car_id: 1, date: "2026-04-27",
+      start_odometer: 100, end_odometer: 150, km: 50, amount: 10,
+      client_id: "uuid-1",
+    };
+    const a = createTrip(db, input);
+    const b = createTrip(db, input);
+    expect(a.id).toBe(b.id);
+    const count = db.prepare("SELECT COUNT(*) c FROM trips").get() as { c: number };
+    expect(count.c).toBe(1);
+  });
+
+  it("creates two rows when client_id differs", () => {
+    const db = new Database(":memory:");
+    runMigrations(db);
+    db.exec("INSERT INTO people (id,name) VALUES (1,'P')");
+    db.exec("INSERT INTO cars (id,short,name,price_per_km) VALUES (1,'X','c',0.2)");
+
+    const a = createTrip(db, { person_id:1, car_id:1, date:"2026-04-27", start_odometer:0, end_odometer:50, km:50, amount:10, client_id:"u-1" });
+    const b = createTrip(db, { person_id:1, car_id:1, date:"2026-04-27", start_odometer:50, end_odometer:80, km:30, amount:6,  client_id:"u-2" });
+    expect(a.id).not.toBe(b.id);
+  });
+
+  it("creates a row when client_id is null (legacy)", () => {
+    const db = new Database(":memory:");
+    runMigrations(db);
+    db.exec("INSERT INTO people (id,name) VALUES (1,'P')");
+    db.exec("INSERT INTO cars (id,short,name,price_per_km) VALUES (1,'X','c',0.2)");
+
+    const a = createTrip(db, { person_id:1, car_id:1, date:"2026-04-27", start_odometer:0, end_odometer:50, km:50, amount:10 });
+    expect(a.id).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm test -- api_idempotency`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement idempotent createTrip**
+
+Find `createTrip` (likely in `lib/queries/trips.ts`). Modify:
+
+```ts
+// lib/queries/trips.ts
+export function createTrip(db: Database.Database, input: TripCreateInput): Trip {
+  if (input.client_id) {
+    const existing = db.prepare(
+      "SELECT * FROM trips WHERE client_id = ?"
+    ).get(input.client_id) as Trip | undefined;
+    if (existing) return existing;
+  }
+  const result = db.prepare(`
+    INSERT INTO trips (person_id, car_id, date, start_odometer, end_odometer, km, amount, location, client_id)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    input.person_id, input.car_id, input.date,
+    input.start_odometer, input.end_odometer, input.km, input.amount,
+    input.location ?? null, input.client_id ?? null
+  );
+  return db.prepare("SELECT * FROM trips WHERE id = ?").get(result.lastInsertRowid) as Trip;
+}
+```
+
+- [ ] **Step 4: Update the route handler to accept client_id**
+
+```ts
+// app/api/trips/route.ts (POST handler — adapt to existing pattern)
+const body = await req.json();
+const trip = createTrip(db, {
+  person_id: body.person_id,
+  car_id: body.car_id,
+  date: body.date,
+  start_odometer: body.start_odometer,
+  end_odometer: body.end_odometer,
+  km: body.km,
+  amount: body.amount,
+  location: body.location ?? null,
+  client_id: typeof body.client_id === "string" ? body.client_id : null,
+});
+return NextResponse.json(trip, { status: 201 });
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `npm test -- api_idempotency`
+Expected: PASS (3/3).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/api/trips/route.ts lib/queries/trips.ts lib/__tests__/api_idempotency.test.ts
+git commit -m "feat(api): trips POST is idempotent on client_id"
+```
+
+---
+
+### Task 4: API — PUT `/api/trips/[id]` enforces conflict check
+
+**Files:**
+- Modify: `app/api/trips/[id]/route.ts`
+- Modify: `lib/queries/trips.ts` (`updateTrip`)
+- Test: extend `api_idempotency.test.ts`
+
+- [ ] **Step 1: Add failing test for conflict path**
+
+```ts
+// add to lib/__tests__/api_idempotency.test.ts
+it("updateTrip throws ConflictError when expectedUpdatedAt is older than DB", () => {
+  const db = new Database(":memory:");
+  runMigrations(db);
+  db.exec("INSERT INTO people (id,name) VALUES (1,'P')");
+  db.exec("INSERT INTO cars (id,short,name,price_per_km) VALUES (1,'X','c',0.2)");
+  const t = createTrip(db, { person_id:1, car_id:1, date:"2026-04-27", start_odometer:0, end_odometer:50, km:50, amount:10 });
+
+  // Simulate someone else updating in the meantime
+  db.prepare("UPDATE trips SET amount = 20, updated_at = '2099-01-01 00:00:00' WHERE id = ?").run(t.id);
+
+  expect(() =>
+    updateTrip(db, { id: t.id, amount: 30 }, { expectedUpdatedAt: t.updated_at })
+  ).toThrowError(ConflictError);
+});
+```
+
+- [ ] **Step 2: Add `ConflictError` and the check**
+
+```ts
+// lib/queries/trips.ts
+export class ConflictError extends Error {
+  constructor(message = "Conflict") { super(message); this.name = "ConflictError"; }
+}
+
+export function updateTrip(
+  db: Database.Database,
+  input: TripUpdateInput,
+  opts?: { expectedUpdatedAt?: string }
+): Trip {
+  if (opts?.expectedUpdatedAt) {
+    const cur = db.prepare("SELECT updated_at FROM trips WHERE id = ?").get(input.id) as { updated_at: string } | undefined;
+    if (!cur) throw new ConflictError("Trip no longer exists");
+    if (cur.updated_at !== opts.expectedUpdatedAt) {
+      throw new ConflictError("Trip was modified after this offline edit");
+    }
+  }
+  // ... existing UPDATE logic ...
+}
+```
+
+- [ ] **Step 3: Plumb it through the route**
+
+```ts
+// app/api/trips/[id]/route.ts (PUT)
+try {
+  const expected = req.headers.get("X-Expected-Updated-At") ?? undefined;
+  const trip = updateTrip(db, { id, ...body }, { expectedUpdatedAt: expected });
+  return NextResponse.json(trip);
+} catch (e) {
+  if (e instanceof ConflictError) {
+    return NextResponse.json({ error: e.message }, { status: 409 });
+  }
+  throw e;
+}
+```
+
+- [ ] **Step 4: Make DELETE idempotent**
+
+```ts
+// app/api/trips/[id]/route.ts (DELETE)
+const result = db.prepare("DELETE FROM trips WHERE id = ?").run(id);
+return NextResponse.json({ deleted: result.changes > 0 }); // 200 either way
+```
+
+- [ ] **Step 5: Run tests, commit**
+
+Run: `npm test -- api_idempotency`
+Expected: PASS.
+
+```bash
+git add app/api/trips lib/queries/trips.ts lib/__tests__/api_idempotency.test.ts
+git commit -m "feat(api): trips PUT supports conflict check, DELETE is idempotent"
+```
+
+---
+
+### Task 5: Repeat Tasks 3–4 for fuel_fillups
+
+**Files:**
+- Modify: `app/api/fuel/route.ts`, `app/api/fuel/[id]/route.ts`, `lib/queries/fuel.ts`
+- Test: extend `api_idempotency.test.ts`
+
+- [ ] **Step 1: Mirror Tasks 3–4 for fuel**
+
+Apply the same pattern: `client_id` idempotency on POST, `expectedUpdatedAt` on PUT, idempotent DELETE. Tests follow the same shape with the fuel inputs (`liters`, `amount`, `is_full`, `location`, `date`, etc.).
+
+- [ ] **Step 2: Run tests, commit**
+
+```bash
+git add app/api/fuel lib/queries/fuel.ts lib/__tests__/api_idempotency.test.ts
+git commit -m "feat(api): fuel POST idempotent, PUT conflict-checked, DELETE idempotent"
+```
+
+---
+
+### Task 6: Repeat Tasks 3–4 for expenses and reservations
+
+**Files:**
+- Modify: `app/api/expenses/route.ts`, `app/api/expenses/[id]/route.ts`, `lib/queries/expenses.ts`
+- Modify: `app/api/reservations/route.ts`, `app/api/reservations/[id]/route.ts`, `lib/queries/reservations.ts`
+- Test: extend `api_idempotency.test.ts`
+
+- [ ] **Step 1: Apply the pattern to expenses**
+
+Same shape as Tasks 3–4. Skip the conflict logic for `reservation status changes` (admin-driven, currently rare offline) — but do support it for the standard PUT flow.
+
+- [ ] **Step 2: Apply to reservations**
+
+Reservations have an extra subtlety: the `/api/reservations/[id]/status` endpoint (confirm/reject) should also accept `client_id` if we want admins to do this offline. For Phase 2 scope, **leave status-change online-only** and document this in the i18n hint.
+
+- [ ] **Step 3: Run all tests, commit**
+
+```bash
+npm test
+git add app/api lib/queries lib/__tests__/api_idempotency.test.ts
+git commit -m "feat(api): expenses & reservations idempotent POST/PUT/DELETE"
+```
+
+---
+
+### Task 7: UUID utility
+
+**Files:**
+- Create: `lib/offline/uuid.ts`
+
+- [ ] **Step 1: Implement**
+
+```ts
+// lib/offline/uuid.ts
+export function newUuid(): string {
+  const c = (globalThis as any).crypto;
+  if (c?.randomUUID) return c.randomUUID();
+  // RFC 4122 v4 fallback
+  const b = new Uint8Array(16);
+  for (let i = 0; i < 16; i++) b[i] = Math.floor(Math.random() * 256);
+  b[6] = (b[6] & 0x0f) | 0x40;
+  b[8] = (b[8] & 0x3f) | 0x80;
+  const h = Array.from(b).map((x) => x.toString(16).padStart(2, "0")).join("");
+  return `${h.slice(0,8)}-${h.slice(8,12)}-${h.slice(12,16)}-${h.slice(16,20)}-${h.slice(20)}`;
+}
+```
+
+- [ ] **Step 2: Quick smoke test**
+
+```ts
+// lib/offline/uuid.test.ts
+import { describe, it, expect } from "vitest";
+import { newUuid } from "./uuid";
+
+describe("newUuid", () => {
+  it("returns RFC4122 v4 shape", () => {
+    expect(newUuid()).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  });
+  it("yields unique values across N calls", () => {
+    const set = new Set(Array.from({ length: 1000 }, newUuid));
+    expect(set.size).toBe(1000);
+  });
+});
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/offline/uuid.ts lib/offline/uuid.test.ts
+git commit -m "feat(offline): UUIDv4 helper with crypto fallback"
+```
+
+---
+
+### Task 8: Outbox — IndexedDB queue
+
+**Files:**
+- Create: `lib/offline/outbox.ts`
+- Create: `lib/offline/outbox.test.ts`
+- Modify: `package.json` (add deps `idb`, `fake-indexeddb`)
+
+- [ ] **Step 1: Install deps**
+
+```bash
+npm install idb
+npm install -D fake-indexeddb
+```
+
+- [ ] **Step 2: Set up jsdom-like env for IndexedDB tests**
+
+`fake-indexeddb` works in node, no jsdom needed. Add a per-file directive in the test.
+
+- [ ] **Step 3: Write failing tests**
+
+```ts
+// lib/offline/outbox.test.ts
+// @vitest-environment node
+import { describe, it, expect, beforeEach } from "vitest";
+import "fake-indexeddb/auto";
+import { enqueue, list, peek, remove, count, clearAll } from "./outbox";
+
+describe("outbox", () => {
+  beforeEach(async () => { await clearAll(); });
+
+  it("enqueues and lists items in FIFO order", async () => {
+    await enqueue({ url: "/api/trips", method: "POST", body: { a: 1 }, resource: "trips", client_id: "u-1" });
+    await enqueue({ url: "/api/trips", method: "POST", body: { a: 2 }, resource: "trips", client_id: "u-2" });
+    const items = await list();
+    expect(items).toHaveLength(2);
+    expect(items[0].body).toEqual({ a: 1 });
+    expect(items[1].body).toEqual({ a: 2 });
+  });
+
+  it("peek returns the oldest item without removing it", async () => {
+    await enqueue({ url: "/api/trips", method: "POST", body: { a: 1 }, resource: "trips", client_id: "u-1" });
+    const head = await peek();
+    expect(head?.body).toEqual({ a: 1 });
+    expect(await count()).toBe(1);
+  });
+
+  it("remove drops an item by id", async () => {
+    await enqueue({ url: "/api/trips", method: "POST", body: { a: 1 }, resource: "trips", client_id: "u-1" });
+    const item = await peek();
+    await remove(item!.id);
+    expect(await count()).toBe(0);
+  });
+
+  it("count returns the queue size", async () => {
+    expect(await count()).toBe(0);
+    await enqueue({ url: "/api/trips", method: "POST", body: {}, resource: "trips", client_id: "u" });
+    expect(await count()).toBe(1);
+  });
+
+  it("survives 'reopens' (re-import) preserving items", async () => {
+    await enqueue({ url: "/api/trips", method: "POST", body: {}, resource: "trips", client_id: "u-1" });
+    // simulate reopen by clearing module cache — fake-indexeddb persists per test
+    expect(await count()).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 4: Run to verify it fails**
+
+Run: `npm test -- lib/offline/outbox`
+Expected: FAIL — module not found.
+
+- [ ] **Step 5: Implement outbox**
+
+```ts
+// lib/offline/outbox.ts
+import { openDB, type DBSchema, type IDBPDatabase } from "idb";
+
+export interface QueuedMutation {
+  id: number;
+  url: string;
+  method: "POST" | "PUT" | "DELETE";
+  body: unknown;
+  headers?: Record<string, string>;
+  resource: "trips" | "fuel" | "expenses" | "reservations";
+  resource_id?: number | string;
+  client_id?: string;
+  expectedUpdatedAt?: string;
+  queued_at: number;
+  attempts: number;
+  last_error?: string;
+}
+
+interface OutboxDB extends DBSchema {
+  mutations: {
+    key: number;
+    value: QueuedMutation;
+    indexes: { "by-queued_at": number };
+  };
+}
+
+let dbPromise: Promise<IDBPDatabase<OutboxDB>> | null = null;
+function db(): Promise<IDBPDatabase<OutboxDB>> {
+  if (!dbPromise) {
+    dbPromise = openDB<OutboxDB>("autodelen-outbox", 1, {
+      upgrade(d) {
+        const store = d.createObjectStore("mutations", { keyPath: "id", autoIncrement: true });
+        store.createIndex("by-queued_at", "queued_at");
+      },
+    });
+  }
+  return dbPromise;
+}
+
+export async function enqueue(item: Omit<QueuedMutation, "id" | "queued_at" | "attempts">): Promise<number> {
+  const d = await db();
+  const id = await d.add("mutations", { ...item, queued_at: Date.now(), attempts: 0 } as QueuedMutation);
+  return id as number;
+}
+
+export async function peek(): Promise<QueuedMutation | undefined> {
+  const d = await db();
+  const all = await d.getAllFromIndex("mutations", "by-queued_at");
+  return all[0];
+}
+
+export async function list(): Promise<QueuedMutation[]> {
+  const d = await db();
+  return d.getAllFromIndex("mutations", "by-queued_at");
+}
+
+export async function remove(id: number): Promise<void> {
+  const d = await db();
+  await d.delete("mutations", id);
+}
+
+export async function update(id: number, patch: Partial<QueuedMutation>): Promise<void> {
+  const d = await db();
+  const cur = await d.get("mutations", id);
+  if (!cur) return;
+  await d.put("mutations", { ...cur, ...patch });
+}
+
+export async function count(): Promise<number> {
+  const d = await db();
+  return d.count("mutations");
+}
+
+export async function clearAll(): Promise<void> {
+  const d = await db();
+  await d.clear("mutations");
+}
+```
+
+- [ ] **Step 6: Run to verify it passes**
+
+Run: `npm test -- lib/offline/outbox`
+Expected: PASS (5/5).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/offline/outbox.ts lib/offline/outbox.test.ts package.json package-lock.json
+git commit -m "feat(offline): IndexedDB outbox for queued mutations"
+```
+
+---
+
+### Task 9: Sync engine — drainer + Background Sync
+
+**Files:**
+- Create: `lib/offline/sync-engine.ts`
+- Create: `lib/offline/sync-engine.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+// lib/offline/sync-engine.test.ts
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import "fake-indexeddb/auto";
+import { enqueue, list, clearAll } from "./outbox";
+import { drainOutbox, type DrainOptions } from "./sync-engine";
+
+function makeFetcher(responses: Array<{ status: number; body?: unknown }>) {
+  let i = 0;
+  return vi.fn(async () => {
+    const r = responses[i++] ?? { status: 200, body: { ok: true } };
+    return new Response(JSON.stringify(r.body ?? {}), { status: r.status });
+  });
+}
+
+describe("drainOutbox", () => {
+  beforeEach(async () => { await clearAll(); });
+
+  it("drains all items on success in FIFO order", async () => {
+    await enqueue({ url:"/api/trips", method:"POST", body:{a:1}, resource:"trips", client_id:"u-1" });
+    await enqueue({ url:"/api/trips", method:"POST", body:{a:2}, resource:"trips", client_id:"u-2" });
+    const fetcher = makeFetcher([{ status: 201 }, { status: 201 }]);
+    const onSuccess = vi.fn();
+    const result = await drainOutbox({ fetch: fetcher, onSuccess });
+    expect(result.drained).toBe(2);
+    expect(await list()).toHaveLength(0);
+    expect(fetcher).toHaveBeenNthCalledWith(1, expect.stringContaining("/api/trips"), expect.objectContaining({ method: "POST", body: JSON.stringify({a:1}) }));
+  });
+
+  it("stops draining on 5xx and leaves item in queue with incremented attempts", async () => {
+    await enqueue({ url:"/api/trips", method:"POST", body:{a:1}, resource:"trips", client_id:"u-1" });
+    await enqueue({ url:"/api/trips", method:"POST", body:{a:2}, resource:"trips", client_id:"u-2" });
+    const fetcher = makeFetcher([{ status: 500 }]);
+    const result = await drainOutbox({ fetch: fetcher });
+    expect(result.drained).toBe(0);
+    const items = await list();
+    expect(items).toHaveLength(2);
+    expect(items[0].attempts).toBe(1);
+  });
+
+  it("drops an item on 409 conflict and continues", async () => {
+    await enqueue({ url:"/api/trips/5", method:"PUT", body:{}, resource:"trips", resource_id:5, expectedUpdatedAt:"old" });
+    await enqueue({ url:"/api/trips", method:"POST", body:{}, resource:"trips", client_id:"u-2" });
+    const fetcher = makeFetcher([{ status: 409 }, { status: 201 }]);
+    const onConflict = vi.fn();
+    const result = await drainOutbox({ fetch: fetcher, onConflict });
+    expect(result.drained).toBe(1);
+    expect(result.conflicts).toBe(1);
+    expect(onConflict).toHaveBeenCalled();
+    expect(await list()).toHaveLength(0);
+  });
+
+  it("aborts cleanly when network fails (offline mid-drain)", async () => {
+    await enqueue({ url:"/api/trips", method:"POST", body:{}, resource:"trips", client_id:"u" });
+    const fetcher = vi.fn(async () => { throw new TypeError("Failed to fetch"); });
+    const result = await drainOutbox({ fetch: fetcher });
+    expect(result.drained).toBe(0);
+    expect((await list()).length).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm test -- lib/offline/sync-engine`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement drainer**
+
+```ts
+// lib/offline/sync-engine.ts
+"use client";
+import { useEffect, useRef } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { peek, remove, update, count } from "./outbox";
+import type { QueuedMutation } from "./outbox";
+import { useOnlineState } from "./online-state";
+
+export interface DrainResult {
+  drained: number;
+  conflicts: number;
+  failed: number;
+}
+
+export interface DrainOptions {
+  fetch?: (url: string, init: RequestInit) => Promise<Response>;
+  onSuccess?: (item: QueuedMutation, response: unknown) => void;
+  onConflict?: (item: QueuedMutation) => void;
+}
+
+let draining = false; // single-flight
+
+export async function drainOutbox(opts: DrainOptions = {}): Promise<DrainResult> {
+  if (draining) return { drained: 0, conflicts: 0, failed: 0 };
+  draining = true;
+  const fetcher = opts.fetch ?? fetch;
+  let drained = 0, conflicts = 0, failed = 0;
+  try {
+    while (true) {
+      const head = await peek();
+      if (!head) break;
+
+      const headers: Record<string, string> = { "Content-Type": "application/json", ...(head.headers ?? {}) };
+      if (head.expectedUpdatedAt) headers["X-Expected-Updated-At"] = head.expectedUpdatedAt;
+
+      let res: Response;
+      try {
+        res = await fetcher(head.url, {
+          method: head.method,
+          headers,
+          body: head.method === "DELETE" ? undefined : JSON.stringify(head.body),
+        });
+      } catch {
+        await update(head.id, { attempts: head.attempts + 1, last_error: "network" });
+        failed++;
+        break; // network failure → stop draining, will retry next time
+      }
+
+      if (res.status === 409) {
+        await remove(head.id);
+        conflicts++;
+        opts.onConflict?.(head);
+        continue;
+      }
+
+      if (res.status >= 500) {
+        await update(head.id, { attempts: head.attempts + 1, last_error: `server-${res.status}` });
+        failed++;
+        break; // server error → stop, retry later
+      }
+
+      if (!res.ok) {
+        // 4xx (other than 409) — likely permanent. Drop with conflict semantics.
+        await remove(head.id);
+        conflicts++;
+        opts.onConflict?.(head);
+        continue;
+      }
+
+      const body = await res.json().catch(() => ({}));
+      await remove(head.id);
+      drained++;
+      opts.onSuccess?.(head, body);
+    }
+  } finally {
+    draining = false;
+  }
+  return { drained, conflicts, failed };
+}
+
+export function useSyncEngine() {
+  const qc = useQueryClient();
+  const { online } = useOnlineState();
+  const lastTriggerRef = useRef(0);
+
+  // Drain on transition online → and on mount if there's a queue.
+  useEffect(() => {
+    if (!online) return;
+    const now = Date.now();
+    if (now - lastTriggerRef.current < 1000) return;
+    lastTriggerRef.current = now;
+    drainOutbox({
+      onSuccess: (item) => {
+        qc.invalidateQueries({ queryKey: [item.resource] });
+      },
+      onConflict: (item) => {
+        qc.invalidateQueries({ queryKey: [item.resource] });
+        // Toast is fired from the consumer (mutation hook) since it has i18n context.
+        window.dispatchEvent(new CustomEvent("offline-conflict", { detail: item }));
+      },
+    }).then((result) => {
+      window.dispatchEvent(new CustomEvent("offline-drain-complete", { detail: result }));
+    });
+  }, [online, qc]);
+
+  // Register Background Sync if available.
+  useEffect(() => {
+    if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) return;
+    navigator.serviceWorker.ready.then((reg) => {
+      if ("sync" in reg) {
+        // Sync will fire when the browser thinks we're online and the SW is registered.
+        (reg as any).sync.register("autodelen-mutations").catch(() => { /* unsupported */ });
+      }
+    });
+  }, []);
+}
+
+export async function pendingCount(): Promise<number> {
+  return count();
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npm test -- lib/offline/sync-engine`
+Expected: PASS (4/4).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/offline/sync-engine.ts lib/offline/sync-engine.test.ts
+git commit -m "feat(offline): sync engine with FIFO drainer and Background Sync"
+```
+
+---
+
+### Task 10: Optimistic update helpers
+
+**Files:**
+- Create: `lib/offline/optimistic.ts`
+- Create: `lib/offline/optimistic.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+// lib/offline/optimistic.test.ts
+import { describe, it, expect } from "vitest";
+import { QueryClient } from "@tanstack/react-query";
+import { applyCreate, replaceCreate, rollbackCreate, applyUpdate, applyDelete } from "./optimistic";
+
+interface Trip { id: number; client_id?: string | null; amount: number; }
+
+describe("optimistic helpers", () => {
+  it("applyCreate inserts a pending row at the start of the list", () => {
+    const qc = new QueryClient();
+    qc.setQueryData<Trip[]>(["trips"], [{ id: 1, amount: 5 }]);
+    applyCreate<Trip>(qc, ["trips"], { id: -123, client_id: "u-1", amount: 10 });
+    const list = qc.getQueryData<Trip[]>(["trips"])!;
+    expect(list).toHaveLength(2);
+    expect(list[0].client_id).toBe("u-1");
+  });
+
+  it("replaceCreate swaps the pending row for the server row", () => {
+    const qc = new QueryClient();
+    qc.setQueryData<Trip[]>(["trips"], [{ id: -123, client_id: "u-1", amount: 10 }]);
+    replaceCreate<Trip>(qc, ["trips"], "u-1", { id: 999, client_id: "u-1", amount: 10 });
+    const list = qc.getQueryData<Trip[]>(["trips"])!;
+    expect(list[0].id).toBe(999);
+  });
+
+  it("rollbackCreate removes the pending row by client_id", () => {
+    const qc = new QueryClient();
+    qc.setQueryData<Trip[]>(["trips"], [{ id: -123, client_id: "u-1", amount: 10 }]);
+    rollbackCreate<Trip>(qc, ["trips"], "u-1");
+    expect(qc.getQueryData<Trip[]>(["trips"])).toHaveLength(0);
+  });
+
+  it("applyUpdate patches an existing row by id", () => {
+    const qc = new QueryClient();
+    qc.setQueryData<Trip[]>(["trips"], [{ id: 1, amount: 5 }]);
+    applyUpdate<Trip>(qc, ["trips"], 1, { amount: 7 });
+    expect(qc.getQueryData<Trip[]>(["trips"])![0].amount).toBe(7);
+  });
+
+  it("applyDelete removes a row by id", () => {
+    const qc = new QueryClient();
+    qc.setQueryData<Trip[]>(["trips"], [{ id: 1, amount: 5 }]);
+    applyDelete<Trip>(qc, ["trips"], 1);
+    expect(qc.getQueryData<Trip[]>(["trips"])).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm test -- lib/offline/optimistic`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// lib/offline/optimistic.ts
+import type { QueryClient } from "@tanstack/react-query";
+
+export function applyCreate<T extends { id: number; client_id?: string | null }>(
+  qc: QueryClient, key: readonly unknown[], pending: T
+): void {
+  qc.setQueryData<T[]>(key, (old) => [pending, ...(old ?? [])]);
+}
+
+export function replaceCreate<T extends { id: number; client_id?: string | null }>(
+  qc: QueryClient, key: readonly unknown[], clientId: string, server: T
+): void {
+  qc.setQueryData<T[]>(key, (old) =>
+    (old ?? []).map((row) => (row.client_id === clientId ? server : row))
+  );
+}
+
+export function rollbackCreate<T extends { id: number; client_id?: string | null }>(
+  qc: QueryClient, key: readonly unknown[], clientId: string
+): void {
+  qc.setQueryData<T[]>(key, (old) => (old ?? []).filter((row) => row.client_id !== clientId));
+}
+
+export function applyUpdate<T extends { id: number }>(
+  qc: QueryClient, key: readonly unknown[], id: number, patch: Partial<T>
+): void {
+  qc.setQueryData<T[]>(key, (old) =>
+    (old ?? []).map((row) => (row.id === id ? { ...row, ...patch } : row))
+  );
+}
+
+export function applyDelete<T extends { id: number }>(
+  qc: QueryClient, key: readonly unknown[], id: number
+): void {
+  qc.setQueryData<T[]>(key, (old) => (old ?? []).filter((row) => row.id !== id));
+}
+```
+
+- [ ] **Step 4: Run, commit**
+
+Run: `npm test -- lib/offline/optimistic`
+Expected: PASS (5/5).
+
+```bash
+git add lib/offline/optimistic.ts lib/offline/optimistic.test.ts
+git commit -m "feat(offline): optimistic update helpers for create/update/delete"
+```
+
+---
+
+### Task 11: Wire mutation hooks — trips
+
+**Files:**
+- Modify: `hooks/use-trips.ts`
+
+- [ ] **Step 1: Refactor `useCreateTrip` to enqueue on offline failure**
+
+```ts
+// hooks/use-trips.ts (replace the create hook with this shape)
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { newUuid } from "@/lib/offline/uuid";
+import { enqueue } from "@/lib/offline/outbox";
+import { applyCreate, replaceCreate, rollbackCreate } from "@/lib/offline/optimistic";
+import type { Trip } from "@/types";
+
+interface CreateInput {
+  person_id: number; car_id: number; date: string;
+  start_odometer: number; end_odometer: number; km: number; amount: number;
+  location?: string | null;
+}
+
+export function useCreateTrip() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: CreateInput): Promise<Trip> => {
+      const client_id = newUuid();
+      const optimistic: Trip = {
+        id: -Date.now(),                       // negative sentinel for pending
+        client_id,
+        person_id: input.person_id, car_id: input.car_id, date: input.date,
+        start_odometer: input.start_odometer, end_odometer: input.end_odometer,
+        km: input.km, amount: input.amount, location: input.location ?? null,
+        updated_at: new Date().toISOString(),
+        // ...other fields from Trip type (person_name, car_short, etc.) — populate from cache lookup
+      } as Trip;
+      applyCreate<Trip>(qc, ["trips"], optimistic);
+
+      try {
+        const res = await fetch("/api/trips", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ...input, client_id }),
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const server = (await res.json()) as Trip;
+        replaceCreate<Trip>(qc, ["trips"], client_id, server);
+        return server;
+      } catch (e) {
+        // If we're offline, leave optimistic row, queue the mutation.
+        if (typeof navigator !== "undefined" && !navigator.onLine) {
+          await enqueue({
+            url: "/api/trips", method: "POST", body: { ...input, client_id },
+            resource: "trips", client_id,
+          });
+          toast.success("Opgeslagen — wordt gesynchroniseerd zodra je weer online bent.");
+          return optimistic;
+        }
+        rollbackCreate<Trip>(qc, ["trips"], client_id);
+        throw e;
+      }
+    },
+  });
+}
+```
+
+The same pattern applies to `useUpdateTrip` and `useDeleteTrip`. Update them similarly:
+- `useUpdateTrip`: optimistic patch via `applyUpdate`; on offline → enqueue with `expectedUpdatedAt`; on success → invalidate `["trips"]`.
+- `useDeleteTrip`: optimistic remove via `applyDelete`; on offline → enqueue DELETE; on success → no-op.
+
+- [ ] **Step 2: Manual verification**
+
+Run dev. Take browser offline. Add a trip. The list shows the new row immediately (with the upcoming pending badge from Task 15). Network tab shows no successful POST. Application → IndexedDB → `autodelen-outbox` → `mutations` shows one entry. Go online. Within ~1s the entry disappears, the row's `id` flips from negative to positive (server-assigned).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add hooks/use-trips.ts
+git commit -m "feat(offline): trips create/update/delete with optimistic + outbox"
+```
+
+---
+
+### Task 12: Wire mutation hooks — fuel
+
+Same pattern as Task 11, applied to `hooks/use-fuel.ts`. Resource: `"fuel"`. Endpoint: `/api/fuel`.
+
+- [ ] **Step 1: Refactor**
+- [ ] **Step 2: Verify offline POST + sync**
+- [ ] **Step 3: Commit**
+
+```bash
+git add hooks/use-fuel.ts
+git commit -m "feat(offline): fuel create/update/delete with optimistic + outbox"
+```
+
+---
+
+### Task 13: Wire mutation hooks — expenses
+
+Same pattern. `hooks/use-expenses.ts`. Resource: `"expenses"`.
+
+- [ ] **Step 1: Refactor**
+- [ ] **Step 2: Verify**
+- [ ] **Step 3: Commit**
+
+---
+
+### Task 14: Wire mutation hooks — reservations
+
+Same pattern. `hooks/use-reservations.ts`. Resource: `"reservations"`.
+
+Note: status changes (confirm/reject) stay online-only. Show a toast if the user tries to confirm/reject offline:
+
+```tsx
+if (!navigator.onLine) {
+  toast.error("Bevestigen/afwijzen kan alleen online.");
+  return;
+}
+```
+
+- [ ] **Step 1: Refactor create/update/delete only; gate status changes**
+- [ ] **Step 2: Verify**
+- [ ] **Step 3: Commit**
+
+---
+
+### Task 15: PendingBadge component + list integration
+
+**Files:**
+- Create: `components/pending-badge.tsx`
+- Modify: the four list pages to render `<PendingBadge />` for rows with `id < 0` or `client_id` not yet reconciled
+
+- [ ] **Step 1: Implement the badge**
+
+```tsx
+// components/pending-badge.tsx
+"use client";
+import { paper, fontMono } from "@/lib/paper-theme";
+import { useT } from "@/components/locale-provider";
+
+export function PendingBadge() {
+  const t = useT();
+  return (
+    <span
+      title={t("offline.pending_tooltip")}
+      style={{
+        display: "inline-block",
+        padding: "1px 6px",
+        fontFamily: fontMono,
+        fontSize: 8,
+        letterSpacing: 1.5,
+        textTransform: "uppercase",
+        color: paper.amber,
+        border: `1px dashed ${paper.amber}`,
+        marginLeft: 6,
+        verticalAlign: "middle",
+      }}
+    >
+      ↻ {t("offline.pending")}
+    </span>
+  );
+}
+```
+
+- [ ] **Step 2: Add i18n**
+
+```ts
+// nl
+"offline.pending": "Sync.",
+"offline.pending_tooltip": "Wordt gesynchroniseerd zodra je weer online bent.",
+// en
+"offline.pending": "Sync",
+"offline.pending_tooltip": "Will sync when you're back online.",
+```
+
+- [ ] **Step 3: Render conditionally in the list pages**
+
+For each row in `/trips`, `/fuel`, `/expenses`, `/calendar`:
+
+```tsx
+{row.id < 0 && <PendingBadge />}
+```
+
+Place it next to the title or amount, where it's visible but not intrusive.
+
+- [ ] **Step 4: Manual verification**
+
+Offline, add a trip. The trip appears in the list with the `↻ Sync.` badge. Go online — within seconds the badge disappears.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/pending-badge.tsx app/trips app/fuel app/expenses app/calendar lib/i18n
+git commit -m "feat(offline): pending badge on optimistic rows"
+```
+
+---
+
+### Task 16: Extend OfflineBadge with queue count
+
+**Files:**
+- Modify: `lib/offline/online-state.tsx` — add `pendingCount`
+- Modify: `components/offline-badge.tsx` — show `· N wachten` when count > 0
+- Modify: `app/providers.tsx` — mount `useSyncEngine()`, push count into context
+
+- [ ] **Step 1: Extend OnlineState**
+
+```tsx
+// lib/offline/online-state.tsx — extend the value
+export interface OnlineState {
+  online: boolean;
+  lastSyncAt: number | null;
+  staleness: Staleness;
+  pendingCount: number;
+  markSynced: () => void;
+  setPendingCount: (n: number) => void;
+}
+```
+
+Add `const [pendingCount, setPendingCount] = useState(0);` to the provider and expose it.
+
+- [ ] **Step 2: Subscribe to outbox changes**
+
+In `useSyncEngine`, after each drain or enqueue, recalculate the count and call `setPendingCount`. Wire this through context (or expose a `useEffect` that polls every few seconds — simpler).
+
+```tsx
+// inside useSyncEngine
+useEffect(() => {
+  let cancelled = false;
+  const tick = async () => {
+    const c = await pendingCount();
+    if (!cancelled) setPendingCount(c);
+  };
+  tick();
+  const id = setInterval(tick, 3000);
+  return () => { cancelled = true; clearInterval(id); };
+}, [setPendingCount]);
+```
+
+- [ ] **Step 3: Update OfflineBadge to show queue count**
+
+```tsx
+// components/offline-badge.tsx
+const { online, staleness, pendingCount } = useOnlineState();
+
+// 4-state model:
+if (online && pendingCount === 0) return null;
+if (online && pendingCount > 0) {
+  return <Badge color={paper.amber} label={`SYNC · ${pendingCount}`} tooltip={t("offline.tooltip_syncing")} />;
+}
+// offline branch
+const isStale = staleness !== "fresh";
+const color = isStale ? paper.amber : paper.inkDim;
+const suffix = pendingCount > 0
+  ? ` · ${t("offline.queued_suffix", { count: pendingCount })}`
+  : isStale ? ` · ${t("offline.stale_suffix")}` : "";
+return <Badge color={color} label={`${t("offline.label")}${suffix}`} tooltip={...} />;
+```
+
+- [ ] **Step 4: i18n keys**
+
+```ts
+// nl
+"offline.queued_suffix": "{count} wachten",
+"offline.tooltip_syncing": "Synchroniseren…",
+// en
+"offline.queued_suffix": "{count} pending",
+"offline.tooltip_syncing": "Syncing…",
+```
+
+- [ ] **Step 5: Mount sync engine**
+
+```tsx
+// app/providers.tsx — extend BootPrewarm
+function BootPrewarm() {
+  // ... existing useMe + useBootPrewarm ...
+  useSyncEngine();
+  return null;
+}
+```
+
+- [ ] **Step 6: Conflict toast wiring**
+
+Listen for the `offline-conflict` custom event in a small client component (e.g. mounted next to `<Toaster />`):
+
+```tsx
+useEffect(() => {
+  const handler = (e: Event) => {
+    const detail = (e as CustomEvent).detail;
+    toast.error(t("offline.conflict_toast", { resource: detail.resource }));
+  };
+  window.addEventListener("offline-conflict", handler);
+  return () => window.removeEventListener("offline-conflict", handler);
+}, []);
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/offline components/offline-badge.tsx app/providers.tsx lib/i18n
+git commit -m "feat(offline): badge shows queue count, conflict toasts wired"
+```
+
+---
+
+### Task 17: End-to-end QA
+
+**Files:** none.
+
+- [ ] **Step 1: Online happy path (regression check)**
+
+Add a trip / edit / delete while online. Behavior identical to Phase 1.
+
+- [ ] **Step 2: Offline create**
+
+Toggle DevTools offline. Add a trip. Verify:
+- Row appears immediately with `↻ Sync.` badge
+- Header badge shows `OFFLINE · 1 wachten`
+- IndexedDB `autodelen-outbox.mutations` contains the entry
+
+Go online. Verify:
+- Within ~3s: row's pending badge disappears
+- Header badge clears
+- IndexedDB queue is empty
+- Server has the row (verify via direct DB check or admin page)
+
+- [ ] **Step 3: Offline edit + idempotency**
+
+Online, add trip A. Take offline. Edit A's amount. Take online again. Verify the server amount is the new one (single edit applied).
+
+Then: simulate flaky network. Take offline, edit A. Take online but immediately throttle to "Slow 3G" with timeout. Force a partial failure. Take online fully. Verify:
+- Idempotency: A is updated exactly once (no double-apply)
+- Queue eventually drains
+
+- [ ] **Step 4: Conflict path**
+
+Online, add trip A. Note `updated_at`. In another tab (or via SQL) update A's amount. In the original tab, take offline, edit A, take online. Verify:
+- 409 returned
+- Queue item dropped
+- Toast appears: "Edit conflict — refresh and retry"
+- A in cache is invalidated and shows the *other* tab's value after refetch
+
+- [ ] **Step 5: Cross-resource ordering**
+
+Offline. Add trip A, add fuel B, add expense C (in that order). Go online. Verify all three sync, and none of them is missed.
+
+- [ ] **Step 6: Tab-close survival**
+
+Offline. Add trip A. Close tab. Open tab. Verify:
+- Trip A still visible (from React Query cache OR re-loaded from server when online — the queue should drain on reopen since `online` is true and `useSyncEngine` mounts)
+
+- [ ] **Step 7: Background Sync (Chrome only)**
+
+Offline. Add trip A. Close tab. Restore network. Without opening the tab, wait. Background Sync should fire — but since our drainer runs in the page, it can only drain when a page is open. Acceptable: drains on next visit.
+
+Document the limitation in the PR description.
+
+---
+
+### Task 18: PR
+
+**Files:** none.
+
+- [ ] **Step 1: Run full suite**
+
+```bash
+npm test
+```
+Expected: green.
+
+- [ ] **Step 2: Push and PR**
+
+```bash
+git push -u origin feature/offline-phase-2
+gh pr create --title "feat(offline): Phase 2 — write queue, optimistic UI, sync" --body "$(cat <<'EOF'
+## Summary
+- DB migration: `client_id` (UNIQUE) + `updated_at` on trips/fuel/expenses/reservations
+- API: idempotent POST via `client_id`; PUT respects `X-Expected-Updated-At` for LWW conflicts; DELETE idempotent
+- Client: IndexedDB outbox, FIFO drainer, optimistic React Query updates, Background Sync registration
+- UI: per-row `↻ Sync.` badge for pending mutations; header badge shows queue count and conflict toasts
+
+Closes #20. Depends on #8 (Phase 1) being merged first.
+
+## Test plan
+- [ ] Add/edit/delete each resource offline → all replay on reconnect
+- [ ] Conflict (concurrent edit) shows toast and invalidates cache
+- [ ] Offline create survives tab close
+- [ ] Idempotency: replaying same client_id twice does not duplicate
+- [ ] Queue count updates in header within 3s
+- [ ] All 41+ Phase 1 tests still pass
+- [ ] New tests: migration_0003, api_idempotency, outbox, sync-engine, optimistic, uuid
+
+## Known limitations
+- Background Sync API is Chrome/Edge only; Safari falls back to drain-on-next-visit
+- Reservation status changes (confirm/reject) remain online-only
+- Conflict resolution is LWW with drop-and-toast — no auto-merge
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: After merge, deploy and watch**
+
+After merge to main:
+```bash
+ssh root@100.86.173.115 "cd /opt/dockge/stacks/autodelen && docker compose pull && docker compose up -d"
+```
+
+Watch for the migration to apply on container start. Verify on production by adding a trip offline on a real phone, force-closing the app, reopening, and confirming sync.
+
+---
+
+## Self-review checklist
+
+- [x] **Spec coverage:** Issue #20 acceptance criteria covered: offline create/edit/delete (Tasks 11–14), queue visible in indicator (Task 16), sync invalidates cache (Task 9 + onSuccess callback), conflict toast (Task 16).
+- [x] **No placeholders:** Every step is concrete code or an exact command. Where existing code locations need confirming (e.g. trip form file path), there's a `grep` to find it.
+- [x] **Type consistency:** `QueuedMutation`, `Trip`, `OnlineState` extended once and referenced consistently. `applyCreate`/`replaceCreate`/`rollbackCreate` signatures match across optimistic.ts and the mutation hooks.
+- [x] **Causal ordering preserved:** outbox uses `by-queued_at` index; drainer is single-flight (`draining` flag); breaks on first failure to maintain order.
+- [x] **Idempotency:** server enforced via `client_id` UNIQUE index + check-then-insert; client tracks `client_id` in optimistic row so replays-during-success-already-arrived don't double-write.
+
+---
+
+## Risks & mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Migration fails on existing prod data due to NOT NULL default | Low | `DEFAULT CURRENT_TIMESTAMP` works on SQLite ALTER TABLE; tested in `migration_0003.test.ts`. Take a backup before deploying. |
+| Race: user submits, response arrives, drain ALSO submits queued copy | Medium | Mitigated by `client_id` UNIQUE — server returns existing row, client gets same `id` either way. |
+| Negative-id sentinel collides if Date.now() repeats (impossible at ms resolution but worth noting) | Very low | Acceptable; collisions would just replace a different pending row briefly. |
+| Background Sync unsupported in Safari | Known | Documented; fallback to `online`-event drain on next visit. |
+| Outbox grows unbounded if user stays offline for weeks | Low | `attempts` field + future eviction policy if `attempts > 50` (out of scope, log only for now). |
+| User edits an offline-created row before its first sync | Medium | The optimistic row has a negative `id`; mutation hook should detect this and chain by `client_id` instead — **add to acceptance criteria of Task 11 if reproducible in QA**. |
+| Trigger-based `updated_at` doesn't fire on `INSERT OR REPLACE` paths | Low | Verified: existing code uses `INSERT` and `UPDATE`, never `REPLACE`. If it changes, add `updated_at = CURRENT_TIMESTAMP` explicitly. |
+
+---
+
+## What's intentionally NOT in this plan
+
+- **Multi-device sync / real-time:** out of scope; this is single-device offline.
+- **CRDT-based merging:** unnecessary at this concurrency level.
+- **Admin operations offline (cars, members):** require online connectivity. Document in user help text.
+- **Reservation status changes offline:** the social contract here is that confirming a reservation should be deliberate and online; queueing confirms could mislead users.
+- **Outbox eviction / age-based GC:** can be added later as a maintenance hook; not needed in Phase 2.

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -387,6 +387,7 @@ export const en: Messages = {
   "offline.tooltip_fresh": "You are offline. Data was recently synced.",
   "offline.tooltip_stale": "You are offline and the data is over an hour old.",
   "offline.admin_unavailable": "Admin is not available without a connection.",
+  "offline.mutation_blocked": "Saving is not available without a connection.",
   "form.offline_start_km_hint": "Offline — start KM is from last sync.",
   "form.offline_reservation_hint": "Offline — verify availability when reconnected.",
 };

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -386,6 +386,7 @@ export const en: Messages = {
   "offline.stale_suffix": "data >1h old",
   "offline.tooltip_fresh": "You are offline. Data was recently synced.",
   "offline.tooltip_stale": "You are offline and the data is over an hour old.",
+  "offline.admin_unavailable": "Admin is not available without a connection.",
   "form.offline_start_km_hint": "Offline — start KM is from last sync.",
   "form.offline_reservation_hint": "Offline — verify availability when reconnected.",
 };

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -380,4 +380,12 @@ export const en: Messages = {
   "admin.username_label": "Username",
   "admin.is_admin_label": "Admin",
   "admin.no_username": "No login yet",
+
+  // Offline indicator
+  "offline.label": "OFFLINE",
+  "offline.stale_suffix": "data >1h old",
+  "offline.tooltip_fresh": "You are offline. Data was recently synced.",
+  "offline.tooltip_stale": "You are offline and the data is over an hour old.",
+  "form.offline_start_km_hint": "Offline — start KM is from last sync.",
+  "form.offline_reservation_hint": "Offline — verify availability when reconnected.",
 };

--- a/lib/i18n/messages/nl.ts
+++ b/lib/i18n/messages/nl.ts
@@ -385,6 +385,7 @@ export const nl = {
   "offline.tooltip_fresh": "Je bent offline. Gegevens zijn recent gesynchroniseerd.",
   "offline.tooltip_stale": "Je bent offline en de gegevens zijn ouder dan een uur.",
   "offline.admin_unavailable": "Admin niet beschikbaar zonder verbinding.",
+  "offline.mutation_blocked": "Opslaan niet mogelijk zonder verbinding.",
   "form.offline_start_km_hint": "Offline — start KM is van laatste sync.",
   "form.offline_reservation_hint": "Offline — controleer beschikbaarheid bij verbinding.",
 } as const;

--- a/lib/i18n/messages/nl.ts
+++ b/lib/i18n/messages/nl.ts
@@ -378,6 +378,14 @@ export const nl = {
   "admin.username_label": "Gebruikersnaam",
   "admin.is_admin_label": "Admin",
   "admin.no_username": "Nog geen login",
+
+  // Offline indicator
+  "offline.label": "OFFLINE",
+  "offline.stale_suffix": "ouder dan 1u",
+  "offline.tooltip_fresh": "Je bent offline. Gegevens zijn recent gesynchroniseerd.",
+  "offline.tooltip_stale": "Je bent offline en de gegevens zijn ouder dan een uur.",
+  "form.offline_start_km_hint": "Offline — start KM is van laatste sync.",
+  "form.offline_reservation_hint": "Offline — controleer beschikbaarheid bij verbinding.",
 } as const;
 
 export type MessageKey = keyof typeof nl;

--- a/lib/i18n/messages/nl.ts
+++ b/lib/i18n/messages/nl.ts
@@ -384,6 +384,7 @@ export const nl = {
   "offline.stale_suffix": "ouder dan 1u",
   "offline.tooltip_fresh": "Je bent offline. Gegevens zijn recent gesynchroniseerd.",
   "offline.tooltip_stale": "Je bent offline en de gegevens zijn ouder dan een uur.",
+  "offline.admin_unavailable": "Admin niet beschikbaar zonder verbinding.",
   "form.offline_start_km_hint": "Offline — start KM is van laatste sync.",
   "form.offline_reservation_hint": "Offline — controleer beschikbaarheid bij verbinding.",
 } as const;

--- a/lib/offline/online-state.test.ts
+++ b/lib/offline/online-state.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { computeStaleness, STALE_THRESHOLD_MS } from "./online-state";
+
+describe("computeStaleness", () => {
+  it("returns 'fresh' when sync was within threshold", () => {
+    const now = 1_700_000_000_000;
+    expect(computeStaleness(now - 60_000, now)).toBe("fresh");
+  });
+
+  it("returns 'stale' when sync was older than threshold", () => {
+    const now = 1_700_000_000_000;
+    expect(computeStaleness(now - STALE_THRESHOLD_MS - 1, now)).toBe("stale");
+  });
+
+  it("returns 'unknown' when never synced", () => {
+    expect(computeStaleness(null, 1_700_000_000_000)).toBe("unknown");
+  });
+
+  it("treats exact threshold boundary as 'fresh'", () => {
+    const now = 1_700_000_000_000;
+    expect(computeStaleness(now - STALE_THRESHOLD_MS, now)).toBe("fresh");
+  });
+});

--- a/lib/offline/online-state.tsx
+++ b/lib/offline/online-state.tsx
@@ -1,0 +1,111 @@
+"use client";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+export const STALE_THRESHOLD_MS = 60 * 60 * 1000; // 1 hour
+const HEARTBEAT_INTERVAL_MS = 30 * 1000;
+const HEARTBEAT_TIMEOUT_MS = 5 * 1000;
+const STALENESS_TICK_MS = 60 * 1000;
+
+export type Staleness = "fresh" | "stale" | "unknown";
+
+export function computeStaleness(lastSyncAt: number | null, now: number): Staleness {
+  if (lastSyncAt === null) return "unknown";
+  return now - lastSyncAt <= STALE_THRESHOLD_MS ? "fresh" : "stale";
+}
+
+export interface OnlineState {
+  online: boolean;
+  lastSyncAt: number | null;
+  staleness: Staleness;
+  markSynced: () => void;
+}
+
+const Ctx = createContext<OnlineState | null>(null);
+
+export function useOnlineState(): OnlineState {
+  const v = useContext(Ctx);
+  if (!v) throw new Error("useOnlineState must be used inside OnlineStateProvider");
+  return v;
+}
+
+async function heartbeat(): Promise<boolean> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), HEARTBEAT_TIMEOUT_MS);
+  try {
+    const res = await fetch("/api/health", {
+      method: "HEAD",
+      signal: ctrl.signal,
+      cache: "no-store",
+    });
+    return res.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function OnlineStateProvider({ children }: { children: React.ReactNode }) {
+  const [online, setOnline] = useState<boolean>(() =>
+    typeof navigator === "undefined" ? true : navigator.onLine
+  );
+  const [lastSyncAt, setLastSyncAt] = useState<number | null>(null);
+  const [now, setNow] = useState(() => Date.now());
+  const heartbeatRunningRef = useRef(false);
+
+  const markSynced = useCallback(() => setLastSyncAt(Date.now()), []);
+
+  useEffect(() => {
+    const onUp = () => setOnline(true);
+    const onDown = () => setOnline(false);
+    window.addEventListener("online", onUp);
+    window.addEventListener("offline", onDown);
+    return () => {
+      window.removeEventListener("online", onUp);
+      window.removeEventListener("offline", onDown);
+    };
+  }, []);
+
+  // Periodic heartbeat — corrects for captive portals where navigator.onLine is true
+  // but the network is unreachable.
+  useEffect(() => {
+    if (!online) return;
+    let cancelled = false;
+    const id = setInterval(async () => {
+      if (heartbeatRunningRef.current) return;
+      heartbeatRunningRef.current = true;
+      try {
+        const ok = await heartbeat();
+        if (!cancelled && !ok) setOnline(false);
+      } finally {
+        heartbeatRunningRef.current = false;
+      }
+    }, HEARTBEAT_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [online]);
+
+  // Tick `now` once a minute so staleness recomputes without remounts.
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), STALENESS_TICK_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  const value: OnlineState = {
+    online,
+    lastSyncAt,
+    staleness: computeStaleness(lastSyncAt, now),
+    markSynced,
+  };
+
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}

--- a/lib/offline/online-state.tsx
+++ b/lib/offline/online-state.tsx
@@ -94,6 +94,27 @@ export function OnlineStateProvider({ children }: { children: React.ReactNode })
     };
   }, [online]);
 
+  // Recovery heartbeat — runs when offline to detect network return even when
+  // the browser doesn't fire the 'online' event (e.g. DevTools SW offline checkbox).
+  useEffect(() => {
+    if (online) return;
+    let cancelled = false;
+    const id = setInterval(async () => {
+      if (heartbeatRunningRef.current) return;
+      heartbeatRunningRef.current = true;
+      try {
+        const ok = await heartbeat();
+        if (!cancelled && ok) setOnline(true);
+      } finally {
+        heartbeatRunningRef.current = false;
+      }
+    }, 5_000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [online]);
+
   // Tick `now` once a minute so staleness recomputes without remounts.
   useEffect(() => {
     const id = setInterval(() => setNow(Date.now()), STALENESS_TICK_MS);

--- a/lib/offline/prewarm.test.ts
+++ b/lib/offline/prewarm.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from "vitest";
+import { QueryClient } from "@tanstack/react-query";
+import { prewarmCriticalEndpoints, CRITICAL_ENDPOINTS } from "./prewarm";
+
+describe("prewarmCriticalEndpoints", () => {
+  it("calls fetcher for every critical endpoint in parallel", async () => {
+    const fetcher = vi.fn().mockResolvedValue([]);
+    const qc = new QueryClient();
+    await prewarmCriticalEndpoints(qc, fetcher);
+    expect(fetcher).toHaveBeenCalledTimes(CRITICAL_ENDPOINTS.length);
+    for (const ep of CRITICAL_ENDPOINTS) {
+      expect(fetcher).toHaveBeenCalledWith(ep.url);
+    }
+  });
+
+  it("does not throw when an individual fetch fails", async () => {
+    const fetcher = vi.fn().mockImplementation((url: string) =>
+      url.includes("trips")
+        ? Promise.reject(new Error("boom"))
+        : Promise.resolve([])
+    );
+    const qc = new QueryClient();
+    await expect(prewarmCriticalEndpoints(qc, fetcher)).resolves.toBeDefined();
+  });
+
+  it("populates the QueryClient cache for successful fetches", async () => {
+    const fetcher = vi.fn().mockResolvedValue([{ id: 1 }]);
+    const qc = new QueryClient();
+    await prewarmCriticalEndpoints(qc, fetcher);
+    const tripsState = qc.getQueryState(["trips"]);
+    expect(tripsState?.data).toEqual([{ id: 1 }]);
+  });
+
+  it("returns one settled result per endpoint", async () => {
+    const fetcher = vi.fn().mockResolvedValue({});
+    const qc = new QueryClient();
+    const results = await prewarmCriticalEndpoints(qc, fetcher);
+    expect(results).toHaveLength(CRITICAL_ENDPOINTS.length);
+    expect(results.every((r) => r.status === "fulfilled")).toBe(true);
+  });
+});

--- a/lib/offline/prewarm.ts
+++ b/lib/offline/prewarm.ts
@@ -10,9 +10,8 @@ export interface CriticalEndpoint {
 }
 
 export const CRITICAL_ENDPOINTS: readonly CriticalEndpoint[] = [
-  { queryKey: ["dashboard"],    url: "/api/dashboard" },
   { queryKey: ["trips"],        url: "/api/trips" },
-  { queryKey: ["fuel"],         url: "/api/fuel" },
+  { queryKey: ["fuel-fillups"], url: "/api/fuel" },
   { queryKey: ["expenses"],     url: "/api/expenses" },
   { queryKey: ["reservations"], url: "/api/reservations" },
   { queryKey: ["people"],       url: "/api/people" },

--- a/lib/offline/prewarm.ts
+++ b/lib/offline/prewarm.ts
@@ -1,0 +1,56 @@
+"use client";
+import { useEffect, useRef } from "react";
+import type { QueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
+import { useOnlineState } from "./online-state";
+
+export interface CriticalEndpoint {
+  queryKey: readonly unknown[];
+  url: string;
+}
+
+export const CRITICAL_ENDPOINTS: readonly CriticalEndpoint[] = [
+  { queryKey: ["dashboard"],    url: "/api/dashboard" },
+  { queryKey: ["trips"],        url: "/api/trips" },
+  { queryKey: ["fuel"],         url: "/api/fuel" },
+  { queryKey: ["expenses"],     url: "/api/expenses" },
+  { queryKey: ["reservations"], url: "/api/reservations" },
+  { queryKey: ["people"],       url: "/api/people" },
+  { queryKey: ["cars"],         url: "/api/cars" },
+] as const;
+
+export type Fetcher = (url: string) => Promise<unknown>;
+
+async function defaultFetcher(url: string): Promise<unknown> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`${url} → ${res.status}`);
+  return res.json();
+}
+
+export async function prewarmCriticalEndpoints(
+  qc: QueryClient,
+  fetcher: Fetcher = defaultFetcher
+): Promise<PromiseSettledResult<unknown>[]> {
+  const tasks = CRITICAL_ENDPOINTS.map((ep) =>
+    qc
+      .prefetchQuery({ queryKey: ep.queryKey, queryFn: () => fetcher(ep.url) })
+      .then(() => qc.getQueryData(ep.queryKey))
+  );
+  return Promise.allSettled(tasks);
+}
+
+export function useBootPrewarm(authReady: boolean): void {
+  const qc = useQueryClient();
+  const { online, markSynced } = useOnlineState();
+  const ranRef = useRef(false);
+
+  useEffect(() => {
+    if (ranRef.current) return;
+    if (!authReady || !online) return;
+    ranRef.current = true;
+    prewarmCriticalEndpoints(qc).then((results) => {
+      const anyOk = results.some((r) => r.status === "fulfilled");
+      if (anyOk) markSynced();
+    });
+  }, [authReady, online, qc, markSynced]);
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -7,6 +7,7 @@ const PUBLIC_PATHS = [
   "/login",
   "/api/auth/login",
   "/api/auth/logout",
+  "/api/health",
   "/invite",
   "/api/invite",
 ];

--- a/next.config.ts
+++ b/next.config.ts
@@ -152,6 +152,9 @@ const withPWA = withPWAInit({
         handler: "NetworkFirst",
         options: {
           cacheName: "pages-rsc-prefetch",
+          // ignoreSearch: URL params are client-side state only (sheets, filters);
+          // the server renders the same RSC shell regardless of query params.
+          matchOptions: { ignoreSearch: true },
           expiration: { maxEntries: 32, maxAgeSeconds: ONE_DAY },
         },
       },
@@ -163,6 +166,7 @@ const withPWA = withPWAInit({
         handler: "NetworkFirst",
         options: {
           cacheName: "pages-rsc",
+          matchOptions: { ignoreSearch: true },
           expiration: { maxEntries: 32, maxAgeSeconds: ONE_DAY },
         },
       },
@@ -172,6 +176,7 @@ const withPWA = withPWAInit({
         handler: "NetworkFirst",
         options: {
           cacheName: "pages",
+          matchOptions: { ignoreSearch: true },
           expiration: { maxEntries: 32, maxAgeSeconds: ONE_DAY },
         },
       },

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,10 +1,193 @@
 import type { NextConfig } from "next";
 import withPWAInit from "@ducanh2912/next-pwa";
 
+const ONE_HOUR = 60 * 60;
+const ONE_DAY = 24 * ONE_HOUR;
+const ONE_WEEK = 7 * ONE_DAY;
+const ONE_MONTH = 30 * ONE_DAY;
+const ONE_YEAR = 365 * ONE_DAY;
+
 const withPWA = withPWAInit({
   dest: "public",
   register: true,
-  workboxOptions: { skipWaiting: true, importScripts: ["/sw-helpers.js"] },
+  workboxOptions: {
+    skipWaiting: true,
+    importScripts: ["/sw-helpers.js"],
+    runtimeCaching: [
+      // ---- API routes (most specific first) ----
+      // Auth & identity — must always reflect latest server state.
+      {
+        urlPattern: ({ url }) =>
+          url.pathname === "/api/me" || url.pathname.startsWith("/api/auth/"),
+        handler: "NetworkFirst",
+        options: {
+          cacheName: "api-auth",
+          networkTimeoutSeconds: 5,
+          expiration: { maxEntries: 8, maxAgeSeconds: ONE_HOUR },
+        },
+      },
+      // Health endpoint — never cache (used as a heartbeat).
+      {
+        urlPattern: ({ url }) => url.pathname === "/api/health",
+        handler: "NetworkOnly",
+      },
+      // Data APIs — serve cache instantly, refresh in background.
+      {
+        urlPattern: ({ url, request, sameOrigin }) =>
+          sameOrigin && request.method === "GET" && url.pathname.startsWith("/api/"),
+        handler: "StaleWhileRevalidate",
+        options: {
+          cacheName: "api-data",
+          expiration: { maxEntries: 64, maxAgeSeconds: ONE_WEEK },
+        },
+      },
+
+      // ---- Cross-origin fonts ----
+      {
+        urlPattern: /^https:\/\/fonts\.(?:gstatic)\.com\/.*/i,
+        handler: "CacheFirst",
+        options: {
+          cacheName: "google-fonts-webfonts",
+          expiration: { maxEntries: 4, maxAgeSeconds: ONE_YEAR },
+        },
+      },
+      {
+        urlPattern: /^https:\/\/fonts\.(?:googleapis)\.com\/.*/i,
+        handler: "StaleWhileRevalidate",
+        options: {
+          cacheName: "google-fonts-stylesheets",
+          expiration: { maxEntries: 4, maxAgeSeconds: ONE_WEEK },
+        },
+      },
+
+      // ---- Static asset types ----
+      {
+        urlPattern: /\.(?:eot|otf|ttc|ttf|woff|woff2|font.css)$/i,
+        handler: "StaleWhileRevalidate",
+        options: {
+          cacheName: "static-font-assets",
+          expiration: { maxEntries: 4, maxAgeSeconds: ONE_WEEK },
+        },
+      },
+      {
+        urlPattern: /\.(?:jpg|jpeg|gif|png|svg|ico|webp)$/i,
+        handler: "StaleWhileRevalidate",
+        options: {
+          cacheName: "static-image-assets",
+          expiration: { maxEntries: 64, maxAgeSeconds: ONE_MONTH },
+        },
+      },
+      {
+        urlPattern: /\/_next\/image\?url=.+$/i,
+        handler: "StaleWhileRevalidate",
+        options: {
+          cacheName: "next-image",
+          expiration: { maxEntries: 64, maxAgeSeconds: ONE_DAY },
+        },
+      },
+      {
+        urlPattern: /\.(?:mp3|wav|ogg)$/i,
+        handler: "CacheFirst",
+        options: {
+          cacheName: "static-audio-assets",
+          expiration: { maxEntries: 32, maxAgeSeconds: ONE_DAY },
+        },
+      },
+      {
+        urlPattern: /\.(?:mp4|webm)$/i,
+        handler: "CacheFirst",
+        options: {
+          cacheName: "static-video-assets",
+          expiration: { maxEntries: 32, maxAgeSeconds: ONE_DAY },
+        },
+      },
+      {
+        urlPattern: /\/_next\/static.+\.js$/i,
+        handler: "CacheFirst",
+        options: {
+          cacheName: "next-static-js-assets",
+          expiration: { maxEntries: 64, maxAgeSeconds: ONE_DAY },
+        },
+      },
+      {
+        urlPattern: /\.(?:js)$/i,
+        handler: "StaleWhileRevalidate",
+        options: {
+          cacheName: "static-js-assets",
+          expiration: { maxEntries: 48, maxAgeSeconds: ONE_DAY },
+        },
+      },
+      {
+        urlPattern: /\.(?:css|less)$/i,
+        handler: "StaleWhileRevalidate",
+        options: {
+          cacheName: "static-style-assets",
+          expiration: { maxEntries: 32, maxAgeSeconds: ONE_DAY },
+        },
+      },
+      {
+        urlPattern: /\/_next\/data\/.+\/.+\.json$/i,
+        handler: "StaleWhileRevalidate",
+        options: {
+          cacheName: "next-data",
+          expiration: { maxEntries: 32, maxAgeSeconds: ONE_DAY },
+        },
+      },
+      {
+        urlPattern: /\.(?:json|xml|csv)$/i,
+        handler: "NetworkFirst",
+        options: {
+          cacheName: "static-data-assets",
+          expiration: { maxEntries: 32, maxAgeSeconds: ONE_DAY },
+        },
+      },
+
+      // ---- Next.js RSC + page navigations ----
+      {
+        urlPattern: ({ request, url, sameOrigin }) =>
+          sameOrigin &&
+          request.headers.get("RSC") === "1" &&
+          request.headers.get("Next-Router-Prefetch") === "1" &&
+          !url.pathname.startsWith("/api/"),
+        handler: "NetworkFirst",
+        options: {
+          cacheName: "pages-rsc-prefetch",
+          expiration: { maxEntries: 32, maxAgeSeconds: ONE_DAY },
+        },
+      },
+      {
+        urlPattern: ({ request, url, sameOrigin }) =>
+          sameOrigin &&
+          request.headers.get("RSC") === "1" &&
+          !url.pathname.startsWith("/api/"),
+        handler: "NetworkFirst",
+        options: {
+          cacheName: "pages-rsc",
+          expiration: { maxEntries: 32, maxAgeSeconds: ONE_DAY },
+        },
+      },
+      {
+        urlPattern: ({ url, sameOrigin }) =>
+          sameOrigin && !url.pathname.startsWith("/api/"),
+        handler: "NetworkFirst",
+        options: {
+          cacheName: "pages",
+          expiration: { maxEntries: 32, maxAgeSeconds: ONE_DAY },
+        },
+      },
+
+      // ---- Catch-all for cross-origin GETs ----
+      {
+        urlPattern: ({ sameOrigin }) => !sameOrigin,
+        handler: "NetworkFirst",
+        options: {
+          cacheName: "cross-origin",
+          networkTimeoutSeconds: 10,
+          expiration: { maxEntries: 32, maxAgeSeconds: ONE_HOUR },
+        },
+      },
+    ],
+  },
   disable: process.env.NODE_ENV === "development",
   publicExcludes: ["!icons/source.svg"],
 });

--- a/next.config.ts
+++ b/next.config.ts
@@ -143,21 +143,10 @@ const withPWA = withPWAInit({
       },
 
       // ---- Next.js RSC + page navigations ----
-      {
-        urlPattern: ({ request, url, sameOrigin }) =>
-          sameOrigin &&
-          request.headers.get("RSC") === "1" &&
-          request.headers.get("Next-Router-Prefetch") === "1" &&
-          !url.pathname.startsWith("/api/"),
-        handler: "NetworkFirst",
-        options: {
-          cacheName: "pages-rsc-prefetch",
-          // ignoreSearch: URL params are client-side state only (sheets, filters);
-          // the server renders the same RSC shell regardless of query params.
-          matchOptions: { ignoreSearch: true },
-          expiration: { maxEntries: 32, maxAgeSeconds: ONE_DAY },
-        },
-      },
+      // Prefetch RSC and navigation RSC share one cache so that a link
+      // prefetch (Next-Router-Prefetch: 1) populates the same entries that
+      // a soft navigation lookup will hit. ignoreSearch lets a cached /trips
+      // entry serve /trips?edit=ID — all search params are client-side state.
       {
         urlPattern: ({ request, url, sameOrigin }) =>
           sameOrigin &&


### PR DESCRIPTION
## Summary

- **Service worker caching** — explicit Workbox `runtimeCaching` with `StaleWhileRevalidate` for all data APIs (7-day TTL), `NetworkFirst` for RSC page payloads (unified `pages-rsc` cache so link-prefetch and nav-cache share entries, `ignoreSearch: true` so `/trips?edit=ID` matches cached `/trips`)
- **Online-state context** — `OnlineStateProvider` tracks `online`, `lastSyncAt`, `staleness`; heartbeat every 30 s detects captive portals; recovery heartbeat every 5 s when offline detects reconnect even when the browser doesn't fire the `online` event (DevTools SW checkbox)
- **Boot prewarm** — `useBootPrewarm` prefetches 6 critical API endpoints into React Query + SW cache on first authenticated session while online
- **Offline badge** — grey `OFFLINE` / amber `OFFLINE · ouder dan 1u` in every page header; disappears within 5 s of reconnect
- **Offline guards** — Add/Save buttons in all user-facing forms (trip, fuel, expense, reservation) and the admin tab are visually dimmed and show a toast when tapped offline, preventing broken "Failed to fetch" errors and SPA state corruption

## What works offline (Phase 1)
- Dashboard, trips, fuel, costs, reservations — read from SW + React Query cache
- Trip edit sheet — opens via cached RSC payload
- Offline badge shows connectivity and data freshness

## What is deliberately blocked (Phase 2)
- Creating or editing any record — shows "Opslaan niet mogelijk zonder verbinding."
- Admin section — shows "Admin niet beschikbaar zonder verbinding."

## Test plan
- [ ] Build (`npm run build`) and serve (`npm run start`)
- [ ] Hard-refresh to activate new SW, navigate all pages while online
- [ ] Go offline (airplane mode or Network tab) — badge appears
- [ ] Verify dashboard, trips, fuel, costs, reservations load from cache
- [ ] Tap a trip row — edit sheet opens
- [ ] Tap Save in edit form — toast shown, no "Failed to fetch"
- [ ] Tap + FAB — toast shown
- [ ] Tap Admin tab — toast shown, other pages unaffected
- [ ] Reconnect — badge disappears within ~5 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)