### PR TITLE
refactor: extract shared card components (TripCard, FuelCard, ExpenseCard, ReservationCard) (#18)

### DIFF
--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -14,8 +14,9 @@ import {
 } from "@/hooks/use-reservations";
 import { useCars } from "@/hooks/use-cars";
 import type { Reservation, Car } from "@/types";
-import { paper, fontMono, fontSerif, fmtDate } from "@/lib/paper-theme";
-import { useT, useLocale } from "@/components/locale-provider";
+import { paper, fontMono, fontSerif } from "@/lib/paper-theme";
+import { useT } from "@/components/locale-provider";
+import { ReservationCard } from "@/components/reservation-card";
 import { PickCalendar } from "@/components/pick-calendar";
 
 // ── Bottom Sheet ──────────────────────────────────────────────
@@ -92,65 +93,6 @@ function CarTimeline({
         onRangePick={(from, to) => onPickDone(car.id, from, to)}
       />
     </div>
-  );
-}
-
-// ── Reservation list item ─────────────────────────────────────
-function ResRow({
-  r,
-  onClick,
-}: {
-  r: Reservation;
-  onClick: () => void;
-}) {
-  const { locale } = useLocale();
-  const isPending = r.status === "pending";
-  const days = Math.round((new Date(`${r.end_date}T00:00:00Z`).getTime() - new Date(`${r.start_date}T00:00:00Z`).getTime()) / 86400000) + 1;
-
-  return (
-    <button
-      onClick={onClick}
-      style={{
-        width: "100%", display: "flex", alignItems: "center", gap: 12,
-        padding: "11px 14px", marginBottom: 8,
-        background: isPending
-          ? `repeating-linear-gradient(45deg, ${paper.paper} 0 6px, ${paper.paperDeep} 6px 10px)`
-          : paper.paper,
-        border: "none",
-        borderLeft: `3px ${isPending ? "dashed" : "solid"} ${isPending ? paper.amber : paper.green}`,
-        boxShadow: "0 1px 2px rgba(0,0,0,0.04)",
-        cursor: "pointer", textAlign: "left",
-      }}
-    >
-      <div style={{
-        padding: "5px 7px", background: paper.ink, color: paper.paper,
-        fontFamily: fontMono, fontSize: 11, fontWeight: 700, letterSpacing: 2,
-        flexShrink: 0, minWidth: 38, textAlign: "center",
-      }}>
-        {r.car_short}
-      </div>
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <div style={{ fontFamily: fontSerif, fontSize: 15, fontWeight: 600, color: paper.ink, lineHeight: 1.2 }}>
-          {r.person_name}
-        </div>
-        <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkDim, letterSpacing: 1, marginTop: 2 }}>
-          {fmtDate(r.start_date, locale as "nl" | "en")}{r.start_date !== r.end_date ? ` → ${fmtDate(r.end_date, locale as "nl" | "en")}` : ""}
-        </div>
-        {r.note && (
-          <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkMute, marginTop: 2 }}>
-            {r.note}
-          </div>
-        )}
-      </div>
-      <div style={{ textAlign: "right", flexShrink: 0 }}>
-        <div style={{ fontFamily: fontMono, fontSize: 14, fontWeight: 700, color: paper.ink, whiteSpace: "nowrap" }}>
-          {days}d
-        </div>
-        <div style={{ fontFamily: fontMono, fontSize: 10, fontWeight: 700, color: isPending ? paper.amber : paper.green }}>
-          {isPending ? "?" : "✓"}
-        </div>
-      </div>
-    </button>
   );
 }
 
@@ -295,7 +237,7 @@ function CalendarContent() {
           </div>
         )}
         {upcoming.map((r) => (
-          <ResRow key={r.id} r={r} onClick={() => openEdit(r)} />
+          <ReservationCard key={r.id} reservation={r} onClick={() => openEdit(r)} />
         ))}
       </div>
 

--- a/app/expenses/page.tsx
+++ b/app/expenses/page.tsx
@@ -12,8 +12,9 @@ import { useMe } from "@/hooks/use-me";
 import { useQueryParam } from "@/hooks/use-query-param";
 import { YearSelect } from "@/components/year-select";
 import type { Expense } from "@/types";
