### PR TITLE
UX: reverse filter order to All / Mine

### DIFF
--- a/app/expenses/page.tsx
+++ b/app/expenses/page.tsx
@@ -98,7 +98,7 @@ function ExpensesContent() {
           <div style={{ display: "flex", alignItems: "center" }}>
             {canFilter && (
               <div style={{ display: "flex", gap: 0 }}>
-                {(["mine", "all"] as const).map((v, i, arr) => (
+                {(["all", "mine"] as const).map((v, i, arr) => (
                   <button
                     key={v}
                     onClick={() => setMineParam(v === "mine" ? "true" : "")}

--- a/app/fuel/page.tsx
+++ b/app/fuel/page.tsx
@@ -98,7 +98,7 @@ function FuelContent() {
           <div style={{ display: "flex", alignItems: "center" }}>
             {canFilter && (
               <div style={{ display: "flex", gap: 0 }}>
-                {(["mine", "all"] as const).map((v, i, arr) => (
+                {(["all", "mine"] as const).map((v, i, arr) => (
                   <button
                     key={v}
                     onClick={() => setMineParam(v === "mine" ? "true" : "")}

--- a/app/trips/page.tsx
+++ b/app/trips/page.tsx
@@ -100,7 +100,7 @@ function TripsContent() {
           <div style={{ display: "flex", alignItems: "center" }}>
             {canFilter && (
               <div style={{ display: "flex", gap: 0 }}>
-                {(["mine", "all"] as const).map((v, i, arr) => (
+                {(["all", "mine"] as const).map((v, i, arr) => (
                   <button
                     key={v}
                     onClick={() => setMineParam(v === "mine" ? "true" : "")}


### PR DESCRIPTION
## Summary
- Reversed filter toggle order from Mine | All to All | Mine on /trips, /fuel, and /expenses
- Active-state logic unchanged — only render order flipped

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)