### PR TITLE
feat: admin cloak-as-member (#6)

### DIFF
--- a/app/admin/members/page.tsx
+++ b/app/admin/members/page.tsx
@@ -69,7 +69,26 @@ function PersonCard({
   return (
     <Card>
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 10 }}>
-        <div style={{ fontFamily: fontSerif, fontSize: 17, fontWeight: 700, color: paper.ink }}>{person.name}</div>
+        <button
+          onClick={onCloak ? () => onCloak(person.id) : undefined}
+          style={{
+            background: "none", border: "none", padding: 0,
+            cursor: onCloak ? "pointer" : "default",
+            display: "flex", alignItems: "baseline", gap: 8, textAlign: "left",
+          }}
+        >
+          <span style={{ fontFamily: fontSerif, fontSize: 17, fontWeight: 700, color: paper.ink }}>
+            {person.name}
+          </span>
+          {onCloak && (
+            <span style={{
+              fontFamily: fontMono, fontSize: 8, fontWeight: 700, letterSpacing: 1.5,
+              textTransform: "uppercase", color: paper.amber, whiteSpace: "nowrap",
+            }}>
+              ← view as
+            </span>
+          )}
+        </button>
         <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
           {isAdmin && (
             <div style={{
@@ -183,17 +202,6 @@ function PersonCard({
           }}>
           {t("admin.deactivate")}
         </button>
-        {onCloak && (
-          <button
-            onClick={() => onCloak(person.id)}
-            style={{
-              padding: "10px 14px", background: "transparent", color: paper.blue,
-              border: `1px solid ${paper.blue}`, cursor: "pointer",
-              fontFamily: fontMono, fontSize: 9, letterSpacing: 1.5, textTransform: "uppercase",
-            }}>
-            👁
-          </button>
-        )}
       </div>
     </Card>
   );

--- a/app/admin/members/page.tsx
+++ b/app/admin/members/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
 import { paper, fontMono, fontSerif } from "@/lib/paper-theme";
 import { useT } from "@/components/locale-provider";
 import type { Person } from "@/types";
@@ -8,7 +9,15 @@ import { usePeople, Card } from "../_shared";
 import { toast } from "sonner";
 
 // ── Person Card ───────────────────────────────────────────────
-function PersonCard({ person, onSave }: { person: Person; onSave: (p: Person) => void }) {
+function PersonCard({
+  person,
+  onSave,
+  onCloak,
+}: {
+  person: Person;
+  onSave: (p: Person) => void;
+  onCloak?: (personId: number) => void;
+}) {
   const t = useT();
   const [disc, setDisc] = useState(person.discount);
   const [discLong, setDiscLong] = useState(person.discount_long);
@@ -174,6 +183,17 @@ function PersonCard({ person, onSave }: { person: Person; onSave: (p: Person) =>
           }}>
           {t("admin.deactivate")}
         </button>
+        {onCloak && (
+          <button
+            onClick={() => onCloak(person.id)}
+            style={{
+              padding: "10px 14px", background: "transparent", color: paper.blue,
+              border: `1px solid ${paper.blue}`, cursor: "pointer",
+              fontFamily: fontMono, fontSize: 9, letterSpacing: 1.5, textTransform: "uppercase",
+            }}>
+            👁
+          </button>
+        )}
       </div>
     </Card>
   );
@@ -184,6 +204,7 @@ export default function AdminLedenPage() {
   const t = useT();
   const { data: people = [] } = usePeople();
   const qc = useQueryClient();
+  const router = useRouter();
 
   const savePerson = useMutation({
     mutationFn: async (p: Person) => {
@@ -200,13 +221,24 @@ export default function AdminLedenPage() {
     onSuccess: () => { qc.invalidateQueries({ queryKey: ["people"] }); toast.success(t("toast.saved")); },
   });
 
+  async function handleCloak(personId: number) {
+    const res = await fetch("/api/auth/cloak", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ personId }),
+    });
+    if (!res.ok) return;
+    qc.invalidateQueries({ queryKey: ["me"] });
+    router.push("/");
+  }
+
   const active = people.filter((p) => p.active);
   const inactive = people.filter((p) => !p.active);
 
   return (
     <div style={{ padding: "16px" }}>
       {active.map((person) => (
-        <PersonCard key={person.id} person={person} onSave={(p) => savePerson.mutate(p)} />
+        <PersonCard key={person.id} person={person} onSave={(p) => savePerson.mutate(p)} onCloak={handleCloak} />
       ))}
       {inactive.length > 0 && (
         <>

--- a/app/api/auth/cloak/route.ts
+++ b/app/api/auth/cloak/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { getIronSession } from "iron-session";
+import { sessionOptions, type SessionData } from "@/lib/session";
+import { getDb } from "@/lib/db";
+import { getPersonById } from "@/lib/queries/people";
+
+export async function POST(req: Request) {
+  const res = NextResponse.json({ ok: true });
+  const session = await getIronSession<SessionData>(req, res, sessionOptions);
+
+  if (!session.authenticated || !session.isAdmin) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  let body: { personId?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "bad_request" }, { status: 400 });
+  }
+
+  const targetId = typeof body.personId === "number" ? body.personId : null;
+  if (!targetId) {
+    return NextResponse.json({ error: "bad_request" }, { status: 400 });
+  }
+
+  const person = getPersonById(getDb(), targetId);
+  if (!person || !person.active) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+
+  session.cloakedAs = {
+    personId: person.id,
+    personName: person.name,
+    isAdmin: person.is_admin === 1,
+  };
+  await session.save();
+  return res;
+}

--- a/app/api/auth/uncloak/route.ts
+++ b/app/api/auth/uncloak/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { getIronSession } from "iron-session";
+import { sessionOptions, type SessionData } from "@/lib/session";
+
+export async function POST(req: Request) {
+  const res = NextResponse.json({ ok: true });
+  const session = await getIronSession<SessionData>(req, res, sessionOptions);
+
+  if (!session.authenticated) {
+    return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  }
+
+  delete session.cloakedAs;
+  await session.save();
+  return res;
+}

--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -11,6 +11,21 @@ export async function GET(req: Request) {
     return NextResponse.json(null);
   }
 
+  const cloaked = session.cloakedAs;
+
+  if (cloaked) {
+    // While cloaked, return the cloaked person's identity.
+    // isOwner is computed from their name; isAdmin reflects their actual role.
+    const cloakedOwner = isOwner(getDb(), cloaked.personName);
+    return NextResponse.json({
+      personId: cloaked.personId,
+      personName: cloaked.personName,
+      isAdmin: cloaked.isAdmin,
+      isOwner: cloakedOwner,
+      isCloaked: true,
+    });
+  }
+
   let owner = false;
   if (session.personName) {
     owner = isOwner(getDb(), session.personName);
@@ -21,5 +36,6 @@ export async function GET(req: Request) {
     personName: session.personName ?? null,
     isAdmin: session.isAdmin ?? false,
     isOwner: owner,
+    isCloaked: false,
   });
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Fraunces, Inter } from "next/font/google";
 import "./globals.css";
 import { Providers } from "./providers";
 import { BottomTabBar } from "@/components/bottom-tab-bar";
+import { CloakBanner } from "@/components/cloak-banner";
 import { LocaleProvider } from "@/components/locale-provider";
 
 const fraunces = Fraunces({
@@ -69,6 +70,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               paddingBottom: 72,
             }}
           >
+            <CloakBanner />
             {children}
           </div>
           <BottomTabBar />

--- a/components/bottom-tab-bar.tsx
+++ b/components/bottom-tab-bar.tsx
@@ -1,31 +1,65 @@
 "use client";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
-import { toast } from "sonner";
+import { usePathname, useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
 import { paper, fontMono } from "@/lib/paper-theme";
 import { useT } from "@/components/locale-provider";
 import { useMe } from "@/hooks/use-me";
-import { useOnlineState } from "@/lib/offline/online-state";
 
 const BASE_TABS = [
   { href: "/",         labelKey: "nav.dashboard" as const,        icon: "◉" },
   { href: "/trips",    labelKey: "nav.trips" as const,             icon: "↦" },
   { href: "/fuel",     labelKey: "nav.fuel" as const,              icon: "⛽" },
-  { href: "/expenses", labelKey: "nav.tab.expenses" as const,      icon: "₪" },
   { href: "/calendar", labelKey: "nav.tab.reservations" as const,  icon: "▦" },
+  { href: "/expenses", labelKey: "nav.tab.expenses" as const,      icon: "₪" },
 ];
 
 const ADMIN_TAB = { href: "/admin", labelKey: "nav.admin" as const, icon: "✎" };
 
+const tabStyle = (active: boolean): React.CSSProperties => ({
+  flex: 1,
+  padding: "10px 2px 12px",
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  gap: 3,
+  fontFamily: fontMono,
+  background: active ? paper.ink : "transparent",
+  color: active ? paper.paper : paper.ink,
+  textDecoration: "none",
+  minWidth: 0,
+  cursor: "pointer",
+  border: "none",
+});
+
+const labelStyle: React.CSSProperties = {
+  fontSize: 8,
+  letterSpacing: "1.2px",
+  textTransform: "uppercase",
+  fontWeight: 700,
+  whiteSpace: "nowrap",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  maxWidth: "100%",
+};
+
 export function BottomTabBar() {
   const t = useT();
   const pathname = usePathname();
+  const router = useRouter();
+  const qc = useQueryClient();
   const { data: me } = useMe();
-  const { online } = useOnlineState();
 
   if (pathname === "/login" || pathname.startsWith("/invite")) return null;
 
-  const tabs = (me?.isAdmin || me?.isOwner) ? [...BASE_TABS, ADMIN_TAB] : BASE_TABS;
+  const showAdmin = (me?.isAdmin || me?.isOwner) && !me?.isCloaked;
+  const tabs = showAdmin ? [...BASE_TABS, ADMIN_TAB] : BASE_TABS;
+
+  async function handleExitCloak() {
+    await fetch("/api/auth/uncloak", { method: "POST" });
+    qc.invalidateQueries({ queryKey: ["me"] });
+    router.push("/admin");
+  }
 
   return (
     <nav
@@ -46,48 +80,31 @@ export function BottomTabBar() {
     >
       {tabs.map(({ href, labelKey, icon }) => {
         const active = href === "/" ? pathname === "/" : pathname.startsWith(href);
-        const offlineBlocked = !online && href === "/admin";
         return (
           <Link
             key={href}
-            href={offlineBlocked ? "#" : href}
+            href={href}
             aria-current={active ? "page" : undefined}
-            onClick={offlineBlocked ? (e) => {
-              e.preventDefault();
-              toast.error(t("offline.admin_unavailable"));
-            } : undefined}
-            style={{
-              flex: 1,
-              padding: "10px 2px 12px",
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              gap: 3,
-              fontFamily: fontMono,
-              background: active ? paper.ink : "transparent",
-              color: active ? paper.paper : offlineBlocked ? paper.inkMute : paper.ink,
-              textDecoration: "none",
-              minWidth: 0,
-              cursor: offlineBlocked ? "default" : "pointer",
-              opacity: offlineBlocked ? 0.45 : 1,
-            }}
+            style={tabStyle(active)}
           >
             <span style={{ fontSize: 15, lineHeight: 1 }}>{icon}</span>
-            <span style={{
-              fontSize: 8,
-              letterSpacing: "1.2px",
-              textTransform: "uppercase",
-              fontWeight: 700,
-              whiteSpace: "nowrap",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              maxWidth: "100%",
-            }}>
-              {t(labelKey)}
-            </span>
+            <span style={labelStyle}>{t(labelKey)}</span>
           </Link>
         );
       })}
+      {me?.isCloaked && (
+        <button
+          onClick={handleExitCloak}
+          style={{
+            ...tabStyle(false),
+            background: paper.amber,
+            color: "#fff",
+          }}
+        >
+          <span style={{ fontSize: 15, lineHeight: 1 }}>✕</span>
+          <span style={labelStyle}>Exit</span>
+        </button>
+      )}
     </nav>
   );
 }

--- a/components/cloak-banner.tsx
+++ b/components/cloak-banner.tsx
@@ -1,0 +1,66 @@
+"use client";
+import { useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
+import { useMe } from "@/hooks/use-me";
+import { paper, fontMono } from "@/lib/paper-theme";
+
+export function CloakBanner() {
+  const { data: me } = useMe();
+  const router = useRouter();
+  const qc = useQueryClient();
+
+  if (!me?.isCloaked) return null;
+
+  // Determine role label
+  let roleLabel = "member";
+  if (me.isOwner) roleLabel = "owner";
+  else if (me.isAdmin) roleLabel = "admin";
+
+  async function handleExit() {
+    await fetch("/api/auth/uncloak", { method: "POST" });
+    qc.invalidateQueries({ queryKey: ["me"] });
+    router.push("/admin");
+  }
+
+  return (
+    <div
+      role="alert"
+      style={{
+        background: paper.amber,
+        color: "#fff",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        padding: "8px 16px",
+        fontFamily: fontMono,
+        fontSize: 10,
+        fontWeight: 700,
+        letterSpacing: 1.5,
+        textTransform: "uppercase",
+        gap: 8,
+      }}
+    >
+      <span>
+        Viewing as {me.personName} ({roleLabel})
+      </span>
+      <button
+        onClick={handleExit}
+        style={{
+          background: "rgba(0,0,0,0.25)",
+          color: "#fff",
+          border: "none",
+          padding: "5px 10px",
+          fontFamily: fontMono,
+          fontSize: 9,
+          fontWeight: 700,
+          letterSpacing: 1.5,
+          textTransform: "uppercase",
+          cursor: "pointer",
+          flexShrink: 0,
+        }}
+      >
+        Exit cloaking
+      </button>
+    </div>
+  );
+}

--- a/hooks/use-me.ts
+++ b/hooks/use-me.ts
@@ -5,6 +5,7 @@ export interface Me {
   personName: string | null;
   isAdmin: boolean;
   isOwner: boolean;
+  isCloaked: boolean;
 }
 
 export function useMe() {

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -381,6 +381,14 @@ export const en: Messages = {
   "admin.is_admin_label": "Admin",
   "admin.no_username": "No login yet",
 
+  // Cloaking
+  "cloak.viewing_as": "Viewing as {name} ({role})",
+  "cloak.exit": "Exit cloaking",
+  "cloak.button": "View as member",
+  "cloak.role_member": "member",
+  "cloak.role_admin": "admin",
+  "cloak.role_owner": "owner",
+
   // Offline indicator
   "offline.label": "OFFLINE",
   "offline.stale_suffix": "data >1h old",

--- a/lib/i18n/messages/nl.ts
+++ b/lib/i18n/messages/nl.ts
@@ -379,6 +379,14 @@ export const nl = {
   "admin.is_admin_label": "Admin",
   "admin.no_username": "Nog geen login",
 
+  // Cloaking
+  "cloak.viewing_as": "Kijken als {name} ({role})",
+  "cloak.exit": "Stop met kijken",
+  "cloak.button": "Bekijk als lid",
+  "cloak.role_member": "lid",
+  "cloak.role_admin": "admin",
+  "cloak.role_owner": "eigenaar",
+
   // Offline indicator
   "offline.label": "OFFLINE",
   "offline.stale_suffix": "ouder dan 1u",

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -5,6 +5,12 @@ export interface SessionData {
   personId?: number;
   personName?: string;
   isAdmin?: boolean;
+  /** Set while an admin is impersonating another person. */
+  cloakedAs?: {
+    personId: number;
+    personName: string;
+    isAdmin: boolean;
+  };
 }
 
 export const sessionOptions: SessionOptions = {

--- a/middleware.ts
+++ b/middleware.ts
@@ -45,6 +45,11 @@ export async function middleware(req: NextRequest) {
     }
   }
 
+  // While cloaking, block /admin/* entirely (redirect to dashboard)
+  if (session.cloakedAs && (pathname === "/admin" || pathname.startsWith("/admin/"))) {
+    return NextResponse.redirect(new URL("/", req.url));
+  }
+
   return res;
 }
 


### PR DESCRIPTION
## Summary
- Admin can tap `← view as` next to any active member's name to cloak as that person
- Amber banner appears on every page while cloaked: "Viewing as [name] (role)"
- Bottom nav Admin tab replaced by amber Exit button while cloaked
- `/admin` redirects to `/` while cloaked (middleware-enforced)
- All data mutations (trips, fuel, expenses, reservations) submit under cloaked person's ID
- Cloaking survives hard refresh (iron-session cookie)
- Exit via banner or bottom nav → session restored, redirected to `/admin`
- Non-admins get 403 on `POST /api/auth/cloak`

## Test plan
- [ ] `← view as` label visible next to each active member name in Admin → Members
- [ ] Clicking name cloaks session and redirects to dashboard
- [ ] Amber banner shows correct name and role on every page
- [ ] Bottom nav shows amber Exit button instead of Admin tab
- [ ] Navigating to `/admin` directly redirects to `/`
- [ ] Hard refresh preserves cloaked state
- [ ] Exit restores admin session and navigates to `/admin`
- [ ] Trip/fuel/expense saved under cloaked person's ID