-import { paper, fontMono, fontSerif, fmtMoney, fmtYearMonth, fmtDate } from "@/lib/paper-theme";
-import { useT, useLocale } from "@/components/locale-provider";
+import { paper, fontMono, fmtYearMonth } from "@/lib/paper-theme";
+import { useT } from "@/components/locale-provider";
+import { ExpenseCard } from "@/components/expense-card";
 
 const overlayStyle: React.CSSProperties = {
   position: "fixed", inset: 0, background: "rgba(0,0,0,0.45)", zIndex: 49,
@@ -28,7 +29,6 @@ const sheetStyle: React.CSSProperties = {
 
 function ExpensesContent() {
   const t = useT();
-  const { locale } = useLocale();
   const { data: expenses = [], isLoading } = useExpenses();
   const { data: me } = useMe();
   const createE = useCreateExpense();
@@ -145,38 +145,7 @@ function ExpensesContent() {
         getGroupTotal={(items) => items.reduce((s, e) => s + e.amount, 0)}
         totalSuffix="€"
         renderItem={(e) => (
-          <button
-            key={e.id}
-            onClick={() => openEdit(e)}
-            style={{
-              width: "100%", display: "flex", alignItems: "center", gap: 12,
-              padding: "12px 14px", marginBottom: 8,
-              background: paper.paper, border: "none", cursor: "pointer", textAlign: "left",
-              borderLeft: `3px solid ${paper.green}`,
-              boxShadow: "0 1px 2px rgba(0,0,0,0.04)",
-            }}
-          >
-            <div style={{
-              padding: "6px 8px", background: paper.ink, color: paper.paper,
-              fontFamily: fontMono, fontSize: 11, fontWeight: 700, letterSpacing: 2, flexShrink: 0, minWidth: 42, textAlign: "center",
-            }}>
-              {e.car_short}
-            </div>
-            <div style={{ flex: 1, minWidth: 0 }}>
-              <div style={{
-                fontFamily: fontSerif, fontSize: 15, fontWeight: 600, lineHeight: 1.2,
-                whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis",
-              }}>
-                {e.description ?? "—"}
-              </div>
-              <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkDim, letterSpacing: 1, marginTop: 2 }}>
-                {e.person_name} · {fmtDate(e.date, locale)}
-              </div>
-            </div>
-            <div style={{ textAlign: "right", flexShrink: 0 }}>
-              <div style={{ fontFamily: fontMono, fontSize: 14, fontWeight: 700, color: paper.green }}>{fmtMoney(e.amount)}</div>
-            </div>
-          </button>
+          <ExpenseCard key={e.id} expense={e} onClick={() => openEdit(e)} />
         )}
       />
 

--- a/app/fuel/page.tsx
+++ b/app/fuel/page.tsx
@@ -12,8 +12,9 @@ import { useMe } from "@/hooks/use-me";
 import { useQueryParam } from "@/hooks/use-query-param";
 import { YearSelect } from "@/components/year-select";
 import type { FuelFillup } from "@/types";
-import { paper, fontMono, fontSerif, fmtMoney, fmtYearMonth, fmtDate } from "@/lib/paper-theme";
-import { useT, useLocale } from "@/components/locale-provider";
+import { paper, fontMono, fmtYearMonth } from "@/lib/paper-theme";
+import { useT } from "@/components/locale-provider";
+import { FuelCard } from "@/components/fuel-card";
 
 const overlayStyle: React.CSSProperties = {
   position: "fixed", inset: 0, background: "rgba(0,0,0,0.45)", zIndex: 49,
@@ -28,7 +29,6 @@ const sheetStyle: React.CSSProperties = {
 
 function FuelContent() {
   const t = useT();
-  const { locale } = useLocale();
   const { data: fillups = [], isLoading } = useFuelFillups();
   const { data: me } = useMe();
   const createF = useCreateFuelFillup();
@@ -145,38 +145,7 @@ function FuelContent() {
         getGroupTotal={(items) => items.reduce((s, f) => s + f.amount, 0)}
         totalSuffix="€"
         renderItem={(f) => (
-          <button
-            key={f.id}
-            onClick={() => openEdit(f)}
-            style={{
-              width: "100%", display: "flex", alignItems: "center", gap: 12,
-              padding: "12px 14px", marginBottom: 8,
-              background: paper.paper, border: "none", cursor: "pointer", textAlign: "left",
-              borderLeft: `3px solid ${paper.green}`,
-              boxShadow: "0 1px 2px rgba(0,0,0,0.04)",
-            }}
-          >
-            <div style={{
-              padding: "6px 8px", background: paper.ink, color: paper.paper,
-              fontFamily: fontMono, fontSize: 11, fontWeight: 700, letterSpacing: 2, flexShrink: 0, minWidth: 42, textAlign: "center",
-            }}>
-              {f.car_short}
-            </div>
-            <div style={{ flex: 1, minWidth: 0 }}>
-              <div style={{ fontFamily: fontSerif, fontSize: 15, fontWeight: 600, lineHeight: 1.2, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
-                ⛽ {f.location ?? t("dashboard.fillup_label")}
-              </div>
-              <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkDim, letterSpacing: 1, marginTop: 2 }}>
-                {f.person_name} · {fmtDate(f.date, locale)} · {f.liters.toFixed(1)}L
-              </div>
-            </div>
-            <div style={{ textAlign: "right", flexShrink: 0 }}>
-              <div style={{ fontFamily: fontMono, fontSize: 14, fontWeight: 700, color: paper.green }}>{fmtMoney(f.amount)}</div>
-              {f.price_per_liter && (
-                <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkDim }}>€{f.price_per_liter.toFixed(3)}/L</div>
-              )}
-            </div>
-          </button>
+          <FuelCard key={f.id} fuel={f} onClick={() => openEdit(f)} />
         )}
       />
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,6 +18,10 @@ import { ReservationForm } from "@/app/calendar/reservation-form";
 import { toast } from "sonner";
 import { useT } from "@/components/locale-provider";
 import { LangSwitcher } from "@/components/lang-switcher";
+import { TripCard } from "@/components/trip-card";
+import { FuelCard } from "@/components/fuel-card";
+import { ExpenseCard } from "@/components/expense-card";
+import { ReservationCard } from "@/components/reservation-card";
 import { useMe } from "@/hooks/use-me";
 import {
   useCreateTrip, useUpdateTrip, useDeleteTrip,
@@ -74,18 +78,6 @@ function ReceiptRow({
     );
   }
   return inner;
-}
-
-function CarStamp({ code }: { code: string }) {
-  return (
-    <div style={{
-      padding: "6px 8px", textAlign: "center",
-      border: `1.5px solid ${paper.ink}`,
-      background: paper.ink, color: paper.paper,
-      fontFamily: fontMono, fontSize: 11, fontWeight: 700, letterSpacing: 2,
-      display: "inline-block", minWidth: 42, flexShrink: 0,
-    }}>{code}</div>
-  );
 }
 
 // ── Balance Receipt ───────────────────────────────────────────────
@@ -290,7 +282,13 @@ function CarLocations({ trips, onTripClick }: { trips: Trip[]; onTripClick: (tri
                 cursor: "pointer",
               }}
             >
-              <CarStamp code={short} />
+              <div style={{
+                padding: "6px 8px", textAlign: "center",
+                border: `1.5px solid ${paper.ink}`,
+                background: paper.ink, color: paper.paper,
+                fontFamily: fontMono, fontSize: 11, fontWeight: 700, letterSpacing: 2,
+                display: "inline-block", minWidth: 42, flexShrink: 0,
+              }}>{short}</div>
               <div style={{ flex: 1, minWidth: 0 }}>
                 <div style={{
                   fontFamily: fontSerif, fontSize: 14, fontWeight: 600, lineHeight: 1.2,
@@ -310,128 +308,6 @@ function CarLocations({ trips, onTripClick }: { trips: Trip[]; onTripClick: (tri
         })}
       </div>
     </div>
-  );
-}
-
-// ── Activity strips ───────────────────────────────────────────
-function TripStrip({ trip, onClick }: { trip: Trip; onClick?: () => void }) {
-  return (
-    <button onClick={onClick} style={{
-      width: "100%", textAlign: "left", appearance: "none",
-      background: paper.paper, padding: "12px 14px", marginBottom: 8,
-      display: "flex", alignItems: "center", gap: 12,
-      borderTop: "none", borderRight: "none", borderBottom: "none",
-      borderLeft: `3px solid ${paper.accent}`,
-      boxShadow: "0 1px 2px rgba(0,0,0,0.04)",
-      cursor: onClick ? "pointer" : "default",
-    }}>
-      <CarStamp code={trip.car_short ?? "?"} />
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <div style={{
-          fontFamily: fontSerif, fontSize: 15, color: (!trip.location && !trip.gps_coords && trip.parking) ? paper.inkDim : paper.ink,
-          fontStyle: (!trip.location && !trip.gps_coords && trip.parking) ? "italic" : "normal",
-          fontWeight: 600, lineHeight: 1.2, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis",
-        }}>
-          {trip.location ?? trip.gps_coords ?? trip.parking ?? "—"}
-        </div>
-        <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkDim, letterSpacing: 1, marginTop: 2 }}>
-          {trip.person_name} · {fmtDate(trip.date)} · {trip.start_odometer.toLocaleString("nl-BE")} → {trip.end_odometer.toLocaleString("nl-BE")}
-        </div>
-      </div>
-      <div style={{ textAlign: "right", flexShrink: 0 }}>
-        <div style={{ fontFamily: fontMono, fontSize: 14, fontWeight: 700, color: paper.accent, whiteSpace: "nowrap" }}>
-          {fmtMoney(trip.amount)}
-        </div>
-        <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkDim }}>{trip.km} km</div>
-      </div>
-    </button>
-  );
-}
-
-const stripButton: React.CSSProperties = {
-  width: "100%", textAlign: "left", appearance: "none",
-  background: paper.paper, padding: "12px 14px", marginBottom: 8,
-  display: "flex", alignItems: "center", gap: 12,
-  borderTop: "none", borderRight: "none", borderBottom: "none",
-  boxShadow: "0 1px 2px rgba(0,0,0,0.04)", cursor: "pointer",
-};
-
-function FuelStrip({ fuel, onClick }: { fuel: FuelFillup; onClick?: () => void }) {
-  const t = useT();
-  return (
-    <button onClick={onClick} style={{ ...stripButton, borderLeft: `3px solid ${paper.green}` }}>
-      <CarStamp code={fuel.car_short ?? "?"} />
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <div style={{ fontFamily: fontSerif, fontSize: 15, color: paper.ink, fontWeight: 600, lineHeight: 1.2, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
-          ⛽ {fuel.location ?? t("dashboard.fillup_label")}
-        </div>
-        <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkDim, letterSpacing: 1, marginTop: 2 }}>
-          {fuel.person_name} · {fmtDate(fuel.date)} · {fuel.liters.toFixed(1)}L
-        </div>
-      </div>
-      <div style={{ textAlign: "right", flexShrink: 0 }}>
-        <div style={{ fontFamily: fontMono, fontSize: 14, fontWeight: 700, color: paper.green, whiteSpace: "nowrap" }}>
-          {fmtMoney(fuel.amount)}
-        </div>
-        {fuel.price_per_liter && (
-          <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkDim }}>€{fuel.price_per_liter.toFixed(3)}/L</div>
-        )}
-      </div>
-    </button>
-  );
-}
-
-function ExpenseStrip({ expense, onClick }: { expense: Expense; onClick?: () => void }) {
-  const t = useT();
-  return (
-    <button onClick={onClick} style={{ ...stripButton, borderLeft: `3px solid ${paper.green}` }}>
-      <CarStamp code={expense.car_short ?? "?"} />
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <div style={{ fontFamily: fontSerif, fontSize: 15, color: paper.ink, fontWeight: 600, lineHeight: 1.2, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
-          {expense.description ?? t("dashboard.maintenance_label")}
-        </div>
-        <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkDim, letterSpacing: 1, marginTop: 2 }}>
-          {expense.person_name} · {fmtDate(expense.date)}
-        </div>
-      </div>
-      <div style={{ textAlign: "right" }}>
-        <div style={{ fontFamily: fontMono, fontSize: 14, fontWeight: 700, color: paper.green, whiteSpace: "nowrap" }}>
-          {fmtMoney(expense.amount)}
-        </div>
-      </div>
-    </button>
-  );
-}
-
-function ReservationStrip({ r, onClick }: { r: Reservation; onClick?: () => void }) {
-  const isPending = r.status === "pending";
-  const days = Math.round((new Date(`${r.end_date}T00:00:00Z`).getTime() - new Date(`${r.start_date}T00:00:00Z`).getTime()) / 86400000) + 1;
-  return (
-    <button onClick={onClick} style={{
-      ...stripButton,
-      background: isPending
-        ? `repeating-linear-gradient(-45deg, ${paper.paperDeep}, ${paper.paperDeep} 4px, ${paper.paper} 4px, ${paper.paper} 10px)`
-        : paper.paper,
-      borderLeft: `3px ${isPending ? "dashed" : "solid"} ${isPending ? paper.amber : paper.green}`,
-    }}>
-      <CarStamp code={r.car_short ?? "?"} />
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <div style={{ fontFamily: fontSerif, fontSize: 15, color: paper.ink, fontWeight: 600, lineHeight: 1.2 }}>
-          {r.person_name}
-        </div>
-        <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkDim, letterSpacing: 1, marginTop: 2 }}>
-          {fmtDate(r.start_date)}{r.start_date !== r.end_date ? ` → ${fmtDate(r.end_date)}` : ""}
-        </div>
-      </div>
-      <div style={{ textAlign: "right", flexShrink: 0 }}>
-        <div style={{ fontFamily: fontMono, fontSize: 14, fontWeight: 700, color: paper.ink, whiteSpace: "nowrap" }}>
-          {days}d
-        </div>
-        <div style={{ fontFamily: fontMono, fontSize: 10, fontWeight: 700, color: isPending ? paper.amber : paper.green }}>
-          {isPending ? "?" : "✓"}
-        </div>
-      </div>
-    </button>
   );
 }
 
