### PR TITLE
feat(admin/members): accordion rows + CarBadge + consistent buttons (#48)

### DIFF
--- a/app/admin/cars/page.tsx
+++ b/app/admin/cars/page.tsx
@@ -9,14 +9,16 @@ import { usePeople } from "@/hooks/use-people";
 import { useAdminSummary, beMetrics, Card, Row, Perf } from "../_shared";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { CarBadge } from "@/components/car-badge";
 
 // ── Car Row (accordion) ───────────────────────────────────────
-function CarRow({ car, expanded, onToggle, onSave, people }: {
+function CarRow({ car, expanded, onToggle, onSave, people, isSaving }: {
   car: Car;
   expanded: boolean;
   onToggle: () => void;
   onSave: (data: Partial<Car>) => void;
   people: { id: number; name: string }[];
+  isSaving?: boolean;
 }) {
   const t = useT();
   const [name, setName] = useState(car.name);
@@ -34,6 +36,8 @@ function CarRow({ car, expanded, onToggle, onSave, people }: {
 
   const dirty = name !== car.name || price !== car.price_per_km || owner !== (car.owner_name ?? "");
 
+  const reset = () => { setName(car.name); setPrice(car.price_per_km); setOwner(car.owner_name ?? ""); };
+
   const inputStyle: React.CSSProperties = {
     width: "100%", padding: "6px 8px", fontFamily: fontMono, fontSize: 11,
     border: `1px solid ${paper.paperDark}`, background: paper.paperDeep,
@@ -44,12 +48,36 @@ function CarRow({ car, expanded, onToggle, onSave, people }: {
     textTransform: "uppercase", display: "block", marginBottom: 3,
   };
 
+  // Inactive: name + activate only
+  if (!isActive) {
+    return (
+      <div style={{
+        background: paper.paper, marginBottom: 6, opacity: 0.55,
+        boxShadow: "0 1px 2px rgba(0,0,0,0.05), 0 4px 16px rgba(0,0,0,0.06)",
+        borderLeft: "3px solid transparent",
+        display: "flex", alignItems: "center", padding: "12px 14px",
+      }}>
+        <CarBadge short={car.short} active={false} style={{ padding: "4px 8px" }} />
+        <div style={{ flex: 1 }} />
+        <button
+          disabled={isSaving}
+          onClick={() => onSave({ active: 1 })}
+          style={{
+            padding: "5px 12px", background: paper.green, color: paper.paper,
+            border: "none", cursor: isSaving ? "default" : "pointer", opacity: isSaving ? 0.6 : 1,
+            fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 1.5, textTransform: "uppercase",
+          }}>
+          {isSaving ? "…" : t("admin.activate")}
+        </button>
+      </div>
+    );
+  }
+
   return (
     <div style={{
       background: paper.paper, marginBottom: 6,
       boxShadow: "0 1px 2px rgba(0,0,0,0.05), 0 4px 16px rgba(0,0,0,0.06)",
       borderLeft: expanded ? `3px solid ${paper.blue}` : `3px solid transparent`,
-      opacity: isActive ? 1 : 0.55,
     }}>
       {/* Collapsed header — click to toggle */}
       <div
@@ -62,13 +90,7 @@ function CarRow({ car, expanded, onToggle, onSave, people }: {
           padding: "12px 14px", cursor: "pointer", userSelect: "none",
         }}
       >
-        <div style={{
-          padding: "4px 8px", background: isActive ? paper.ink : paper.inkMute, color: paper.paper,
-          fontFamily: fontMono, fontSize: 11, fontWeight: 700,
-          letterSpacing: 2, flexShrink: 0, minWidth: 40, textAlign: "center",
-        }}>
-          {car.short}
-        </div>
+        <CarBadge short={car.short} active={isActive} style={{ padding: "4px 8px" }} />
         <div style={{
           flex: 1, fontFamily: fontSerif, fontSize: 14, fontWeight: 600, color: paper.ink,
           overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
@@ -106,20 +128,19 @@ function CarRow({ car, expanded, onToggle, onSave, people }: {
           </div>
           <div style={{ marginBottom: 12 }}>
             <button
-              onClick={() => onSave({ name, price_per_km: price, owner_name: owner || null, active: isActive ? 0 : 1 })}
+              disabled={isSaving}
+              onClick={() => onSave({ name, price_per_km: price, owner_name: owner || null, active: 0 })}
               style={{
                 width: "100%", padding: "8px",
-                background: isActive ? paper.accent : paper.green,
-                color: paper.paper,
-                border: "none",
-                cursor: "pointer", fontFamily: fontMono, fontSize: 9,
-                fontWeight: 700, letterSpacing: 1.5, textTransform: "uppercase",
+                background: paper.accent, color: paper.paper, border: "none",
+                cursor: isSaving ? "default" : "pointer", opacity: isSaving ? 0.6 : 1,
+                fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 1.5, textTransform: "uppercase",
               }}>
-              {isActive ? t("admin.deactivate") : t("admin.activate")}
+              {isSaving ? "…" : t("admin.deactivate")}
             </button>
           </div>
           <div style={{ display: "flex", gap: 8 }}>
-            <button onClick={onToggle} style={{
+            <button onClick={() => { reset(); onToggle(); }} style={{
               flex: 1, padding: "9px", background: "transparent", color: paper.inkDim,
               border: `1px solid ${paper.paperDark}`, cursor: "pointer",
               fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 1.5, textTransform: "uppercase",
@@ -127,17 +148,16 @@ function CarRow({ car, expanded, onToggle, onSave, people }: {
               {t("action.cancel")}
             </button>
             <button
-              disabled={!dirty}
+              disabled={!dirty || isSaving}
               onClick={() => onSave({ name, price_per_km: price, owner_name: owner || null, active: car.active })}
               style={{
                 flex: 2, padding: "9px",
-                background: dirty ? paper.ink : paper.paperDark,
-                color: dirty ? paper.paper : paper.inkMute,
-                border: "none", cursor: dirty ? "pointer" : "default",
-                fontFamily: fontMono, fontSize: 9,
-                fontWeight: 700, letterSpacing: 2, textTransform: "uppercase",
+                background: dirty && !isSaving ? paper.ink : paper.paperDark,
+                color: dirty && !isSaving ? paper.paper : paper.inkMute,
+                border: "none", cursor: dirty && !isSaving ? "pointer" : "default",
+                fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 2, textTransform: "uppercase",
               }}>
-              {t("action.save")}
+              {isSaving ? "…" : t("action.save")}
             </button>
           </div>
         </div>
@@ -578,6 +598,7 @@ function FleetTiles() {
   const { data: people = [] } = usePeople();
   const updateCar = useUpdateCar();
   const [expanded, setExpanded] = useState<number | null>(null);
+  const [savingId, setSavingId] = useState<number | null>(null);
   const [breakEvenCar, setBreakEvenCar] = useState<number | null>(null);
 
   const pnl = data?.carPnL ?? [];
@@ -590,9 +611,13 @@ function FleetTiles() {
   const toggle = (id: number) => setExpanded((prev) => (prev === id ? null : id));
 
   const handleSave = (car: Car, patch: Partial<Car>) => {
+    setSavingId(car.id);
     updateCar.mutate(
       { ...car, ...patch } as Car & { id: number },
-      { onSuccess: () => { setExpanded(null); toast.success(t("toast.saved")); } }
+      {
+        onSuccess: () => { setExpanded(null); toast.success(t("toast.saved")); },
+        onSettled: () => setSavingId(null),
+      }
     );
   };
 
@@ -636,6 +661,7 @@ function FleetTiles() {
       onToggle={() => toggle(car.id)}
       onSave={(patch) => handleSave(car, patch)}
       people={people}
+      isSaving={savingId === car.id}
     />
   );
 

--- a/app/admin/cars/page.tsx
+++ b/app/admin/cars/page.tsx
@@ -32,6 +32,8 @@ function CarRow({ car, expanded, onToggle, onSave, people }: {
     setOwner(car.owner_name ?? "");
   }
 
+  const dirty = name !== car.name || price !== car.price_per_km || owner !== (car.owner_name ?? "");
+
   const inputStyle: React.CSSProperties = {
     width: "100%", padding: "6px 8px", fontFamily: fontMono, fontSize: 11,
     border: `1px solid ${paper.paperDark}`, background: paper.paperDeep,
@@ -106,9 +108,10 @@ function CarRow({ car, expanded, onToggle, onSave, people }: {
             <button
               onClick={() => onSave({ name, price_per_km: price, owner_name: owner || null, active: isActive ? 0 : 1 })}
               style={{
-                width: "100%", padding: "8px", background: "transparent",
-                color: isActive ? paper.accent : paper.green,
-                border: `1.5px solid ${isActive ? paper.accent : paper.green}`,
+                width: "100%", padding: "8px",
+                background: isActive ? paper.accent : paper.green,
+                color: paper.paper,
+                border: "none",
                 cursor: "pointer", fontFamily: fontMono, fontSize: 9,
                 fontWeight: 700, letterSpacing: 1.5, textTransform: "uppercase",
               }}>
@@ -124,10 +127,14 @@ function CarRow({ car, expanded, onToggle, onSave, people }: {
               {t("action.cancel")}
             </button>
             <button
+              disabled={!dirty}
               onClick={() => onSave({ name, price_per_km: price, owner_name: owner || null, active: car.active })}
               style={{
-                flex: 2, padding: "9px", background: paper.ink, color: paper.paper,
-                border: "none", cursor: "pointer", fontFamily: fontMono, fontSize: 9,
+                flex: 2, padding: "9px",
+                background: dirty ? paper.ink : paper.paperDark,
+                color: dirty ? paper.paper : paper.inkMute,
+                border: "none", cursor: dirty ? "pointer" : "default",
+                fontFamily: fontMono, fontSize: 9,
                 fontWeight: 700, letterSpacing: 2, textTransform: "uppercase",
               }}>
               {t("action.save")}

--- a/app/admin/cars/page.tsx
+++ b/app/admin/cars/page.tsx
@@ -57,7 +57,7 @@ function CarRow({ car, expanded, onToggle, onSave, people, isSaving }: {
         borderLeft: "3px solid transparent",
         display: "flex", alignItems: "center", padding: "12px 14px",
       }}>
-        <CarBadge short={car.short} active={false} style={{ padding: "4px 8px" }} />
+        <CarBadge short={car.short} active={false} />
         <div style={{ flex: 1 }} />
         <button
           disabled={isSaving}
@@ -90,7 +90,7 @@ function CarRow({ car, expanded, onToggle, onSave, people, isSaving }: {
           padding: "12px 14px", cursor: "pointer", userSelect: "none",
         }}
       >
-        <CarBadge short={car.short} active={isActive} style={{ padding: "4px 8px" }} />
+        <CarBadge short={car.short} active={isActive} />
         <div style={{
           flex: 1, fontFamily: fontSerif, fontSize: 14, fontWeight: 600, color: paper.ink,
           overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",

--- a/app/admin/hygiene/page.tsx
+++ b/app/admin/hygiene/page.tsx
@@ -7,6 +7,7 @@ import type { KmGap, ZeroKmTrip } from "@/lib/queries/admin";
 import { useAdminSummary, usePeople, Card } from "../_shared";
 import { useCreateTrip } from "@/hooks/use-trips";
 import { toast } from "sonner";
+import { CarBadge } from "@/components/car-badge";
 
 // ── Helpers ───────────────────────────────────────────────────
 function groupByYear<T extends { date?: string; after_date?: string }>(items: T[]): [string, T[]][] {
@@ -109,13 +110,7 @@ export default function AdminHygienePage() {
                   onClick={() => setExpandedGap(expanded ? null : key)}
                 >
                   <div style={{ display: "flex", gap: 10, alignItems: "flex-start" }}>
-                    <div style={{
-                      fontFamily: fontMono, fontSize: 10, fontWeight: 700, letterSpacing: 1,
-                      background: paper.ink, color: paper.paper,
-                      padding: "4px 7px", flexShrink: 0, alignSelf: "flex-start",
-                    }}>
-                      {gap.car_short}
-                    </div>
+                    <CarBadge short={gap.car_short} style={{ padding: "4px 7px", alignSelf: "flex-start" }} />
                     <div style={{ flex: 1 }}>
                       <div style={{ fontFamily: fontSerif, fontSize: 16, fontWeight: 700, color: paper.ink, lineHeight: 1.1 }}>
                         {gap.missing_km.toLocaleString("nl-BE")} km {t("admin.km_missing_suffix")}

--- a/app/admin/hygiene/page.tsx
+++ b/app/admin/hygiene/page.tsx
@@ -110,7 +110,7 @@ export default function AdminHygienePage() {
                   onClick={() => setExpandedGap(expanded ? null : key)}
                 >
                   <div style={{ display: "flex", gap: 10, alignItems: "flex-start" }}>
-                    <CarBadge short={gap.car_short} style={{ padding: "4px 7px", alignSelf: "flex-start" }} />
+                    <CarBadge short={gap.car_short} />
                     <div style={{ flex: 1 }}>
                       <div style={{ fontFamily: fontSerif, fontSize: 16, fontWeight: 700, color: paper.ink, lineHeight: 1.1 }}>
                         {gap.missing_km.toLocaleString("nl-BE")} km {t("admin.km_missing_suffix")}

--- a/app/admin/members/page.tsx
+++ b/app/admin/members/page.tsx
@@ -9,12 +9,13 @@ import { usePeople } from "../_shared";
 import { toast } from "sonner";
 
 // ── Person Row (accordion) ────────────────────────────────────
-function PersonRow({ person, expanded, onToggle, onSave, onCloak }: {
+function PersonRow({ person, expanded, onToggle, onSave, onCloak, isSaving }: {
   person: Person;
   expanded: boolean;
   onToggle: () => void;
   onSave: (p: Person) => void;
   onCloak?: (personId: number) => void;
+  isSaving?: boolean;
 }) {
   const t = useT();
   const [disc, setDisc] = useState(person.discount);
@@ -37,6 +38,8 @@ function PersonRow({ person, expanded, onToggle, onSave, onCloak }: {
     discLong !== person.discount_long ||
     username !== (person.username ?? "") ||
     isAdmin !== (person.is_admin === 1);
+
+  const reset = () => { setDisc(person.discount); setDiscLong(person.discount_long); setUsername(person.username ?? ""); setIsAdmin(person.is_admin === 1); };
 
   const isActive = !!person.active;
   const hasDiscount = person.discount > 0 || person.discount_long > 0;
@@ -69,13 +72,14 @@ function PersonRow({ person, expanded, onToggle, onSave, onCloak }: {
           {person.name}
         </div>
         <button
+          disabled={isSaving}
           onClick={() => onSave({ ...person, active: 1 })}
           style={{
             padding: "5px 12px", background: paper.green, color: paper.paper,
-            border: "none", cursor: "pointer",
+            border: "none", cursor: isSaving ? "default" : "pointer", opacity: isSaving ? 0.6 : 1,
             fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 1.5, textTransform: "uppercase",
           }}>
-          {t("admin.activate")}
+          {isSaving ? "…" : t("admin.activate")}
         </button>
       </div>
     );
@@ -98,11 +102,11 @@ function PersonRow({ person, expanded, onToggle, onSave, onCloak }: {
           padding: "12px 14px", cursor: "pointer", userSelect: "none",
         }}
       >
-        {/* Name + ← view as */}
+        {/* Name + ← view as + username */}
         <div style={{ flex: 1, display: "flex", alignItems: "baseline", gap: 8, minWidth: 0 }}>
           <span style={{
             fontFamily: fontSerif, fontSize: 15, fontWeight: 700, color: paper.ink,
-            overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
+            whiteSpace: "nowrap",
           }}>
             {person.name}
           </span>
@@ -118,17 +122,15 @@ function PersonRow({ person, expanded, onToggle, onSave, onCloak }: {
               ← view as
             </button>
           )}
+          {person.username && (
+            <span style={{
+              fontFamily: fontMono, fontSize: 10, color: paper.inkDim,
+              whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis",
+            }}>
+              {person.username}
+            </span>
+          )}
         </div>
-
-        {/* Username */}
-        {person.username && (
-          <div style={{
-            fontFamily: fontMono, fontSize: 10, color: paper.inkDim, flexShrink: 0,
-            overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: 90,
-          }}>
-            {person.username}
-          </div>
-        )}
 
         {/* Discount badge */}
         {hasDiscount && (
@@ -216,20 +218,21 @@ function PersonRow({ person, expanded, onToggle, onSave, onCloak }: {
           {/* Deactivate */}
           <div style={{ marginBottom: 12 }}>
             <button
+              disabled={isSaving}
               onClick={() => onSave({ ...person, discount: disc, discount_long: discLong, active: 0 })}
               style={{
                 width: "100%", padding: "8px",
                 background: paper.accent, color: paper.paper,
-                border: "none", cursor: "pointer",
+                border: "none", cursor: isSaving ? "default" : "pointer", opacity: isSaving ? 0.6 : 1,
                 fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 1.5, textTransform: "uppercase",
               }}>
-              {t("admin.deactivate")}
+              {isSaving ? "…" : t("admin.deactivate")}
             </button>
           </div>
 
           {/* Cancel / Save */}
           <div style={{ display: "flex", gap: 8 }}>
-            <button onClick={onToggle} style={{
+            <button onClick={() => { reset(); onToggle(); }} style={{
               flex: 1, padding: "9px", background: "transparent", color: paper.inkDim,
               border: `1px solid ${paper.paperDark}`, cursor: "pointer",
               fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 1.5, textTransform: "uppercase",
@@ -237,16 +240,16 @@ function PersonRow({ person, expanded, onToggle, onSave, onCloak }: {
               {t("action.cancel")}
             </button>
             <button
-              disabled={!dirty}
+              disabled={!dirty || isSaving}
               onClick={() => onSave({ ...person, discount: disc, discount_long: discLong, username: username || null, is_admin: isAdmin ? 1 : 0 })}
               style={{
                 flex: 2, padding: "9px",
-                background: dirty ? paper.ink : paper.paperDark,
-                color: dirty ? paper.paper : paper.inkMute,
-                border: "none", cursor: dirty ? "pointer" : "default",
+                background: dirty && !isSaving ? paper.ink : paper.paperDark,
+                color: dirty && !isSaving ? paper.paper : paper.inkMute,
+                border: "none", cursor: dirty && !isSaving ? "pointer" : "default",
                 fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 2, textTransform: "uppercase",
               }}>
-              {t("action.save")}
+              {isSaving ? "…" : t("action.save")}
             </button>
           </div>
         </div>
@@ -262,6 +265,7 @@ export default function AdminLedenPage() {
   const qc = useQueryClient();
   const router = useRouter();
   const [expanded, setExpanded] = useState<number | null>(null);
+  const [savingId, setSavingId] = useState<number | null>(null);
 
   const toggle = (id: number) => setExpanded((prev) => (prev === id ? null : id));
 
@@ -277,6 +281,8 @@ export default function AdminLedenPage() {
       });
       if (!res.ok) throw new Error("Failed");
     },
+    onMutate: (p) => setSavingId(p.id),
+    onSettled: () => setSavingId(null),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["people"] });
       setExpanded(null);
@@ -308,6 +314,7 @@ export default function AdminLedenPage() {
           onToggle={() => toggle(person.id)}
           onSave={(p) => savePerson.mutate(p)}
           onCloak={handleCloak}
+          isSaving={savingId === person.id}
         />
       ))}
       {inactive.length > 0 && (
@@ -326,6 +333,7 @@ export default function AdminLedenPage() {
               expanded={false}
               onToggle={() => {}}
               onSave={(p) => savePerson.mutate(p)}
+              isSaving={savingId === person.id}
             />
           ))}
         </>

--- a/app/admin/members/page.tsx
+++ b/app/admin/members/page.tsx
@@ -5,16 +5,14 @@ import { useRouter } from "next/navigation";
 import { paper, fontMono, fontSerif } from "@/lib/paper-theme";
 import { useT } from "@/components/locale-provider";
 import type { Person } from "@/types";
-import { usePeople, Card } from "../_shared";
+import { usePeople } from "../_shared";
 import { toast } from "sonner";
 
-// ── Person Card ───────────────────────────────────────────────
-function PersonCard({
-  person,
-  onSave,
-  onCloak,
-}: {
+// ── Person Row (accordion) ────────────────────────────────────
+function PersonRow({ person, expanded, onToggle, onSave, onCloak }: {
   person: Person;
+  expanded: boolean;
+  onToggle: () => void;
   onSave: (p: Person) => void;
   onCloak?: (personId: number) => void;
 }) {
@@ -25,6 +23,15 @@ function PersonCard({
   const [isAdmin, setIsAdmin] = useState(person.is_admin === 1);
   const [inviteBanner, setInviteBanner] = useState<string | null>(null);
 
+  const [prevId, setPrevId] = useState(person.id);
+  if (person.id !== prevId) {
+    setPrevId(person.id);
+    setDisc(person.discount);
+    setDiscLong(person.discount_long);
+    setUsername(person.username ?? "");
+    setIsAdmin(person.is_admin === 1);
+  }
+
   const dirty =
     disc !== person.discount ||
     discLong !== person.discount_long ||
@@ -32,6 +39,7 @@ function PersonCard({
     isAdmin !== (person.is_admin === 1);
 
   const isActive = !!person.active;
+  const hasDiscount = person.discount > 0 || person.discount_long > 0;
 
   const handleInvite = async () => {
     try {
@@ -47,163 +55,203 @@ function PersonCard({
     }
   };
 
+  // Inactive: simple row with Activate button only
   if (!isActive) {
     return (
-      <Card style={{ opacity: 0.55, marginBottom: 8 }}>
-        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-          <div style={{ fontFamily: fontSerif, fontSize: 17, fontWeight: 700, color: paper.inkDim }}>{person.name}</div>
-          <button
-            onClick={() => onSave({ ...person, active: 1 })}
-            style={{
-              padding: "5px 12px", background: "transparent", color: paper.green,
-              border: `1.5px solid ${paper.green}`, cursor: "pointer",
-              fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 1.5, textTransform: "uppercase",
-            }}>
-            {t("admin.activate")}
-          </button>
+      <div style={{
+        background: paper.paper, marginBottom: 6, opacity: 0.55,
+        boxShadow: "0 1px 2px rgba(0,0,0,0.05), 0 4px 16px rgba(0,0,0,0.06)",
+        borderLeft: "3px solid transparent",
+        display: "flex", alignItems: "center", justifyContent: "space-between",
+        padding: "12px 14px",
+      }}>
+        <div style={{ fontFamily: fontSerif, fontSize: 15, fontWeight: 700, color: paper.inkDim }}>
+          {person.name}
         </div>
-      </Card>
+        <button
+          onClick={() => onSave({ ...person, active: 1 })}
+          style={{
+            padding: "5px 12px", background: paper.green, color: paper.paper,
+            border: "none", cursor: "pointer",
+            fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 1.5, textTransform: "uppercase",
+          }}>
+          {t("admin.activate")}
+        </button>
+      </div>
     );
   }
 
   return (
-    <Card>
-      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 10 }}>
-        <button
-          onClick={onCloak ? () => onCloak(person.id) : undefined}
-          style={{
-            background: "none", border: "none", padding: 0,
-            cursor: onCloak ? "pointer" : "default",
-            display: "flex", alignItems: "baseline", gap: 8, textAlign: "left",
-          }}
-        >
-          <span style={{ fontFamily: fontSerif, fontSize: 17, fontWeight: 700, color: paper.ink }}>
+    <div style={{
+      background: paper.paper, marginBottom: 6,
+      boxShadow: "0 1px 2px rgba(0,0,0,0.05), 0 4px 16px rgba(0,0,0,0.06)",
+      borderLeft: expanded ? `3px solid ${paper.blue}` : `3px solid transparent`,
+    }}>
+      {/* Collapsed header */}
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={onToggle}
+        onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && onToggle()}
+        style={{
+          display: "flex", alignItems: "center", gap: 10,
+          padding: "12px 14px", cursor: "pointer", userSelect: "none",
+        }}
+      >
+        {/* Name + ← view as */}
+        <div style={{ flex: 1, display: "flex", alignItems: "baseline", gap: 8, minWidth: 0 }}>
+          <span style={{
+            fontFamily: fontSerif, fontSize: 15, fontWeight: 700, color: paper.ink,
+            overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
+          }}>
             {person.name}
           </span>
           {onCloak && (
-            <span style={{
-              fontFamily: fontMono, fontSize: 8, fontWeight: 700, letterSpacing: 1.5,
-              textTransform: "uppercase", color: paper.amber, whiteSpace: "nowrap",
-            }}>
+            <button
+              onClick={(e) => { e.stopPropagation(); onCloak(person.id); }}
+              style={{
+                background: "none", border: "none", padding: 0, cursor: "pointer",
+                fontFamily: fontMono, fontSize: 8, fontWeight: 700, letterSpacing: 1.5,
+                textTransform: "uppercase", color: paper.amber, whiteSpace: "nowrap", flexShrink: 0,
+              }}
+            >
               ← view as
-            </span>
-          )}
-        </button>
-        <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
-          {isAdmin && (
-            <div style={{
-              fontFamily: fontMono, fontSize: 9, color: paper.blue, fontWeight: 700,
-              letterSpacing: 1, border: `1px solid ${paper.blue}`, padding: "2px 6px",
-              textTransform: "uppercase",
-            }}>Admin</div>
-          )}
-          {(disc > 0 || discLong > 0) && (
-            <div style={{
-              fontFamily: fontMono, fontSize: 9, color: paper.amber, fontWeight: 700,
-              letterSpacing: 1, border: `1px solid ${paper.amber}`, padding: "2px 6px",
-              textTransform: "uppercase",
-            }}>{t("admin.discount_badge")}</div>
+            </button>
           )}
         </div>
-      </div>
 
-      {/* Login credentials */}
-      <div style={{ marginBottom: 12, display: "flex", gap: 8, alignItems: "flex-end" }}>
-        <div style={{ flex: 1 }}>
-          <div style={{ fontFamily: fontMono, fontSize: 9, color: paper.inkDim, letterSpacing: 1.5, textTransform: "uppercase", marginBottom: 4 }}>
-            {t("admin.username_label")}
+        {/* Username */}
+        {person.username && (
+          <div style={{
+            fontFamily: fontMono, fontSize: 10, color: paper.inkDim, flexShrink: 0,
+            overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: 90,
+          }}>
+            {person.username}
           </div>
-          <input
-            type="text"
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
-            placeholder={t("admin.no_username")}
-            style={{
-              width: "100%", padding: "6px 8px",
-              border: `1px solid ${paper.paperDark}`,
-              background: paper.paperDeep,
-              fontFamily: fontMono, fontSize: 12, color: paper.ink,
-              outline: "none",
-            }}
-          />
-        </div>
-        <label style={{ display: "flex", alignItems: "center", gap: 6, paddingBottom: 6, cursor: "pointer" }}>
-          <input
-            type="checkbox"
-            checked={isAdmin}
-            onChange={(e) => setIsAdmin(e.target.checked)}
-            style={{ accentColor: paper.blue, width: 14, height: 14 }}
-          />
-          <span style={{ fontFamily: fontMono, fontSize: 9, letterSpacing: 1.5, textTransform: "uppercase", color: paper.inkDim }}>
-            {t("admin.is_admin_label")}
-          </span>
-        </label>
-      </div>
+        )}
 
-      {/* Invite */}
-      <div style={{ marginBottom: 12 }}>
-        <button
-          onClick={handleInvite}
-          style={{
-            padding: "7px 12px", background: "transparent",
-            border: `1px dashed ${paper.inkDim}`, cursor: "pointer",
-            fontFamily: fontMono, fontSize: 9, letterSpacing: 1.5, textTransform: "uppercase",
-            color: paper.inkDim,
+        {/* Discount badge */}
+        {hasDiscount && (
+          <div style={{
+            fontFamily: fontMono, fontSize: 8, color: paper.amber, fontWeight: 700,
+            letterSpacing: 1, border: `1px solid ${paper.amber}`, padding: "2px 5px",
+            textTransform: "uppercase", flexShrink: 0,
           }}>
-          {t("admin.invite_copy")}
-        </button>
-        {inviteBanner && (
-          <span style={{ marginLeft: 10, fontFamily: fontMono, fontSize: 10, color: paper.green }}>
-            {inviteBanner}
-          </span>
+            {t("admin.discount_badge")}
+          </div>
         )}
       </div>
 
-      <div style={{ marginBottom: 10 }}>
-        <div style={{ fontFamily: fontMono, fontSize: 9, color: paper.inkDim, letterSpacing: 1.5, textTransform: "uppercase", marginBottom: 4 }}>
-          {t("admin.base_discount", { pct: (disc * 100).toFixed(0) })}
-        </div>
-        <input type="range" min={0} max={0.5} step={0.05} value={disc}
-          onChange={(e) => setDisc(parseFloat(e.target.value))}
-          style={{ width: "100%", accentColor: disc > 0 ? paper.amber : paper.inkDim }} />
-      </div>
+      {/* Expanded edit form */}
+      {expanded && (
+        <div style={{ padding: "0 14px 14px", borderTop: `1px dashed ${paper.paperDark}` }}>
+          {/* Username + admin */}
+          <div style={{ paddingTop: 12, marginBottom: 12, display: "flex", gap: 8, alignItems: "flex-end" }}>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontFamily: fontMono, fontSize: 9, color: paper.inkDim, letterSpacing: 1.5, textTransform: "uppercase", marginBottom: 4 }}>
+                {t("admin.username_label")}
+              </div>
+              <input
+                type="text"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                placeholder={t("admin.no_username")}
+                style={{
+                  width: "100%", padding: "6px 8px",
+                  border: `1px solid ${paper.paperDark}`, background: paper.paperDeep,
+                  fontFamily: fontMono, fontSize: 12, color: paper.ink, outline: "none",
+                }}
+              />
+            </div>
+            <label style={{ display: "flex", alignItems: "center", gap: 6, paddingBottom: 6, cursor: "pointer" }}>
+              <input
+                type="checkbox"
+                checked={isAdmin}
+                onChange={(e) => setIsAdmin(e.target.checked)}
+                style={{ accentColor: paper.blue, width: 14, height: 14 }}
+              />
+              <span style={{ fontFamily: fontMono, fontSize: 9, letterSpacing: 1.5, textTransform: "uppercase", color: paper.inkDim }}>
+                {t("admin.is_admin_label")}
+              </span>
+            </label>
+          </div>
 
-      <div style={{ marginBottom: 10 }}>
-        <div style={{ fontFamily: fontMono, fontSize: 9, color: paper.inkDim, letterSpacing: 1.5, textTransform: "uppercase", marginBottom: 4 }}>
-          {t("admin.long_discount", { pct: (discLong * 100).toFixed(0) })}
-        </div>
-        <input type="range" min={0} max={0.75} step={0.05} value={discLong}
-          onChange={(e) => setDiscLong(parseFloat(e.target.value))}
-          style={{ width: "100%", accentColor: discLong > 0 ? paper.amber : paper.inkDim }} />
-      </div>
+          {/* Invite */}
+          <div style={{ marginBottom: 12 }}>
+            <button
+              onClick={handleInvite}
+              style={{
+                padding: "7px 12px", background: "transparent",
+                border: `1px dashed ${paper.inkDim}`, cursor: "pointer",
+                fontFamily: fontMono, fontSize: 9, letterSpacing: 1.5, textTransform: "uppercase",
+                color: paper.inkDim,
+              }}>
+              {t("admin.invite_copy")}
+            </button>
+            {inviteBanner && (
+              <span style={{ marginLeft: 10, fontFamily: fontMono, fontSize: 10, color: paper.green }}>
+                {inviteBanner}
+              </span>
+            )}
+          </div>
 
-      <div style={{ display: "flex", gap: 8 }}>
-        {dirty && (
-          <button
-            onClick={() => onSave({
-              ...person,
-              discount: disc, discount_long: discLong,
-              username: username || null, is_admin: isAdmin ? 1 : 0,
-            })}
-            style={{
-              flex: 1, padding: "10px", background: paper.ink, color: paper.paper,
-              border: "none", cursor: "pointer", fontFamily: fontMono, fontSize: 10,
-              fontWeight: 700, letterSpacing: 2, textTransform: "uppercase",
+          {/* Discounts */}
+          <div style={{ marginBottom: 10 }}>
+            <div style={{ fontFamily: fontMono, fontSize: 9, color: paper.inkDim, letterSpacing: 1.5, textTransform: "uppercase", marginBottom: 4 }}>
+              {t("admin.base_discount", { pct: (disc * 100).toFixed(0) })}
+            </div>
+            <input type="range" min={0} max={0.5} step={0.05} value={disc}
+              onChange={(e) => setDisc(parseFloat(e.target.value))}
+              style={{ width: "100%", accentColor: disc > 0 ? paper.amber : paper.inkDim }} />
+          </div>
+          <div style={{ marginBottom: 14 }}>
+            <div style={{ fontFamily: fontMono, fontSize: 9, color: paper.inkDim, letterSpacing: 1.5, textTransform: "uppercase", marginBottom: 4 }}>
+              {t("admin.long_discount", { pct: (discLong * 100).toFixed(0) })}
+            </div>
+            <input type="range" min={0} max={0.75} step={0.05} value={discLong}
+              onChange={(e) => setDiscLong(parseFloat(e.target.value))}
+              style={{ width: "100%", accentColor: discLong > 0 ? paper.amber : paper.inkDim }} />
+          </div>
+
+          {/* Deactivate */}
+          <div style={{ marginBottom: 12 }}>
+            <button
+              onClick={() => onSave({ ...person, discount: disc, discount_long: discLong, active: 0 })}
+              style={{
+                width: "100%", padding: "8px",
+                background: paper.accent, color: paper.paper,
+                border: "none", cursor: "pointer",
+                fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 1.5, textTransform: "uppercase",
+              }}>
+              {t("admin.deactivate")}
+            </button>
+          </div>
+
+          {/* Cancel / Save */}
+          <div style={{ display: "flex", gap: 8 }}>
+            <button onClick={onToggle} style={{
+              flex: 1, padding: "9px", background: "transparent", color: paper.inkDim,
+              border: `1px solid ${paper.paperDark}`, cursor: "pointer",
+              fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 1.5, textTransform: "uppercase",
             }}>
-            {t("action.save")}
-          </button>
-        )}
-        <button
-          onClick={() => onSave({ ...person, discount: disc, discount_long: discLong, active: 0 })}
-          style={{
-            padding: "10px 14px", background: "transparent", color: paper.inkMute,
-            border: `1px solid ${paper.paperDark}`, cursor: "pointer",
-            fontFamily: fontMono, fontSize: 9, letterSpacing: 1.5, textTransform: "uppercase",
-          }}>
-          {t("admin.deactivate")}
-        </button>
-      </div>
-    </Card>
+              {t("action.cancel")}
+            </button>
+            <button
+              disabled={!dirty}
+              onClick={() => onSave({ ...person, discount: disc, discount_long: discLong, username: username || null, is_admin: isAdmin ? 1 : 0 })}
+              style={{
+                flex: 2, padding: "9px",
+                background: dirty ? paper.ink : paper.paperDark,
+                color: dirty ? paper.paper : paper.inkMute,
+                border: "none", cursor: dirty ? "pointer" : "default",
+                fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 2, textTransform: "uppercase",
+              }}>
+              {t("action.save")}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -213,6 +261,9 @@ export default function AdminLedenPage() {
   const { data: people = [] } = usePeople();
   const qc = useQueryClient();
   const router = useRouter();
+  const [expanded, setExpanded] = useState<number | null>(null);
+
+  const toggle = (id: number) => setExpanded((prev) => (prev === id ? null : id));
 
   const savePerson = useMutation({
     mutationFn: async (p: Person) => {
@@ -226,7 +277,11 @@ export default function AdminLedenPage() {
       });
       if (!res.ok) throw new Error("Failed");
     },
-    onSuccess: () => { qc.invalidateQueries({ queryKey: ["people"] }); toast.success(t("toast.saved")); },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["people"] });
+      setExpanded(null);
+      toast.success(t("toast.saved"));
+    },
   });
 
   async function handleCloak(personId: number) {
@@ -246,7 +301,14 @@ export default function AdminLedenPage() {
   return (
     <div style={{ padding: "16px" }}>
       {active.map((person) => (
-        <PersonCard key={person.id} person={person} onSave={(p) => savePerson.mutate(p)} onCloak={handleCloak} />
+        <PersonRow
+          key={person.id}
+          person={person}
+          expanded={expanded === person.id}
+          onToggle={() => toggle(person.id)}
+          onSave={(p) => savePerson.mutate(p)}
+          onCloak={handleCloak}
+        />
       ))}
       {inactive.length > 0 && (
         <>
@@ -258,7 +320,13 @@ export default function AdminLedenPage() {
             {t("admin.inactive_section")}
           </div>
           {inactive.map((person) => (
-            <PersonCard key={person.id} person={person} onSave={(p) => savePerson.mutate(p)} />
+            <PersonRow
+              key={person.id}
+              person={person}
+              expanded={false}
+              onToggle={() => {}}
+              onSave={(p) => savePerson.mutate(p)}
+            />
           ))}
         </>
       )}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -4,6 +4,7 @@ import { paper, fontMono, fontSerif } from "@/lib/paper-theme";
 import { useT } from "@/components/locale-provider";
 import { useReservations, Card, Perf } from "./_shared";
 import { toast } from "sonner";
+import { CarBadge } from "@/components/car-badge";
 
 // ── INBOX ─────────────────────────────────────────────────────
 export default function AdminInboxPage() {
@@ -40,10 +41,7 @@ export default function AdminInboxPage() {
       {pending.map((r) => (
         <Card key={r.id}>
           <div style={{ display: "flex", alignItems: "flex-start", gap: 12, marginBottom: 12 }}>
-            <div style={{
-              padding: "8px 10px", background: paper.ink, color: paper.paper,
-              fontFamily: fontMono, fontSize: 13, fontWeight: 700, letterSpacing: 2, flexShrink: 0,
-            }}>{r.car_short}</div>
+            <CarBadge short={r.car_short ?? "?"} style={{ padding: "8px 10px", fontSize: 13 }} />
             <div style={{ flex: 1 }}>
               <div style={{ fontFamily: fontSerif, fontSize: 16, fontWeight: 700, color: paper.ink }}>{r.person_name}</div>
               <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkDim, letterSpacing: 1, marginTop: 2 }}>

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -41,7 +41,7 @@ export default function AdminInboxPage() {
       {pending.map((r) => (
         <Card key={r.id}>
           <div style={{ display: "flex", alignItems: "flex-start", gap: 12, marginBottom: 12 }}>
-            <CarBadge short={r.car_short ?? "?"} style={{ padding: "8px 10px" }} />
+            <CarBadge short={r.car_short ?? "?"} />
             <div style={{ flex: 1 }}>
               <div style={{ fontFamily: fontSerif, fontSize: 16, fontWeight: 700, color: paper.ink }}>{r.person_name}</div>
               <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkDim, letterSpacing: 1, marginTop: 2 }}>

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -41,7 +41,7 @@ export default function AdminInboxPage() {
       {pending.map((r) => (
         <Card key={r.id}>
           <div style={{ display: "flex", alignItems: "flex-start", gap: 12, marginBottom: 12 }}>
-            <CarBadge short={r.car_short ?? "?"} style={{ padding: "8px 10px", fontSize: 13 }} />
+            <CarBadge short={r.car_short ?? "?"} style={{ padding: "8px 10px" }} />
             <div style={{ flex: 1 }}>
               <div style={{ fontFamily: fontSerif, fontSize: 16, fontWeight: 700, color: paper.ink }}>{r.person_name}</div>
               <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkDim, letterSpacing: 1, marginTop: 2 }}>

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -18,6 +18,7 @@ import { paper, fontMono, fontSerif } from "@/lib/paper-theme";
 import { useT } from "@/components/locale-provider";
 import { ReservationCard } from "@/components/reservation-card";
 import { PickCalendar } from "@/components/pick-calendar";
+import { CarBadge } from "@/components/car-badge";
 
 // ── Bottom Sheet ──────────────────────────────────────────────
 function BottomSheet({
@@ -74,12 +75,7 @@ function CarTimeline({
       boxShadow: "0 1px 2px rgba(0,0,0,0.04)",
     }}>
       <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 10 }}>
-        <div style={{
-          padding: "5px 8px", background: car.active ? paper.ink : paper.inkMute, color: paper.paper,
-          fontFamily: fontMono, fontSize: 11, fontWeight: 700, letterSpacing: 2, minWidth: 40, textAlign: "center",
-        }}>
-          {car.short}
-        </div>
+        <CarBadge short={car.short} active={!!car.active} style={{ padding: "5px 8px" }} />
         <div style={{ fontFamily: fontSerif, fontSize: 16, fontWeight: 700, color: paper.ink }}>
           {car.name}
         </div>

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -75,7 +75,7 @@ function CarTimeline({
       boxShadow: "0 1px 2px rgba(0,0,0,0.04)",
     }}>
       <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 10 }}>
-        <CarBadge short={car.short} active={!!car.active} style={{ padding: "5px 8px" }} />
+        <CarBadge short={car.short} active={!!car.active} />
         <div style={{ fontFamily: fontSerif, fontSize: 16, fontWeight: 700, color: paper.ink }}>
           {car.name}
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -30,6 +30,7 @@ import {
   useCreateReservation, useUpdateReservation, useDeleteReservation,
 } from "./dashboard-hooks";
 import { useCars } from "@/hooks/use-cars";
+import { CarBadge } from "@/components/car-badge";
 
 // ── Primitives ────────────────────────────────────────────────────
 function Perf({ margin = "12px 0" }: { margin?: string }) {
@@ -282,13 +283,7 @@ function CarLocations({ trips, onTripClick }: { trips: Trip[]; onTripClick: (tri
                 cursor: "pointer",
               }}
             >
-              <div style={{
-                padding: "6px 8px", textAlign: "center",
-                border: `1.5px solid ${paper.ink}`,
-                background: paper.ink, color: paper.paper,
-                fontFamily: fontMono, fontSize: 11, fontWeight: 700, letterSpacing: 2,
-                display: "inline-block", minWidth: 42, flexShrink: 0,
-              }}>{short}</div>
+              <CarBadge short={short} />
               <div style={{ flex: 1, minWidth: 0 }}>
                 <div style={{
                   fontFamily: fontSerif, fontSize: 14, fontWeight: 600, lineHeight: 1.2,

--- a/components/car-badge.tsx
+++ b/components/car-badge.tsx
@@ -1,0 +1,18 @@
+import { paper, fontMono } from "@/lib/paper-theme";
+
+export function CarBadge({ short, active = true, style }: {
+  short: string;
+  active?: boolean;
+  style?: React.CSSProperties;
+}) {
+  return (
+    <div style={{
+      padding: "6px 8px", background: active ? paper.ink : paper.inkMute, color: paper.paper,
+      fontFamily: fontMono, fontSize: 11, fontWeight: 700, letterSpacing: 2,
+      flexShrink: 0, minWidth: 42, textAlign: "center",
+      ...style,
+    }}>
+      {short}
+    </div>
+  );
+}

--- a/components/car-badge.tsx
+++ b/components/car-badge.tsx
@@ -1,16 +1,14 @@
 import { paper, fontMono } from "@/lib/paper-theme";
 
-export function CarBadge({ short, active = true, style }: {
+export function CarBadge({ short, active = true }: {
   short: string;
   active?: boolean;
-  style?: React.CSSProperties;
 }) {
   return (
     <div style={{
       padding: "6px 8px", background: active ? paper.ink : paper.inkMute, color: paper.paper,
       fontFamily: fontMono, fontSize: 11, fontWeight: 700, letterSpacing: 2,
       flexShrink: 0, minWidth: 42, textAlign: "center",
-      ...style,
     }}>
       {short}
     </div>

--- a/components/expense-card.tsx
+++ b/components/expense-card.tsx
@@ -2,6 +2,7 @@
 import type { Expense } from "@/types";
 import { paper, fontMono, fontSerif, fmtMoney, fmtDate } from "@/lib/paper-theme";
 import { useT, useLocale } from "@/components/locale-provider";
+import { CarBadge } from "@/components/car-badge";
 
 export interface ExpenseCardProps {
   expense: Expense;
@@ -21,11 +22,7 @@ export function ExpenseCard({ expense, onClick }: ExpenseCardProps) {
       boxShadow: "0 1px 2px rgba(0,0,0,0.04)",
       cursor: onClick ? "pointer" : "default",
     }}>
-      <div style={{
-        padding: "6px 8px", background: paper.ink, color: paper.paper,
-        fontFamily: fontMono, fontSize: 11, fontWeight: 700, letterSpacing: 2,
-        display: "inline-block", minWidth: 42, flexShrink: 0, textAlign: "center",
-      }}>{expense.car_short ?? "?"}</div>
+      <CarBadge short={expense.car_short ?? "?"} />
       <div style={{ flex: 1, minWidth: 0 }}>
         <div style={{ fontFamily: fontSerif, fontSize: 15, color: paper.ink, fontWeight: 600, lineHeight: 1.2, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
           {expense.description ?? t("dashboard.maintenance_label")}

--- a/components/fuel-card.tsx
+++ b/components/fuel-card.tsx
@@ -2,6 +2,7 @@
 import type { FuelFillup } from "@/types";
 import { paper, fontMono, fontSerif, fmtMoney, fmtDate } from "@/lib/paper-theme";
 import { useT, useLocale } from "@/components/locale-provider";
+import { CarBadge } from "@/components/car-badge";
 
 export interface FuelCardProps {
   fuel: FuelFillup;
@@ -21,11 +22,7 @@ export function FuelCard({ fuel, onClick }: FuelCardProps) {
       boxShadow: "0 1px 2px rgba(0,0,0,0.04)",
       cursor: onClick ? "pointer" : "default",
     }}>
-      <div style={{
-        padding: "6px 8px", background: paper.ink, color: paper.paper,
-        fontFamily: fontMono, fontSize: 11, fontWeight: 700, letterSpacing: 2,
-        display: "inline-block", minWidth: 42, flexShrink: 0, textAlign: "center",
-      }}>{fuel.car_short ?? "?"}</div>
+      <CarBadge short={fuel.car_short ?? "?"} />
       <div style={{ flex: 1, minWidth: 0 }}>
         <div style={{ fontFamily: fontSerif, fontSize: 15, color: paper.ink, fontWeight: 600, lineHeight: 1.2, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
           ⛽ {fuel.location ?? t("dashboard.fillup_label")}

--- a/components/reservation-card.tsx
+++ b/components/reservation-card.tsx
@@ -2,6 +2,7 @@
 import type { Reservation } from "@/types";
 import { paper, fontMono, fontSerif, fmtDate } from "@/lib/paper-theme";
 import { useLocale } from "@/components/locale-provider";
+import { CarBadge } from "@/components/car-badge";
 
 export interface ReservationCardProps {
   reservation: Reservation;
@@ -27,11 +28,7 @@ export function ReservationCard({ reservation, onClick }: ReservationCardProps) 
       textAlign: "left",
       appearance: "none",
     }}>
-      <div style={{
-        padding: "6px 8px", background: paper.ink, color: paper.paper,
-        fontFamily: fontMono, fontSize: 11, fontWeight: 700, letterSpacing: 2,
-        display: "inline-block", minWidth: 42, flexShrink: 0, textAlign: "center",
-      }}>{reservation.car_short ?? "?"}</div>
+      <CarBadge short={reservation.car_short ?? "?"} />
       <div style={{ flex: 1, minWidth: 0 }}>
         <div style={{ fontFamily: fontSerif, fontSize: 15, fontWeight: 600, color: paper.ink, lineHeight: 1.2 }}>
           {reservation.person_name}

--- a/components/trip-card.tsx
+++ b/components/trip-card.tsx
@@ -2,6 +2,7 @@
 import type { Trip } from "@/types";
 import { paper, fontMono, fontSerif, fmtMoney, fmtDate } from "@/lib/paper-theme";
 import { useLocale } from "@/components/locale-provider";
+import { CarBadge } from "@/components/car-badge";
 
 export interface TripCardProps {
   trip: Trip;
@@ -20,11 +21,7 @@ export function TripCard({ trip, onClick }: TripCardProps) {
       boxShadow: "0 1px 2px rgba(0,0,0,0.04)",
       cursor: onClick ? "pointer" : "default",
     }}>
-      <div style={{
-        padding: "6px 8px", background: paper.ink, color: paper.paper,
-        fontFamily: fontMono, fontSize: 11, fontWeight: 700, letterSpacing: 2,
-        display: "inline-block", minWidth: 42, flexShrink: 0, textAlign: "center",
-      }}>{trip.car_short ?? "?"}</div>
+      <CarBadge short={trip.car_short ?? "?"} />
       <div style={{ flex: 1, minWidth: 0 }}>
         <div style={{
           fontFamily: fontSerif, fontSize: 15, color: (!trip.location && !trip.gps_coords && trip.parking) ? paper.inkDim : paper.ink,


### PR DESCRIPTION
## Summary
- admin/members: accordion PersonRow (collapsed: name, ← view as, username, discount badge)
- admin/cars + admin/members: deactivate button filled red, save disabled when not dirty, cancel resets form
- admin/cars + admin/members: `…` pending state on all action buttons while saving
- Inactive cards (cars + people): simplified to name/code + Activate button only
- Extracted `CarBadge` component, replacing 10 inline badge blocks across the codebase
- Standardised CarBadge to uniform `6px 8px` padding and `fontSize: 11` everywhere

## Test Plan
- [ ] admin/members: cards collapsed by default, click expands one at a time
- [ ] admin/members: `← view as` cloaks without expanding card
- [ ] admin/members: cancel resets sliders/username to saved values
- [ ] admin/members: save disabled until something changes
- [ ] admin/cars: same button behaviour (dirty save, red deactivate, reset on cancel)
- [ ] activate button shows `…` while pending on both pages
- [ ] CarBadge looks consistent across trips, fuel, expenses, reservations, calendar, admin

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)