### PR TITLE
feat: Phase 6 — JSDoc, OpenAPI spec, accessibility fixes, and version in header

### DIFF
--- a/app/admin/_shared.tsx
+++ b/app/admin/_shared.tsx
@@ -264,6 +264,7 @@ export function FixedCostEditor({
           />
           <button
             onClick={() => remove(item.id)}
+            aria-label={lang === "nl" ? "Item verwijderen" : "Remove item"}
             style={{
               padding: "4px 7px",
               background: "transparent",

--- a/app/api/docs/route.ts
+++ b/app/api/docs/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+export async function GET() {
+  if (process.env.NODE_ENV !== "development") {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  const yaml = readFileSync(join(process.cwd(), "docs/openapi.yaml"), "utf-8");
+  return new NextResponse(yaml, { headers: { "Content-Type": "application/yaml" } });
+}

--- a/app/calendar/reservation-form.tsx
+++ b/app/calendar/reservation-form.tsx
@@ -151,6 +151,7 @@ export function ReservationForm({ defaultValues, onSubmit, onCancel }: Props) {
         <button
           type="button"
           onClick={onCancel}
+          aria-label={t("action.close")}
           style={{
             fontFamily: fontMono,
             fontSize: 16,

--- a/app/expenses/expense-form.tsx
+++ b/app/expenses/expense-form.tsx
@@ -116,6 +116,7 @@ export function ExpenseForm({ defaultValues, onSubmit, onCancel, onDelete }: Pro
         <button
           type="button"
           onClick={onCancel}
+          aria-label={t("action.close")}
           style={{
             fontFamily: fontMono,
             fontSize: 16,

--- a/app/fuel/fuel-form.tsx
+++ b/app/fuel/fuel-form.tsx
@@ -169,6 +169,7 @@ export function FuelForm({ defaultValues, onSubmit, onCancel, onDelete }: Props)
         <button
           type="button"
           onClick={onCancel}
+          aria-label={t("action.close")}
           style={{
             fontFamily: fontMono,
             fontSize: 16,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -722,6 +722,7 @@ function DashboardContent() {
             <button
               onClick={handleLogout}
               title={t("nav.logout")}
+              aria-label={t("nav.logout")}
               style={{
                 padding: "3px 8px",
                 fontFamily: fontMono,

--- a/app/trips/trip-form.tsx
+++ b/app/trips/trip-form.tsx
@@ -186,6 +186,7 @@ export function TripForm({ defaultValues, onSubmit, onCancel, onDelete }: Props)
         <button
           type="button"
           onClick={onCancel}
+          aria-label={t("action.close")}
           style={{
             fontFamily: fontMono,
             fontSize: 16,

--- a/components/fab.tsx
+++ b/components/fab.tsx
@@ -129,6 +129,8 @@ export function MultiFab({ onPick }: { onPick: (action: string) => void }) {
           }
           setOpen((o) => !o);
         }}
+        aria-label={t("fab.open_menu")}
+        aria-expanded={open}
         style={{
           width: 60,
           height: 60,

--- a/components/location-picker.tsx
+++ b/components/location-picker.tsx
@@ -233,6 +233,7 @@ export function LocationPicker({ address, coords, onAddressChange, onCoordsChang
         <button
           type="button"
           onClick={captureGPS}
+          aria-label={t("location.use_gps")}
           style={{
             fontFamily: fontMono,
             fontSize: 9,
@@ -255,7 +256,8 @@ export function LocationPicker({ address, coords, onAddressChange, onCoordsChang
             onClick={() => {
               onCoordsChange(null);
             }}
-            title="Wis GPS pin"
+            title={t("action.clear_gps")}
+            aria-label={t("action.clear_gps")}
             style={{
               fontFamily: fontMono,
               fontSize: 11,

--- a/components/page-header.tsx
+++ b/components/page-header.tsx
@@ -4,6 +4,9 @@ import { paper, fontMono, fontSerif } from "@/lib/paper-theme";
 import { useT } from "@/components/locale-provider";
 import { LangSwitcher } from "./lang-switcher";
 import { OfflineBadge } from "./offline-badge";
+import pkg from "@/package.json";
+
+const version = pkg.version;
 
 interface Props {
   title: string;
@@ -50,29 +53,34 @@ export function PageHeader({ title, subtitle, right }: Props) {
         >
           {t("brand.tagline")}
         </div>
-        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-          <OfflineBadge />
-          {right}
-          <LangSwitcher />
-          <button
-            onClick={handleLogout}
-            title={t("nav.logout")}
-            style={{
-              padding: "3px 8px",
-              fontFamily: fontMono,
-              fontSize: 9,
-              fontWeight: 700,
-              letterSpacing: 1.5,
-              textTransform: "uppercase",
-              background: "transparent",
-              color: paper.inkDim,
-              border: `1.5px solid ${paper.paperDark}`,
-              cursor: "pointer",
-              lineHeight: 1.6,
-            }}
-          >
-            ⏻
-          </button>
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 2 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <OfflineBadge />
+            {right}
+            <LangSwitcher />
+            <button
+              onClick={handleLogout}
+              title={t("nav.logout")}
+              style={{
+                padding: "3px 8px",
+                fontFamily: fontMono,
+                fontSize: 9,
+                fontWeight: 700,
+                letterSpacing: 1.5,
+                textTransform: "uppercase",
+                background: "transparent",
+                color: paper.inkDim,
+                border: `1.5px solid ${paper.paperDark}`,
+                cursor: "pointer",
+                lineHeight: 1.6,
+              }}
+            >
+              ⏻
+            </button>
+          </div>
+          <span style={{ fontFamily: fontMono, fontSize: 8, color: paper.inkDim, letterSpacing: 1 }}>
+            v{version}
+          </span>
         </div>
       </div>
       <div

--- a/components/page-header.tsx
+++ b/components/page-header.tsx
@@ -57,6 +57,7 @@ export function PageHeader({ title, subtitle, right }: Props) {
           <button
             onClick={handleLogout}
             title={t("nav.logout")}
+            aria-label={t("nav.logout")}
             style={{
               padding: "3px 8px",
               fontFamily: fontMono,

--- a/components/pick-calendar.tsx
+++ b/components/pick-calendar.tsx
@@ -149,6 +149,7 @@ export function PickCalendar({
               <button
                 type="button"
                 onClick={() => setPickFrom(null)}
+                aria-label={t("action.cancel_selection")}
                 style={{
                   border: "none",
                   background: "transparent",
@@ -167,10 +168,10 @@ export function PickCalendar({
             <span style={{ color: paper.inkDim }}>{monthRange(days[0], days[13], locale)}</span>
           )}
         </div>
-        <button type="button" onClick={() => setWeekOffset((o) => o - 1)} style={navBtn}>
+        <button type="button" onClick={() => setWeekOffset((o) => o - 1)} aria-label={t("calendar.prev_weeks")} style={navBtn}>
           ‹
         </button>
-        <button type="button" onClick={() => setWeekOffset((o) => o + 1)} style={navBtn}>
+        <button type="button" onClick={() => setWeekOffset((o) => o + 1)} aria-label={t("calendar.next_weeks")} style={navBtn}>
           ›
         </button>
       </div>

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,495 @@
+openapi: "3.0.3"
+info:
+  title: CarSharing API
+  version: "1.0.0"
+  description: Internal REST API for the CarSharing Next.js application.
+
+servers:
+  - url: /api
+
+security:
+  - cookieAuth: []
+
+components:
+  securitySchemes:
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: carsharing_session
+
+  schemas:
+    Error:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: string
+
+    OkResponse:
+      type: object
+      required: [ok]
+      properties:
+        ok:
+          type: boolean
+          example: true
+
+    CreatedResponse:
+      type: object
+      required: [id]
+      properties:
+        id:
+          type: integer
+          example: 42
+
+    MeResponse:
+      type: object
+      properties:
+        personId:
+          type: integer
+          nullable: true
+        personName:
+          type: string
+          nullable: true
+        isAdmin:
+          type: boolean
+        isOwner:
+          type: boolean
+        isCloaked:
+          type: boolean
+
+    Car:
+      type: object
+      required: [id, short, name, price_per_km]
+      properties:
+        id:
+          type: integer
+        short:
+          type: string
+          maxLength: 10
+        name:
+          type: string
+        price_per_km:
+          type: number
+          format: float
+        brand:
+          type: string
+          nullable: true
+        color:
+          type: string
+          nullable: true
+        owner_name:
+          type: string
+          nullable: true
+        long_threshold:
+          type: integer
+          default: 500
+        fixed_costs_json:
+          type: string
+          nullable: true
+        active:
+          type: integer
+          enum: [0, 1]
+          default: 1
+        expected_km:
+          type: integer
+          nullable: true
+
+    CarInput:
+      type: object
+      required: [short, name, price_per_km]
+      properties:
+        short:
+          type: string
+          minLength: 1
+          maxLength: 10
+        name:
+          type: string
+          minLength: 1
+        price_per_km:
+          type: number
+          format: float
+        brand:
+          type: string
+          nullable: true
+        color:
+          type: string
+          nullable: true
+        owner_name:
+          type: string
+          nullable: true
+        long_threshold:
+          type: integer
+          default: 500
+        fixed_costs_json:
+          type: string
+          nullable: true
+        active:
+          type: integer
+          enum: [0, 1]
+          default: 1
+        expected_km:
+          type: integer
+          nullable: true
+
+    Trip:
+      type: object
+      required: [id, person_id, car_id, date, start_odometer, end_odometer, km, amount]
+      properties:
+        id:
+          type: integer
+        person_id:
+          type: integer
+        car_id:
+          type: integer
+        date:
+          type: string
+          format: date
+        start_odometer:
+          type: integer
+        end_odometer:
+          type: integer
+        km:
+          type: integer
+        amount:
+          type: number
+          format: float
+        location:
+          type: string
+          nullable: true
+        parking:
+          type: string
+          nullable: true
+        gps_coords:
+          type: string
+          nullable: true
+        person_name:
+          type: string
+        car_short:
+          type: string
+        updated_at:
+          type: string
+          format: date-time
+
+    TripInput:
+      type: object
+      required: [person_id, car_id, date, start_odometer, end_odometer]
+      properties:
+        person_id:
+          type: integer
+        car_id:
+          type: integer
+        date:
+          type: string
+          format: date
+          pattern: '^\d{4}-\d{2}-\d{2}$'
+        start_odometer:
+          type: integer
+          minimum: 0
+        end_odometer:
+          type: integer
+          minimum: 0
+        location:
+          type: string
+          nullable: true
+        parking:
+          type: string
+          nullable: true
+        gps_coords:
+          type: string
+          nullable: true
+        client_id:
+          type: string
+          nullable: true
+          description: Client-generated idempotency key.
+
+    Reservation:
+      type: object
+      required: [id, person_id, car_id, start_date, end_date, status]
+      properties:
+        id:
+          type: integer
+        person_id:
+          type: integer
+        car_id:
+          type: integer
+        start_date:
+          type: string
+          format: date
+        end_date:
+          type: string
+          format: date
+        status:
+          type: string
+          enum: [pending, confirmed, rejected]
+        note:
+          type: string
+          nullable: true
+        person_name:
+          type: string
+        car_short:
+          type: string
+        updated_at:
+          type: string
+          format: date-time
+
+    ReservationInput:
+      type: object
+      required: [person_id, car_id, start_date, end_date]
+      properties:
+        person_id:
+          type: integer
+        car_id:
+          type: integer
+        start_date:
+          type: string
+          format: date
+        end_date:
+          type: string
+          format: date
+        note:
+          type: string
+          nullable: true
+        status:
+          type: string
+          enum: [pending, confirmed, rejected]
+          default: pending
+        client_id:
+          type: string
+          nullable: true
+          description: Client-generated idempotency key.
+
+    DashboardRow:
+      type: object
+      required: [person_id, person_name, year]
+      properties:
+        person_id:
+          type: integer
+        person_name:
+          type: string
+        year:
+          type: integer
+        trip_count:
+          type: integer
+        trip_km:
+          type: number
+        trip_amount:
+          type: number
+        fuel_count:
+          type: integer
+        fuel_liters:
+          type: number
+        fuel_amount:
+          type: number
+        expense_count:
+          type: integer
+        expense_amount:
+          type: number
+        total_amount:
+          type: number
+        paid_amount:
+          type: number
+        balance:
+          type: number
+
+paths:
+  /auth/login:
+    post:
+      summary: Log in with username and password.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [username, password]
+              properties:
+                username:
+                  type: string
+                password:
+                  type: string
+                  format: password
+      responses:
+        "200":
+          description: Login successful; session cookie is set.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OkResponse"
+        "401":
+          description: Invalid credentials.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /auth/logout:
+    post:
+      summary: Destroy the current session.
+      responses:
+        "200":
+          description: Session destroyed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OkResponse"
+
+  /me:
+    get:
+      summary: Return the currently authenticated user, or null if unauthenticated.
+      security: []
+      responses:
+        "200":
+          description: Current user info (null body when not logged in).
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/MeResponse"
+                  - type: "null"
+
+  /trips:
+    get:
+      summary: List all trips ordered by date descending.
+      responses:
+        "200":
+          description: Array of trips.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Trip"
+    post:
+      summary: Record a new trip.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TripInput"
+      responses:
+        "201":
+          description: Trip created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreatedResponse"
+        "400":
+          description: Validation error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: CSRF token missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /reservations:
+    get:
+      summary: List all reservations ordered by start_date descending.
+      responses:
+        "200":
+          description: Array of reservations.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Reservation"
+    post:
+      summary: Create a new reservation.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReservationInput"
+      responses:
+        "201":
+          description: Reservation created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreatedResponse"
+        "400":
+          description: Validation error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: CSRF token missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /cars:
+    get:
+      summary: List all cars ordered by short name.
+      responses:
+        "200":
+          description: Array of cars.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Car"
+    post:
+      summary: Add a new car.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CarInput"
+      responses:
+        "201":
+          description: Car created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreatedResponse"
+        "400":
+          description: Validation error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: CSRF token missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /dashboard:
+    get:
+      summary: Return per-person annual summary (trips, fuel, expenses, balance).
+      parameters:
+        - name: year
+          in: query
+          schema:
+            type: integer
+            example: 2025
+          description: Calendar year to summarise; defaults to the current year.
+      responses:
+        "200":
+          description: Array of dashboard rows, one per person.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/DashboardRow"
+        "400":
+          description: Invalid year parameter.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -12,10 +12,12 @@ export class HttpError extends Error {
   }
 }
 
+/** Throws an HttpError with status 404. */
 export function notFound(msg = "Not found"): never {
   throw new HttpError(404, msg);
 }
 
+/** Throws an HttpError with status 400. */
 export function badRequest(msg = "Bad request"): never {
   throw new HttpError(400, msg);
 }
@@ -27,6 +29,7 @@ type Handler<T> = (
 
 const MUTATING_METHODS = ["POST", "PUT", "PATCH", "DELETE"];
 
+/** Wraps a route handler with rate limiting, CSRF validation, and JSON response formatting. */
 export function json<T>(handler: Handler<T>) {
   return async (req: Request, ctx: { params: Promise<Record<string, string>> }) => {
     const ip = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
@@ -67,11 +70,22 @@ export function json<T>(handler: Handler<T>) {
   };
 }
 
+/**
+ * Parses and validates the JSON request body against a Zod schema.
+ * @param req - Incoming request.
+ * @param schema - Zod schema to validate against.
+ * @returns Parsed and validated body.
+ */
 export async function readBody<T>(req: Request, schema: ZodSchema<T>): Promise<T> {
   const raw = await req.json().catch(() => badRequest("Invalid JSON"));
   return schema.parse(raw);
 }
 
+/**
+ * Resolves and validates the `id` route parameter as a positive integer.
+ * @param ctx - Route context containing the awaitable params.
+ * @returns Numeric id.
+ */
 export async function readId(ctx: { params: Promise<Record<string, string>> }): Promise<number> {
   const { id } = await ctx.params;
   const n = Number(id);

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -11,6 +11,12 @@ interface StoredCredentials {
   passwordHash: string;
 }
 
+/**
+ * Verifies login credentials using constant-time comparisons to prevent timing attacks.
+ * @param input - Supplied username and password.
+ * @param stored - Stored username and bcrypt password hash.
+ * @returns `true` if both username and password match.
+ */
 // Both comparisons always run regardless of whether the username matched.
 // Bailing out early on a username mismatch would leak which field was wrong
 // via response timing.

--- a/lib/csrf.ts
+++ b/lib/csrf.ts
@@ -1,10 +1,16 @@
 import { randomBytes } from "crypto";
 import { NextRequest } from "next/server";
 
+/** Generates a cryptographically random 48-character hex CSRF token. */
 export function generateCsrfToken(): string {
   return randomBytes(24).toString("hex");
 }
 
+/**
+ * Validates that the `x-csrf-token` header matches the `csrf-token` cookie.
+ * @param req - Incoming Next.js or plain Request (falls back to parsing the Cookie header).
+ * @returns `true` if the token is present and matches.
+ */
 export function validateCsrfToken(req: NextRequest): boolean {
   // NextRequest has .cookies; plain Request (tests) doesn't — fall back to Cookie header
   const cookieFromParsed = req.cookies?.get("csrf-token")?.value;

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -6,6 +6,11 @@ import { env } from "./env";
 
 let _db: Database.Database | null = null;
 
+/**
+ * Returns the singleton SQLite database connection, initialising it on first call.
+ * Enables WAL mode, foreign keys, and runs pending migrations automatically.
+ * @returns The shared `better-sqlite3` database instance.
+ */
 export function getDb(): Database.Database {
   if (!_db) {
     _db = new Database(env.DB_PATH);

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -59,8 +59,12 @@ export const en: Messages = {
   "action.login": "Log in",
   "action.save": "Save",
   "action.cancel": "Cancel",
+  "action.close": "Close",
   "action.delete": "Delete",
   "action.see_all": "All →",
+  "action.clear_gps": "Clear GPS pin",
+  "action.cancel_selection": "Cancel selection",
+  "action.remove_item": "Remove item",
 
   // Filter toggle
   "filter.all": "All",
@@ -230,6 +234,9 @@ export const en: Messages = {
   "calendar.upcoming": "Upcoming",
   "calendar.all_filter": "All",
   "calendar.mine_filter": "Mine",
+  "calendar.prev_weeks": "Previous weeks",
+  "calendar.next_weeks": "Next weeks",
+  "location.use_gps": "Use current location",
 
   // Person
   "person.inactive": "Inactive",
@@ -239,6 +246,7 @@ export const en: Messages = {
   "fab.fuel": "Fill-up",
   "fab.expense": "Expense",
   "fab.reservation": "Reservation",
+  "fab.open_menu": "Open action menu",
 
   // Admin page
   "admin.subtitle": "Co-op admin · {year}",

--- a/lib/i18n/messages/nl.ts
+++ b/lib/i18n/messages/nl.ts
@@ -57,8 +57,12 @@ export const nl = {
   "action.login": "Inloggen",
   "action.save": "Opslaan",
   "action.cancel": "Annuleer",
+  "action.close": "Sluiten",
   "action.delete": "Verwijderen",
   "action.see_all": "Alles →",
+  "action.clear_gps": "GPS-pin wissen",
+  "action.cancel_selection": "Selectie annuleren",
+  "action.remove_item": "Item verwijderen",
 
   // Filter toggle
   "filter.all": "Alle",
@@ -228,6 +232,9 @@ export const nl = {
   "calendar.upcoming": "Aankomend",
   "calendar.all_filter": "Alles",
   "calendar.mine_filter": "Mijn",
+  "calendar.prev_weeks": "Vorige weken",
+  "calendar.next_weeks": "Volgende weken",
+  "location.use_gps": "Huidige locatie gebruiken",
 
   // Person
   "person.inactive": "Inactief",
@@ -237,6 +244,7 @@ export const nl = {
   "fab.fuel": "Tankbeurt",
   "fab.expense": "Extra kost",
   "fab.reservation": "Reservering",
+  "fab.open_menu": "Actiemenu openen",
 
   // Admin page
   "admin.subtitle": "Co-op administratie · {year}",

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -6,6 +6,12 @@ export interface RateLimitOptions {
   windowMs: number;
 }
 
+/**
+ * Checks an in-memory sliding-window rate limit for the given key.
+ * @param key - Unique identifier (e.g. `"<ip>:<pathname>"`).
+ * @param options - `max` requests allowed within `windowMs` milliseconds.
+ * @returns `{ ok: true }` when under the limit, or `{ ok: false, retryAfter }` in seconds when exceeded.
+ */
 export function checkRateLimit(
   key: string,
   options: RateLimitOptions

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -1,6 +1,7 @@
 import type { SessionOptions } from "iron-session";
 import { env } from "./env";
 
+/** Shape of the iron-session payload stored in the encrypted cookie. */
 export interface SessionData {
   authenticated: boolean;
   personId?: number;
@@ -14,6 +15,7 @@ export interface SessionData {
   };
 }
 
+/** iron-session configuration: cookie name, encryption password, and cookie attributes. */
 export const sessionOptions: SessionOptions = {
   cookieName: "carsharing_session",
   password: env.SESSION_PASSWORD,


### PR DESCRIPTION
## Summary
- **#37** — JSDoc on all public `lib/` functions + `docs/openapi.yaml` (OpenAPI 3.0) + `/api/docs` route serving the spec in development
- **#38** — Accessibility: `aria-label` added to all icon-only buttons (⏻ logout, FAB +, ×, close buttons) across pages and components; new i18n keys for screen-reader labels
- **#57** — App version number displayed top-right in header below the logout button, read from `package.json`

## Test results
- 18 test files, 110 tests passing
- TypeScript clean (`tsc --noEmit`)

## Closes
Closes #37, #38, #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)