@@ -605,7 +481,7 @@ export default function DashboardPage() {
             {t("state.empty_trips")}
           </div>
         ) : (
-          recentTrips.map((trip) => <TripStrip key={trip.id} trip={trip} onClick={() => setEditTrip(trip)} />)
+          recentTrips.map((trip) => <TripCard key={trip.id} trip={trip} onClick={() => setEditTrip(trip)} />)
         )}
       </div>
 
@@ -617,7 +493,7 @@ export default function DashboardPage() {
             {t("state.empty_fuel")}
           </div>
         ) : (
-          recentFuel.map((f) => <FuelStrip key={f.id} fuel={f} onClick={() => setEditFuel(f)} />)
+          recentFuel.map((f) => <FuelCard key={f.id} fuel={f} onClick={() => setEditFuel(f)} />)
         )}
       </div>
 
@@ -629,7 +505,7 @@ export default function DashboardPage() {
             {t("state.empty_expenses")}
           </div>
         ) : (
-          recentExpenses.map((e) => <ExpenseStrip key={e.id} expense={e} onClick={() => setEditExpense(e)} />)
+          recentExpenses.map((e) => <ExpenseCard key={e.id} expense={e} onClick={() => setEditExpense(e)} />)
         )}
       </div>
 
@@ -638,7 +514,7 @@ export default function DashboardPage() {
         <>
           <SectionHeader title={t("dashboard.upcoming")} href="/calendar" />
           <div style={{ padding: "0 16px" }}>
-            {upcoming.map((r) => <ReservationStrip key={r.id} r={r} onClick={() => setEditReservation(r)} />)}
+            {upcoming.map((r) => <ReservationCard key={r.id} reservation={r} onClick={() => setEditReservation(r)} />)}
           </div>
         </>
       )}

