### PR TITLE
fix(admin): include CSRF token when generating invite link

### DIFF
--- a/app/admin/members/page.tsx
+++ b/app/admin/members/page.tsx
@@ -58,7 +58,11 @@ function PersonRow({
 
   const handleInvite = async () => {
     try {
-      const res = await fetch(`/api/people/${person.id}/invite`, { method: "POST" });
+      const csrfToken = document.cookie.match(/csrf-token=([^;]+)/)?.[1] ?? "";
+      const res = await fetch(`/api/people/${person.id}/invite`, {
+        method: "POST",
+        headers: { "x-csrf-token": csrfToken },
+      });
       if (!res.ok) throw new Error();
       const { url } = await res.json();
       await navigator.clipboard.writeText(url);


### PR DESCRIPTION
## Summary
- The `POST /api/people/{id}/invite` fetch call was missing the `x-csrf-token` header
- The `json()` wrapper rejects all mutating requests without it (403), which the UI caught as "Error generating invite"
- Fix: read the CSRF token from the cookie and include it in the request headers, consistent with all other mutations in the codebase

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)