### PR TITLE
fix(ui): align card designs and date formats across all pages (#17)

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Suspense } from "react";
+import { Suspense, useState, useEffect } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { PageHeader } from "@/components/page-header";
@@ -12,11 +12,13 @@ function SubNav() {
   const pathname = usePathname();
   const { data: reservations = [] } = useReservations();
   const pendingCount = reservations.filter((r) => r.status === "pending").length;
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
 
   const year = new Date().getFullYear();
 
   const SUB_PAGES = [
-    { href: "/admin",         label: t("admin.sub_inbox") + (pendingCount > 0 ? ` (${pendingCount})` : "") },
+    { href: "/admin",         label: t("admin.sub_inbox") + (mounted && pendingCount > 0 ? ` (${pendingCount})` : "") },
     { href: "/admin/cars",       label: t("admin.sub_cars") },
     { href: "/admin/members",    label: t("admin.sub_members") },
     { href: "/admin/hygiene",    label: t("admin.sub_data") },

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -14,8 +14,8 @@ import {
 } from "@/hooks/use-reservations";
 import { useCars } from "@/hooks/use-cars";
 import type { Reservation, Car } from "@/types";
-import { paper, fontMono, fontSerif } from "@/lib/paper-theme";
-import { useT } from "@/components/locale-provider";
+import { paper, fontMono, fontSerif, fmtDate } from "@/lib/paper-theme";
+import { useT, useLocale } from "@/components/locale-provider";
 import { PickCalendar } from "@/components/pick-calendar";
 
 // ── Bottom Sheet ──────────────────────────────────────────────
@@ -103,6 +103,7 @@ function ResRow({
   r: Reservation;
   onClick: () => void;
 }) {
+  const { locale } = useLocale();
   const isPending = r.status === "pending";
   const statusColor = r.status === "confirmed" ? paper.green
     : r.status === "rejected" ? paper.accent : paper.amber;
@@ -134,7 +135,7 @@ function ResRow({
           {r.person_name}
         </div>
         <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkDim, letterSpacing: 1, marginTop: 2 }}>
-          {r.start_date}{r.start_date !== r.end_date ? ` → ${r.end_date}` : ""}
+          {fmtDate(r.start_date, locale)}{r.start_date !== r.end_date ? ` → ${fmtDate(r.end_date, locale)}` : ""}
         </div>
         {r.note && (
           <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkMute, marginTop: 2 }}>

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -105,8 +105,7 @@ function ResRow({
 }) {
   const { locale } = useLocale();
   const isPending = r.status === "pending";
-  const statusColor = r.status === "confirmed" ? paper.green
-    : r.status === "rejected" ? paper.accent : paper.amber;
+  const days = Math.round((new Date(`${r.end_date}T00:00:00Z`).getTime() - new Date(`${r.start_date}T00:00:00Z`).getTime()) / 86400000) + 1;
 
   return (
     <button
@@ -118,7 +117,7 @@ function ResRow({
           ? `repeating-linear-gradient(45deg, ${paper.paper} 0 6px, ${paper.paperDeep} 6px 10px)`
           : paper.paper,
         border: "none",
-        borderLeft: `3px ${isPending ? "dashed" : "solid"} ${statusColor}`,
+        borderLeft: `3px ${isPending ? "dashed" : "solid"} ${isPending ? paper.amber : paper.green}`,
         boxShadow: "0 1px 2px rgba(0,0,0,0.04)",
         cursor: "pointer", textAlign: "left",
       }}
@@ -135,7 +134,7 @@ function ResRow({
           {r.person_name}
         </div>
         <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkDim, letterSpacing: 1, marginTop: 2 }}>
-          {fmtDate(r.start_date, locale)}{r.start_date !== r.end_date ? ` → ${fmtDate(r.end_date, locale)}` : ""}
+          {fmtDate(r.start_date, locale as "nl" | "en")}{r.start_date !== r.end_date ? ` → ${fmtDate(r.end_date, locale as "nl" | "en")}` : ""}
         </div>
         {r.note && (
           <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkMute, marginTop: 2 }}>
@@ -143,14 +142,16 @@ function ResRow({
           </div>
         )}
       </div>
-      <div style={{
-        padding: "3px 6px",
-        background: statusColor,
-        color: paper.paper,
-        fontFamily: fontMono, fontSize: 9, fontWeight: 700,
-        letterSpacing: 1, textTransform: "uppercase", flexShrink: 0,
-      }}>
-        {r.status === "confirmed" ? "✓" : r.status === "rejected" ? "✗" : "?"}
+      <div style={{ display: "flex", flexDirection: "column", alignItems: "center", flexShrink: 0, gap: 3 }}>
+        <div style={{ fontFamily: fontMono, fontSize: 11, fontWeight: 700, color: paper.ink }}>
+          {days}d
+        </div>
+        <div style={{
+          fontFamily: fontMono, fontSize: 9, fontWeight: 700,
+          color: isPending ? paper.amber : paper.green,
+        }}>
+          {isPending ? "?" : "✓"}
+        </div>
       </div>
     </button>
   );

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -142,14 +142,11 @@ function ResRow({
           </div>
         )}
       </div>
-      <div style={{ display: "flex", flexDirection: "column", alignItems: "center", flexShrink: 0, gap: 3 }}>
-        <div style={{ fontFamily: fontMono, fontSize: 11, fontWeight: 700, color: paper.ink }}>
+      <div style={{ textAlign: "right", flexShrink: 0 }}>
+        <div style={{ fontFamily: fontMono, fontSize: 14, fontWeight: 700, color: paper.ink, whiteSpace: "nowrap" }}>
           {days}d
         </div>
-        <div style={{
-          fontFamily: fontMono, fontSize: 9, fontWeight: 700,
-          color: isPending ? paper.amber : paper.green,
-        }}>
+        <div style={{ fontFamily: fontMono, fontSize: 10, fontWeight: 700, color: isPending ? paper.amber : paper.green }}>
           {isPending ? "?" : "✓"}
         </div>
       </div>

--- a/app/expenses/page.tsx
+++ b/app/expenses/page.tsx
@@ -12,8 +12,8 @@ import { useMe } from "@/hooks/use-me";
 import { useQueryParam } from "@/hooks/use-query-param";
 import { YearSelect } from "@/components/year-select";
 import type { Expense } from "@/types";
-import { paper, fontMono, fontSerif, fmtMoney, fmtYearMonth } from "@/lib/paper-theme";
-import { useT } from "@/components/locale-provider";
+import { paper, fontMono, fontSerif, fmtMoney, fmtYearMonth, fmtDate } from "@/lib/paper-theme";
+import { useT, useLocale } from "@/components/locale-provider";
 
 const overlayStyle: React.CSSProperties = {
   position: "fixed", inset: 0, background: "rgba(0,0,0,0.45)", zIndex: 49,
@@ -28,6 +28,7 @@ const sheetStyle: React.CSSProperties = {
 
 function ExpensesContent() {
   const t = useT();
+  const { locale } = useLocale();
   const { data: expenses = [], isLoading } = useExpenses();
   const { data: me } = useMe();
   const createE = useCreateExpense();
@@ -169,7 +170,7 @@ function ExpensesContent() {
                 {e.description ?? "—"}
               </div>
               <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkDim, letterSpacing: 1, marginTop: 2 }}>
-                {e.person_name} · {e.date}
+                {e.person_name} · {fmtDate(e.date, locale)}
               </div>
             </div>
             <div style={{ textAlign: "right", flexShrink: 0 }}>

--- a/app/fuel/page.tsx
+++ b/app/fuel/page.tsx
@@ -12,8 +12,8 @@ import { useMe } from "@/hooks/use-me";
 import { useQueryParam } from "@/hooks/use-query-param";
 import { YearSelect } from "@/components/year-select";
 import type { FuelFillup } from "@/types";
-import { paper, fontMono, fontSerif, fmtMoney, fmtYearMonth } from "@/lib/paper-theme";
-import { useT } from "@/components/locale-provider";
+import { paper, fontMono, fontSerif, fmtMoney, fmtYearMonth, fmtDate } from "@/lib/paper-theme";
+import { useT, useLocale } from "@/components/locale-provider";
 
 const overlayStyle: React.CSSProperties = {
   position: "fixed", inset: 0, background: "rgba(0,0,0,0.45)", zIndex: 49,
@@ -28,6 +28,7 @@ const sheetStyle: React.CSSProperties = {
 
 function FuelContent() {
   const t = useT();
+  const { locale } = useLocale();
   const { data: fillups = [], isLoading } = useFuelFillups();
   const { data: me } = useMe();
   const createF = useCreateFuelFillup();
@@ -162,11 +163,11 @@ function FuelContent() {
               {f.car_short}
             </div>
             <div style={{ flex: 1, minWidth: 0 }}>
-              <div style={{ fontFamily: fontSerif, fontSize: 15, fontWeight: 600, lineHeight: 1.2 }}>
-                {f.liters?.toFixed(2)} L
+              <div style={{ fontFamily: fontSerif, fontSize: 15, fontWeight: 600, lineHeight: 1.2, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                ⛽ {f.location ?? t("dashboard.fillup_label")}
               </div>
               <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkDim, letterSpacing: 1, marginTop: 2 }}>
-                {f.person_name} · {f.date}{f.odometer ? ` · ${f.odometer.toLocaleString("nl-BE")} km` : ""}
+                {f.person_name} · {fmtDate(f.date, locale)} · {f.liters.toFixed(1)}L
               </div>
             </div>
             <div style={{ textAlign: "right", flexShrink: 0 }}>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -401,35 +401,36 @@ function ExpenseStrip({ expense, onClick }: { expense: Expense; onClick?: () => 
 }
 
 function ReservationStrip({ r, onClick }: { r: Reservation; onClick?: () => void }) {
-  const t = useT();
   const isPending = r.status === "pending";
+  const days = Math.round((new Date(`${r.end_date}T00:00:00Z`).getTime() - new Date(`${r.start_date}T00:00:00Z`).getTime()) / 86400000) + 1;
   return (
     <button onClick={onClick} style={{
       ...stripButton,
       background: isPending
         ? `repeating-linear-gradient(-45deg, ${paper.paperDeep}, ${paper.paperDeep} 4px, ${paper.paper} 4px, ${paper.paper} 10px)`
         : paper.paper,
-      borderLeft: `3px dashed ${paper.blue}`,
+      borderLeft: `3px ${isPending ? "dashed" : "solid"} ${isPending ? paper.amber : paper.green}`,
     }}>
       <CarStamp code={r.car_short ?? "?"} />
       <div style={{ flex: 1, minWidth: 0 }}>
         <div style={{ fontFamily: fontSerif, fontSize: 15, color: paper.ink, fontWeight: 600, lineHeight: 1.2 }}>
-          {r.note ?? r.person_name}
+          {r.person_name}
         </div>
         <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkDim, letterSpacing: 1, marginTop: 2 }}>
-          {r.person_name} · {fmtDate(r.start_date)}
-          {r.start_date !== r.end_date ? ` → ${fmtDate(r.end_date)}` : ""}
+          {fmtDate(r.start_date)}{r.start_date !== r.end_date ? ` → ${fmtDate(r.end_date)}` : ""}
         </div>
       </div>
-      {isPending && (
-        <div style={{
-          fontFamily: fontMono, fontSize: 8, fontWeight: 700,
-          color: paper.amber, letterSpacing: 1, textTransform: "uppercase",
-          border: `1px solid ${paper.amber}`, padding: "2px 6px",
-        }}>
-          {t("dashboard.pending_badge")}
+      <div style={{ display: "flex", flexDirection: "column", alignItems: "center", flexShrink: 0, gap: 3 }}>
+        <div style={{ fontFamily: fontMono, fontSize: 11, fontWeight: 700, color: paper.ink }}>
+          {days}d
         </div>
-      )}
+        <div style={{
+          fontFamily: fontMono, fontSize: 9, fontWeight: 700,
+          color: isPending ? paper.amber : paper.green,
+        }}>
+          {isPending ? "?" : "✓"}
+        </div>
+      </div>
     </button>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -369,10 +369,13 @@ function FuelStrip({ fuel, onClick }: { fuel: FuelFillup; onClick?: () => void }
           {fuel.person_name} · {fmtDate(fuel.date)} · {fuel.liters.toFixed(1)}L
         </div>
       </div>
-      <div style={{ textAlign: "right" }}>
+      <div style={{ textAlign: "right", flexShrink: 0 }}>
         <div style={{ fontFamily: fontMono, fontSize: 14, fontWeight: 700, color: paper.green, whiteSpace: "nowrap" }}>
           {fmtMoney(fuel.amount)}
         </div>
+        {fuel.price_per_liter && (
+          <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkDim }}>€{fuel.price_per_liter.toFixed(3)}/L</div>
+        )}
       </div>
     </button>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -420,14 +420,11 @@ function ReservationStrip({ r, onClick }: { r: Reservation; onClick?: () => void
           {fmtDate(r.start_date)}{r.start_date !== r.end_date ? ` → ${fmtDate(r.end_date)}` : ""}
         </div>
       </div>
-      <div style={{ display: "flex", flexDirection: "column", alignItems: "center", flexShrink: 0, gap: 3 }}>
-        <div style={{ fontFamily: fontMono, fontSize: 11, fontWeight: 700, color: paper.ink }}>
+      <div style={{ textAlign: "right", flexShrink: 0 }}>
+        <div style={{ fontFamily: fontMono, fontSize: 14, fontWeight: 700, color: paper.ink, whiteSpace: "nowrap" }}>
           {days}d
         </div>
-        <div style={{
-          fontFamily: fontMono, fontSize: 9, fontWeight: 700,
-          color: isPending ? paper.amber : paper.green,
-        }}>
+        <div style={{ fontFamily: fontMono, fontSize: 10, fontWeight: 700, color: isPending ? paper.amber : paper.green }}>
           {isPending ? "?" : "✓"}
         </div>
       </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -327,17 +327,22 @@ function TripStrip({ trip, onClick }: { trip: Trip; onClick?: () => void }) {
     }}>
       <CarStamp code={trip.car_short ?? "?"} />
       <div style={{ flex: 1, minWidth: 0 }}>
-        <div style={{ fontFamily: fontSerif, fontSize: 15, color: paper.ink, fontWeight: 600, lineHeight: 1.2, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
-          {trip.location ?? "—"}
+        <div style={{
+          fontFamily: fontSerif, fontSize: 15, color: (!trip.location && !trip.gps_coords && trip.parking) ? paper.inkDim : paper.ink,
+          fontStyle: (!trip.location && !trip.gps_coords && trip.parking) ? "italic" : "normal",
+          fontWeight: 600, lineHeight: 1.2, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis",
+        }}>
+          {trip.location ?? trip.gps_coords ?? trip.parking ?? "—"}
         </div>
         <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkDim, letterSpacing: 1, marginTop: 2 }}>
-          {trip.person_name} · {fmtDate(trip.date)} · {fmtKm(trip.km)}
+          {trip.person_name} · {fmtDate(trip.date)} · {trip.start_odometer.toLocaleString("nl-BE")} → {trip.end_odometer.toLocaleString("nl-BE")}
         </div>
       </div>
-      <div style={{ textAlign: "right" }}>
+      <div style={{ textAlign: "right", flexShrink: 0 }}>
         <div style={{ fontFamily: fontMono, fontSize: 14, fontWeight: 700, color: paper.accent, whiteSpace: "nowrap" }}>
           {fmtMoney(trip.amount)}
         </div>
+        <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkDim }}>{trip.km} km</div>
       </div>
     </button>
   );

--- a/app/trips/page.tsx
+++ b/app/trips/page.tsx
@@ -12,8 +12,8 @@ import { useMe } from "@/hooks/use-me";
 import { useQueryParam } from "@/hooks/use-query-param";
 import { YearSelect } from "@/components/year-select";
 import type { Trip } from "@/types";
-import { paper, fontMono, fontSerif, fmtMoney, fmtYearMonth } from "@/lib/paper-theme";
-import { useT } from "@/components/locale-provider";
+import { paper, fontMono, fontSerif, fmtMoney, fmtYearMonth, fmtDate } from "@/lib/paper-theme";
+import { useT, useLocale } from "@/components/locale-provider";
 
 const overlayStyle: React.CSSProperties = {
   position: "fixed", inset: 0, background: "rgba(0,0,0,0.45)", zIndex: 49,
@@ -28,6 +28,7 @@ const sheetStyle: React.CSSProperties = {
 
 function TripsContent() {
   const t = useT();
+  const { locale } = useLocale();
   const { data: trips = [], isLoading } = useTrips();
   const { data: me } = useMe();
   const createTrip = useCreateTrip();
@@ -173,7 +174,7 @@ function TripsContent() {
                 {trip.location ?? trip.gps_coords ?? trip.parking ?? "—"}
               </div>
               <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkDim, letterSpacing: 1, marginTop: 2 }}>
-                {trip.person_name} · {trip.date} · {trip.start_odometer.toLocaleString("nl-BE")} → {trip.end_odometer.toLocaleString("nl-BE")}
+                {trip.person_name} · {fmtDate(trip.date, locale)} · {trip.start_odometer.toLocaleString("nl-BE")} → {trip.end_odometer.toLocaleString("nl-BE")}
               </div>
             </div>
             <div style={{ textAlign: "right", flexShrink: 0 }}>


### PR DESCRIPTION
## Summary
- Date format standardised to `dag dd mmm` everywhere — no ISO dates, no hardcoded arrays (uses `fmtDate`)
- Dashboard trip cards now match `/trips` canonical: location top, `person · date · odometer_start → odometer_end` subtitle, km below price
- `/fuel` list cards aligned to dashboard: ⛽ location top, `person · date · liters` subtitle
- Dashboard fuel cards now show `€x.xxx/L` below total to match `/fuel` list
- `/expenses` list dates updated to `fmtDate` format
- Reservation cards unified on dashboard and `/calendar`: `Xd` + `✓`/`?` on the right (fontMono 14px bold, matching money amounts)
- Confirmed reservations: solid green border; pending: dashed amber border — consistent on both pages
- Admin sub-nav pending count deferred to client to fix SSR hydration mismatch
- Dashboard `todayFmt` already deferred to client (pre-existing hydration fix)

Closes #17

## Test plan
- [ ] Dashboard: trip, fuel, expense, reservation cards match their respective list pages
- [ ] `/fuel` list: price/liter visible below total
- [ ] `/calendar`: reservation cards show `Xd` + status icon; pending = dashed amber, confirmed = solid green
- [ ] No hydration errors in browser console
- [ ] No layout regressions on mobile (~480px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)