--- a/app/trips/page.tsx
+++ b/app/trips/page.tsx
@@ -12,8 +12,9 @@ import { useMe } from "@/hooks/use-me";
 import { useQueryParam } from "@/hooks/use-query-param";
 import { YearSelect } from "@/components/year-select";
 import type { Trip } from "@/types";
-import { paper, fontMono, fontSerif, fmtMoney, fmtYearMonth, fmtDate } from "@/lib/paper-theme";
-import { useT, useLocale } from "@/components/locale-provider";
+import { paper, fontMono, fmtYearMonth } from "@/lib/paper-theme";
+import { useT } from "@/components/locale-provider";
+import { TripCard } from "@/components/trip-card";
 
 const overlayStyle: React.CSSProperties = {
   position: "fixed", inset: 0, background: "rgba(0,0,0,0.45)", zIndex: 49,
@@ -28,7 +29,6 @@ const sheetStyle: React.CSSProperties = {
 
 function TripsContent() {
   const t = useT();
-  const { locale } = useLocale();
   const { data: trips = [], isLoading } = useTrips();
   const { data: me } = useMe();
   const createTrip = useCreateTrip();
@@ -147,41 +147,7 @@ function TripsContent() {
         getGroupTotal={(items) => items.reduce((s, trip) => s + trip.km, 0)}
         totalSuffix="km"
         renderItem={(trip) => (
-          <button
-            key={trip.id}
-            onClick={() => openEdit(trip)}
-            style={{
-              width: "100%", display: "flex", alignItems: "center", gap: 12,
-              padding: "12px 14px", marginBottom: 8,
-              background: paper.paper, border: "none", cursor: "pointer", textAlign: "left",
-              borderLeft: `3px solid ${paper.accent}`,
-              boxShadow: "0 1px 2px rgba(0,0,0,0.04)",
-            }}
-          >
-            <div style={{
-              padding: "6px 8px", background: paper.ink, color: paper.paper,
-              fontFamily: fontMono, fontSize: 11, fontWeight: 700, letterSpacing: 2, flexShrink: 0, minWidth: 42, textAlign: "center",
-            }}>
-              {trip.car_short}
-            </div>
-            <div style={{ flex: 1, minWidth: 0 }}>
-              <div style={{
-                fontFamily: fontSerif, fontSize: 15, fontWeight: 600, lineHeight: 1.2,
-                whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis",
-                color: (!trip.location && !trip.gps_coords && trip.parking) ? paper.inkDim : paper.ink,
-                fontStyle: (!trip.location && !trip.gps_coords && trip.parking) ? "italic" : "normal",
-              }}>
-                {trip.location ?? trip.gps_coords ?? trip.parking ?? "—"}
-              </div>
-              <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkDim, letterSpacing: 1, marginTop: 2 }}>
-                {trip.person_name} · {fmtDate(trip.date, locale)} · {trip.start_odometer.toLocaleString("nl-BE")} → {trip.end_odometer.toLocaleString("nl-BE")}
-              </div>
-            </div>
-            <div style={{ textAlign: "right", flexShrink: 0 }}>
-              <div style={{ fontFamily: fontMono, fontSize: 14, fontWeight: 700, color: paper.accent }}>{fmtMoney(trip.amount)}</div>
-              <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkDim }}>{trip.km} km</div>
-            </div>
-          </button>
+          <TripCard key={trip.id} trip={trip} onClick={() => openEdit(trip)} />
         )}
       />
 

