### PR TITLE
feat(owner): filter admin inbox and data hygiene to owner's cars only

### DIFF
--- a/app/admin/_shared.tsx
+++ b/app/admin/_shared.tsx
@@ -91,6 +91,8 @@ import type {
   CarPriceHistory,
 } from "@/lib/queries/admin";
 import type { DashboardRow, Reservation, Person } from "@/types";
+import { useMe } from "@/hooks/use-me";
+import { useCars } from "@/hooks/use-cars";
 
 export interface AdminSummary {
   carPnL: CarPnL[];
@@ -134,6 +136,19 @@ export function usePeople() {
       return res.json();
     },
   });
+}
+
+/**
+ * Returns the set of car_short values owned by the current user,
+ * or null if the user is an admin (meaning no filter should be applied).
+ */
+export function useOwnerCarShorts(): Set<string> | null {
+  const { data: me } = useMe();
+  const { data: cars = [] } = useCars();
+  if (!me || me.isAdmin) return null;
+  return new Set(
+    cars.filter((c) => c.owner_name === me.personName).map((c) => c.short)
+  );
 }
 
 // ── Fleet economics helpers ───────────────────────────────────

--- a/app/admin/hygiene/page.tsx
+++ b/app/admin/hygiene/page.tsx
@@ -4,7 +4,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { paper, fontMono, fontSerif } from "@/lib/paper-theme";
 import { useT } from "@/components/locale-provider";
 import type { KmGap, ZeroKmTrip } from "@/lib/queries/admin";
-import { useAdminSummary, usePeople, Card } from "../_shared";
+import { useAdminSummary, useOwnerCarShorts, usePeople, Card } from "../_shared";
 import { useCreateTrip } from "@/hooks/use-trips";
 import { toast } from "sonner";
 import { CarBadge } from "@/components/car-badge";
@@ -78,8 +78,13 @@ export default function AdminHygienePage() {
   const { data } = useAdminSummary(year);
   const { data: people = [] } = usePeople();
   const createTrip = useCreateTrip();
-  const gaps = data?.kmGaps ?? [];
-  const zeroKmTrips = data?.zeroKmTrips ?? [];
+  const ownerCarShorts = useOwnerCarShorts();
+  const gaps = (data?.kmGaps ?? []).filter(
+    (g) => !ownerCarShorts || ownerCarShorts.has(g.car_short)
+  );
+  const zeroKmTrips = (data?.zeroKmTrips ?? []).filter(
+    (z) => !ownerCarShorts || ownerCarShorts.has(z.car_short)
+  );
   const [expandedGap, setExpandedGap] = useState<string | null>(null);
 
   const gapKey = (gap: KmGap) => `${gap.car_short}-${gap.after_trip_id}-${gap.before_trip_id}`;

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -2,7 +2,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { paper, fontMono, fontSerif } from "@/lib/paper-theme";
 import { useT } from "@/components/locale-provider";
-import { useReservations, Card, Perf } from "./_shared";
+import { useReservations, useOwnerCarShorts, Card, Perf } from "./_shared";
 import { toast } from "sonner";
 import { CarBadge } from "@/components/car-badge";
 
@@ -11,7 +11,10 @@ export default function AdminInboxPage() {
   const t = useT();
   const qc = useQueryClient();
   const { data: reservations = [] } = useReservations();
-  const pending = reservations.filter((r) => r.status === "pending");
+  const ownerCarShorts = useOwnerCarShorts();
+  const pending = reservations
+    .filter((r) => r.status === "pending")
+    .filter((r) => !ownerCarShorts || ownerCarShorts.has(r.car_short ?? ""));
 
   const approve = useMutation({
     mutationFn: async ({ id, status }: { id: number; status: "confirmed" | "rejected" }) => {


### PR DESCRIPTION
## Summary
- Owners visiting `/admin` (inbox) now only see pending reservations for their own cars
- Owners visiting `/admin/hygiene` now only see km gaps and zero-km trips for their own cars
- Admins (including admin-owners) continue to see all data

## Implementation
Added `useOwnerCarShorts()` to `_shared.tsx` — returns a `Set<string>` of `car_short` values where `car.owner_name === me.personName`, or `null` for admins (no filter). Filtering is applied client-side in both pages.

Closes #69