--- a/components/expense-card.tsx
+++ b/components/expense-card.tsx
@@ -1,0 +1,44 @@
+"use client";
+import type { Expense } from "@/types";
+import { paper, fontMono, fontSerif, fmtMoney, fmtDate } from "@/lib/paper-theme";
+import { useT, useLocale } from "@/components/locale-provider";
+
+export interface ExpenseCardProps {
+  expense: Expense;
+  onClick?: () => void;
+}
+
+export function ExpenseCard({ expense, onClick }: ExpenseCardProps) {
+  const t = useT();
+  const { locale } = useLocale();
+  return (
+    <button onClick={onClick} style={{
+      width: "100%", textAlign: "left", appearance: "none",
+      background: paper.paper, padding: "12px 14px", marginBottom: 8,
+      display: "flex", alignItems: "center", gap: 12,
+      borderTop: "none", borderRight: "none", borderBottom: "none",
+      borderLeft: `3px solid ${paper.green}`,
+      boxShadow: "0 1px 2px rgba(0,0,0,0.04)",
+      cursor: onClick ? "pointer" : "default",
+    }}>
+      <div style={{
+        padding: "6px 8px", background: paper.ink, color: paper.paper,
+        fontFamily: fontMono, fontSize: 11, fontWeight: 700, letterSpacing: 2,
+        display: "inline-block", minWidth: 42, flexShrink: 0, textAlign: "center",
+      }}>{expense.car_short ?? "?"}</div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontFamily: fontSerif, fontSize: 15, color: paper.ink, fontWeight: 600, lineHeight: 1.2, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+          {expense.description ?? t("dashboard.maintenance_label")}
+        </div>
+        <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkDim, letterSpacing: 1, marginTop: 2 }}>
+          {expense.person_name} · {fmtDate(expense.date, locale)}
+        </div>
+      </div>
+      <div style={{ textAlign: "right", flexShrink: 0 }}>
+        <div style={{ fontFamily: fontMono, fontSize: 14, fontWeight: 700, color: paper.green, whiteSpace: "nowrap" }}>
+          {fmtMoney(expense.amount)}
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/components/fuel-card.tsx
+++ b/components/fuel-card.tsx
@@ -1,0 +1,47 @@
+"use client";
+import type { FuelFillup } from "@/types";
+import { paper, fontMono, fontSerif, fmtMoney, fmtDate } from "@/lib/paper-theme";
+import { useT, useLocale } from "@/components/locale-provider";
+
+export interface FuelCardProps {
+  fuel: FuelFillup;
+  onClick?: () => void;
+}
+
+export function FuelCard({ fuel, onClick }: FuelCardProps) {
+  const t = useT();
+  const { locale } = useLocale();
+  return (
+    <button onClick={onClick} style={{
+      width: "100%", textAlign: "left", appearance: "none",
+      background: paper.paper, padding: "12px 14px", marginBottom: 8,
+      display: "flex", alignItems: "center", gap: 12,
+      borderTop: "none", borderRight: "none", borderBottom: "none",
+      borderLeft: `3px solid ${paper.green}`,
+      boxShadow: "0 1px 2px rgba(0,0,0,0.04)",
+      cursor: onClick ? "pointer" : "default",
+    }}>
+      <div style={{
+        padding: "6px 8px", background: paper.ink, color: paper.paper,
+        fontFamily: fontMono, fontSize: 11, fontWeight: 700, letterSpacing: 2,
+        display: "inline-block", minWidth: 42, flexShrink: 0, textAlign: "center",
+      }}>{fuel.car_short ?? "?"}</div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontFamily: fontSerif, fontSize: 15, color: paper.ink, fontWeight: 600, lineHeight: 1.2, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+          ⛽ {fuel.location ?? t("dashboard.fillup_label")}
+        </div>
+        <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkDim, letterSpacing: 1, marginTop: 2 }}>
+          {fuel.person_name} · {fmtDate(fuel.date, locale)} · {fuel.liters.toFixed(1)}L
+        </div>
+      </div>
+      <div style={{ textAlign: "right", flexShrink: 0 }}>
+        <div style={{ fontFamily: fontMono, fontSize: 14, fontWeight: 700, color: paper.green, whiteSpace: "nowrap" }}>
+          {fmtMoney(fuel.amount)}
+        </div>
+        {fuel.price_per_liter && (
+          <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkDim }}>€{fuel.price_per_liter.toFixed(3)}/L</div>
+        )}
+      </div>
+    </button>
+  );
+}

--- a/components/reservation-card.tsx
+++ b/components/reservation-card.tsx
@@ -1,0 +1,58 @@
+"use client";
+import type { Reservation } from "@/types";
+import { paper, fontMono, fontSerif, fmtDate } from "@/lib/paper-theme";
+import { useLocale } from "@/components/locale-provider";
+
+export interface ReservationCardProps {
+  reservation: Reservation;
+  onClick?: () => void;
+}
+
+export function ReservationCard({ reservation, onClick }: ReservationCardProps) {
+  const { locale } = useLocale();
+  const isPending = reservation.status === "pending";
+  const days = Math.round((new Date(reservation.end_date + "T00:00:00Z").getTime() - new Date(reservation.start_date + "T00:00:00Z").getTime()) / 86400000) + 1;
+  return (
+    <button onClick={onClick} style={{
+      width: "100%", display: "flex", alignItems: "center", gap: 12,
+      padding: "12px 14px", marginBottom: 8,
+      background: isPending
+        ? `repeating-linear-gradient(-45deg, ${paper.paperDeep}, ${paper.paperDeep} 4px, ${paper.paper} 4px, ${paper.paper} 10px)`
+        : paper.paper,
+      border: "none",
+      borderTop: "none", borderRight: "none", borderBottom: "none",
+      borderLeft: `3px ${isPending ? "dashed" : "solid"} ${isPending ? paper.amber : paper.green}`,
+      boxShadow: "0 1px 2px rgba(0,0,0,0.04)",
+      cursor: onClick ? "pointer" : "default",
+      textAlign: "left",
+      appearance: "none",
+    }}>
+      <div style={{
+        padding: "6px 8px", background: paper.ink, color: paper.paper,
+        fontFamily: fontMono, fontSize: 11, fontWeight: 700, letterSpacing: 2,
+        display: "inline-block", minWidth: 42, flexShrink: 0, textAlign: "center",
+      }}>{reservation.car_short ?? "?"}</div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontFamily: fontSerif, fontSize: 15, fontWeight: 600, color: paper.ink, lineHeight: 1.2 }}>
+          {reservation.person_name}
+        </div>
+        <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkDim, letterSpacing: 1, marginTop: 2 }}>
+          {fmtDate(reservation.start_date, locale)}{reservation.start_date !== reservation.end_date ? ` → ${fmtDate(reservation.end_date, locale)}` : ""}
+        </div>
+        {reservation.note && (
+          <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkMute, marginTop: 2 }}>
+            {reservation.note}
+          </div>
+        )}
+      </div>
+      <div style={{ textAlign: "right", flexShrink: 0 }}>
+        <div style={{ fontFamily: fontMono, fontSize: 14, fontWeight: 700, color: paper.ink, whiteSpace: "nowrap" }}>
+          {days}d
+        </div>
+        <div style={{ fontFamily: fontMono, fontSize: 10, fontWeight: 700, color: isPending ? paper.amber : paper.green }}>
+          {isPending ? "?" : "✓"}
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/components/trip-card.tsx
+++ b/components/trip-card.tsx
@@ -1,0 +1,48 @@
+"use client";
+import type { Trip } from "@/types";
+import { paper, fontMono, fontSerif, fmtMoney, fmtDate } from "@/lib/paper-theme";
+import { useLocale } from "@/components/locale-provider";
+
+export interface TripCardProps {
+  trip: Trip;
+  onClick?: () => void;
+}
+
+export function TripCard({ trip, onClick }: TripCardProps) {
+  const { locale } = useLocale();
+  return (
+    <button onClick={onClick} style={{
+      width: "100%", textAlign: "left", appearance: "none",
+      background: paper.paper, padding: "12px 14px", marginBottom: 8,
+      display: "flex", alignItems: "center", gap: 12,
+      borderTop: "none", borderRight: "none", borderBottom: "none",
+      borderLeft: `3px solid ${paper.accent}`,
+      boxShadow: "0 1px 2px rgba(0,0,0,0.04)",
+      cursor: onClick ? "pointer" : "default",
+    }}>
+      <div style={{
+        padding: "6px 8px", background: paper.ink, color: paper.paper,
+        fontFamily: fontMono, fontSize: 11, fontWeight: 700, letterSpacing: 2,
+        display: "inline-block", minWidth: 42, flexShrink: 0, textAlign: "center",
+      }}>{trip.car_short ?? "?"}</div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{
+          fontFamily: fontSerif, fontSize: 15, color: (!trip.location && !trip.gps_coords && trip.parking) ? paper.inkDim : paper.ink,
+          fontStyle: (!trip.location && !trip.gps_coords && trip.parking) ? "italic" : "normal",
+          fontWeight: 600, lineHeight: 1.2, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis",
+        }}>
+          {trip.location ?? trip.gps_coords ?? trip.parking ?? "—"}
+        </div>
+        <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkDim, letterSpacing: 1, marginTop: 2 }}>
+          {trip.person_name} · {fmtDate(trip.date, locale)} · {trip.start_odometer.toLocaleString("nl-BE")} → {trip.end_odometer.toLocaleString("nl-BE")}
+        </div>
+      </div>
+      <div style={{ textAlign: "right", flexShrink: 0 }}>
+        <div style={{ fontFamily: fontMono, fontSize: 14, fontWeight: 700, color: paper.accent, whiteSpace: "nowrap" }}>
+          {fmtMoney(trip.amount)}
+        </div>
+        <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkDim }}>{trip.km} km</div>
+      </div>
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- Extracts 4 shared card components: `TripCard`, `FuelCard`, `ExpenseCard`, `ReservationCard`
- Dashboard and all list pages now use the same component — design drift is impossible
- Removes duplicate inline markup: 309 deleted, 228 added (net -81 lines)

## Test plan
- [ ] Dashboard cards render correctly (trips, fuel, expenses, reservations)
- [ ] List pages render correctly (/trips, /fuel, /expenses, /calendar)
- [ ] Click handlers open edit sheets on both dashboard and list pages
- [ ] Pending reservations show amber dashed border + stripe background
- [ ] No visual regressions