### PR TITLE
feat(e2e): add CRUD and reservation approval E2E tests

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -7,3 +7,13 @@
 SESSION_PASSWORD=replace-with-32-plus-random-characters-here
 AUTH_USERNAME=autodelen
 AUTH_PASSWORD_HASH=\$2b\$12\$replace-with-bcrypt-hash-from-hash-password-script
+
+# Playwright E2E credentials
+# TEST_EMAIL and TEST_PASSWORD identify the regular (non-admin) test account.
+# TEST_ADMIN_EMAIL and TEST_ADMIN_PASSWORD identify the admin test account used
+# by the reservation approval flow. If omitted, the admin tests fall back to
+# TEST_EMAIL / TEST_PASSWORD (suitable when that account already has admin rights).
+TEST_EMAIL=your-test-user@example.com
+TEST_PASSWORD=your-test-password
+TEST_ADMIN_EMAIL=your-admin-user@example.com
+TEST_ADMIN_PASSWORD=your-admin-password

--- a/e2e/expenses.spec.ts
+++ b/e2e/expenses.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect } from "@playwright/test";
+import { loginAndGetCsrf, makeApi, getTestEntities } from "./helpers";
+
+/**
+ * Expense CRUD + dashboard delta tests.
+ *
+ * Strategy:
+ * - Create an expense via the API in beforeEach (data isolation).
+ * - Assert it appears in the /expenses list UI.
+ * - Verify the dashboard expense_count and expense_amount delta.
+ * - Delete via the API in afterEach (cleanup).
+ */
+
+const TODAY = new Date().toISOString().slice(0, 10);
+const YEAR = new Date().getFullYear();
+
+const DESCRIPTION = "E2E-Test-Expense-Description";
+const AMOUNT = 123.45;
+
+test.describe("expense CRUD", () => {
+  let csrf: string;
+  let api: ReturnType<typeof makeApi>;
+  let expenseId: number;
+  let personId: number;
+  let carId: number;
+
+  test.beforeEach(async ({ request }) => {
+    csrf = await loginAndGetCsrf(request);
+    api = makeApi(request, csrf);
+
+    const entities = await getTestEntities(api);
+    personId = entities.personId;
+    carId = entities.carId;
+
+    const res = await api.post<{ id: number }>("/api/expenses", {
+      person_id: personId,
+      car_id: carId,
+      date: TODAY,
+      amount: AMOUNT,
+      description: DESCRIPTION,
+      category: "onderhoud",
+    });
+    expenseId = res.id;
+  });
+
+  test.afterEach(async ({ request }) => {
+    if (!expenseId) return;
+    try {
+      const cleanupCsrf = await loginAndGetCsrf(request);
+      const cleanupApi = makeApi(request, cleanupCsrf);
+      await cleanupApi.delete(`/api/expenses/${expenseId}`);
+    } catch {
+      // Ignore — expense already deleted
+    }
+  });
+
+  test("expense appears in the expenses list after creation", async ({ page }) => {
+    await page.request.post("/api/auth/login", {
+      data: {
+        username: process.env.TEST_EMAIL ?? "test@example.com",
+        password: process.env.TEST_PASSWORD ?? "changeme",
+      },
+    });
+
+    await page.goto("/expenses");
+    await page.waitForLoadState("networkidle");
+
+    // ExpenseCard renders: {description} as primary text
+    await expect(page.locator(`text=${DESCRIPTION}`).first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("dashboard expense_amount increases by the expense amount", async ({ request }) => {
+    const dashWithExpense = await api.get<Array<{
+      person_id: number;
+      expense_count: number;
+      expense_amount: number;
+    }>>(`/api/dashboard?year=${YEAR}`);
+
+    const rowWith = dashWithExpense.find((r) => r.person_id === personId);
+    const amountWithExpense = rowWith?.expense_amount ?? 0;
+    const countWithExpense = rowWith?.expense_count ?? 0;
+
+    // Delete and compare
+    await api.delete(`/api/expenses/${expenseId}`);
+    expenseId = 0;
+
+    const dashWithout = await api.get<Array<{
+      person_id: number;
+      expense_count: number;
+      expense_amount: number;
+    }>>(`/api/dashboard?year=${YEAR}`);
+
+    const rowWithout = dashWithout.find((r) => r.person_id === personId);
+    const amountWithout = rowWithout?.expense_amount ?? 0;
+    const countWithout = rowWithout?.expense_count ?? 0;
+
+    expect(amountWithExpense - amountWithout).toBeCloseTo(AMOUNT, 2);
+    expect(countWithExpense - countWithout).toBe(1);
+  });
+
+  test("expense disappears from the list after deletion", async ({ page }) => {
+    await page.request.post("/api/auth/login", {
+      data: {
+        username: process.env.TEST_EMAIL ?? "test@example.com",
+        password: process.env.TEST_PASSWORD ?? "changeme",
+      },
+    });
+
+    await page.goto("/expenses");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.locator(`text=${DESCRIPTION}`).first()).toBeVisible({ timeout: 10_000 });
+
+    await api.delete(`/api/expenses/${expenseId}`);
+    expenseId = 0;
+
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+    await expect(page.locator(`text=${DESCRIPTION}`)).toHaveCount(0);
+  });
+});

--- a/e2e/fuel.spec.ts
+++ b/e2e/fuel.spec.ts
@@ -1,0 +1,128 @@
+import { test, expect } from "@playwright/test";
+import { loginAndGetCsrf, makeApi, getTestEntities } from "./helpers";
+
+/**
+ * Fuel fill-up CRUD + dashboard delta tests.
+ *
+ * Strategy:
+ * - Create a fill-up via the API in beforeEach (data isolation).
+ * - Assert it appears in the /fuel list UI.
+ * - Verify the dashboard fuel_count and fuel_liters delta.
+ * - Delete via the API in afterEach (cleanup).
+ */
+
+const TODAY = new Date().toISOString().slice(0, 10);
+const YEAR = new Date().getFullYear();
+
+// Distinctive location text so the card is easy to locate in the UI
+const LOCATION = "E2E-Test-Station-Fuel";
+const AMOUNT = 74.23;
+const LITERS = 42.0;
+
+test.describe("fuel fill-up CRUD", () => {
+  let csrf: string;
+  let api: ReturnType<typeof makeApi>;
+  let fillupId: number;
+  let personId: number;
+  let carId: number;
+
+  test.beforeEach(async ({ request }) => {
+    csrf = await loginAndGetCsrf(request);
+    api = makeApi(request, csrf);
+
+    const entities = await getTestEntities(api);
+    personId = entities.personId;
+    carId = entities.carId;
+
+    const res = await api.post<{ id: number }>("/api/fuel", {
+      person_id: personId,
+      car_id: carId,
+      date: TODAY,
+      amount: AMOUNT,
+      liters: LITERS,
+      location: LOCATION,
+    });
+    fillupId = res.id;
+  });
+
+  test.afterEach(async ({ request }) => {
+    if (!fillupId) return;
+    try {
+      const cleanupCsrf = await loginAndGetCsrf(request);
+      const cleanupApi = makeApi(request, cleanupCsrf);
+      await cleanupApi.delete(`/api/fuel/${fillupId}`);
+    } catch {
+      // Ignore — fill-up already deleted
+    }
+  });
+
+  test("fill-up appears in the fuel list after creation", async ({ page }) => {
+    await page.request.post("/api/auth/login", {
+      data: {
+        username: process.env.TEST_EMAIL ?? "test@example.com",
+        password: process.env.TEST_PASSWORD ?? "changeme",
+      },
+    });
+
+    await page.goto("/fuel");
+    await page.waitForLoadState("networkidle");
+
+    // FuelCard renders: ⛽ {location} — look for the location text
+    await expect(page.locator(`text=${LOCATION}`).first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("dashboard fuel_liters increases by the fill-up liters", async ({ request }) => {
+    const dashWithFillup = await api.get<Array<{
+      person_id: number;
+      fuel_count: number;
+      fuel_liters: number;
+      fuel_amount: number;
+    }>>(`/api/dashboard?year=${YEAR}`);
+
+    const rowWith = dashWithFillup.find((r) => r.person_id === personId);
+    const litersWithFillup = rowWith?.fuel_liters ?? 0;
+    const countWithFillup = rowWith?.fuel_count ?? 0;
+
+    // Delete the fill-up and compare
+    await api.delete(`/api/fuel/${fillupId}`);
+    fillupId = 0;
+
+    const dashWithout = await api.get<Array<{
+      person_id: number;
+      fuel_count: number;
+      fuel_liters: number;
+      fuel_amount: number;
+    }>>(`/api/dashboard?year=${YEAR}`);
+
+    const rowWithout = dashWithout.find((r) => r.person_id === personId);
+    const litersWithout = rowWithout?.fuel_liters ?? 0;
+    const countWithout = rowWithout?.fuel_count ?? 0;
+
+    // Delta should equal exactly the fill-up liters
+    expect(litersWithFillup - litersWithout).toBeCloseTo(LITERS, 2);
+    expect(countWithFillup - countWithout).toBe(1);
+  });
+
+  test("fill-up disappears from the list after deletion", async ({ page }) => {
+    await page.request.post("/api/auth/login", {
+      data: {
+        username: process.env.TEST_EMAIL ?? "test@example.com",
+        password: process.env.TEST_PASSWORD ?? "changeme",
+      },
+    });
+
+    await page.goto("/fuel");
+    await page.waitForLoadState("networkidle");
+
+    // Confirm visible
+    await expect(page.locator(`text=${LOCATION}`).first()).toBeVisible({ timeout: 10_000 });
+
+    // Delete
+    await api.delete(`/api/fuel/${fillupId}`);
+    fillupId = 0;
+
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+    await expect(page.locator(`text=${LOCATION}`)).toHaveCount(0);
+  });
+});

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,109 @@
+import type { APIRequestContext } from "@playwright/test";
+
+/**
+ * Log in via the /api/auth/login endpoint and return the CSRF token
+ * that the server sets in the csrf-token cookie.
+ *
+ * After calling this, the Playwright page/context will hold both the
+ * iron-session cookie and the csrf-token cookie, so subsequent page
+ * navigations are fully authenticated.
+ */
+export async function loginAndGetCsrf(
+  request: APIRequestContext,
+  email = process.env.TEST_EMAIL ?? "test@example.com",
+  password = process.env.TEST_PASSWORD ?? "changeme"
+): Promise<string> {
+  const res = await request.post("/api/auth/login", {
+    data: { username: email, password },
+  });
+  if (!res.ok()) {
+    throw new Error(`Login failed: ${res.status()} ${await res.text()}`);
+  }
+
+  // Read the csrf-token cookie that is set by /api/me (GET) — the login
+  // response itself doesn't write it, but the GET call after login does.
+  // Trigger it now so the cookie is present.
+  const meRes = await request.get("/api/me");
+  const cookies = await meRes.headersArray();
+  // The csrf-token is set as a cookie — extract it from Set-Cookie
+  for (const h of cookies) {
+    if (h.name.toLowerCase() === "set-cookie") {
+      const m = h.value.match(/csrf-token=([^;]+)/);
+      if (m) return decodeURIComponent(m[1]);
+    }
+  }
+
+  throw new Error("csrf-token cookie not found after login + /api/me");
+}
+
+/**
+ * Build a helper that issues authenticated API calls with the CSRF token.
+ */
+export function makeApi(request: APIRequestContext, csrf: string) {
+  return {
+    async post<T>(path: string, body: unknown): Promise<T> {
+      const res = await request.post(path, {
+        data: body,
+        headers: {
+          "Content-Type": "application/json",
+          "x-csrf-token": csrf,
+        },
+      });
+      if (!res.ok()) {
+        throw new Error(`POST ${path} failed: ${res.status()} ${await res.text()}`);
+      }
+      return res.json() as Promise<T>;
+    },
+
+    async delete(path: string): Promise<void> {
+      const res = await request.delete(path, {
+        headers: { "x-csrf-token": csrf },
+      });
+      if (!res.ok()) {
+        throw new Error(`DELETE ${path} failed: ${res.status()} ${await res.text()}`);
+      }
+    },
+
+    async patch<T>(path: string, body: unknown): Promise<T> {
+      const res = await request.patch(path, {
+        data: body,
+        headers: {
+          "Content-Type": "application/json",
+          "x-csrf-token": csrf,
+        },
+      });
+      if (!res.ok()) {
+        throw new Error(`PATCH ${path} failed: ${res.status()} ${await res.text()}`);
+      }
+      return res.json() as Promise<T>;
+    },
+
+    async get<T>(path: string): Promise<T> {
+      const res = await request.get(path);
+      if (!res.ok()) {
+        throw new Error(`GET ${path} failed: ${res.status()} ${await res.text()}`);
+      }
+      return res.json() as Promise<T>;
+    },
+  };
+}
+
+/**
+ * Fetch the first active person and first active car from the API.
+ * These are used as required foreign keys when creating test records.
+ */
+export async function getTestEntities(api: ReturnType<typeof makeApi>) {
+  const [people, cars] = await Promise.all([
+    api.get<Array<{ id: number; name: string; active: number }>>("/api/people"),
+    api.get<Array<{ id: number; short: string; active: number }>>("/api/cars"),
+  ]);
+
+  const person = people.find((p) => p.active === 1) ?? people[0];
+  const car = cars.find((c) => c.active === 1) ?? cars[0];
+
+  if (!person || !car) {
+    throw new Error("No people or cars found in DB — seed data missing");
+  }
+
+  return { personId: person.id, carId: car.id, carShort: (car as any).short };
+}

--- a/e2e/reservations.spec.ts
+++ b/e2e/reservations.spec.ts
@@ -1,0 +1,182 @@
+import { test, expect } from "@playwright/test";
+import { loginAndGetCsrf, makeApi, getTestEntities } from "./helpers";
+
+/**
+ * Reservation approval flow — two-role test.
+ *
+ * Flow:
+ * 1. Regular user creates a reservation via the API (status: pending).
+ * 2. Admin context opens /admin and asserts the reservation appears in the inbox.
+ * 3. Admin approves the reservation via the UI confirm button.
+ * 4. Regular user's calendar page shows the reservation with status "confirmed".
+ *
+ * Cleanup: delete the reservation in afterEach.
+ *
+ * Two-account setup:
+ *   TEST_EMAIL / TEST_PASSWORD          — regular user
+ *   TEST_ADMIN_EMAIL / TEST_ADMIN_PASSWORD — admin (falls back to same as regular user
+ *   if the regular user is already an admin, which is common in single-account test setups)
+ */
+
+// Future dates to avoid conflicts with existing real reservations
+const FUTURE_START = new Date(Date.now() + 60 * 86400_000).toISOString().slice(0, 10); // +60 days
+const FUTURE_END = new Date(Date.now() + 62 * 86400_000).toISOString().slice(0, 10);   // +62 days
+
+test.describe("reservation approval flow", () => {
+  let userCsrf: string;
+  let userApi: ReturnType<typeof makeApi>;
+  let reservationId: number;
+  let personId: number;
+  let carId: number;
+
+  test.beforeEach(async ({ request }) => {
+    // Log in as regular user to create the reservation
+    userCsrf = await loginAndGetCsrf(
+      request,
+      process.env.TEST_EMAIL ?? "test@example.com",
+      process.env.TEST_PASSWORD ?? "changeme"
+    );
+    userApi = makeApi(request, userCsrf);
+
+    const entities = await getTestEntities(userApi);
+    personId = entities.personId;
+    carId = entities.carId;
+
+    const res = await userApi.post<{ id: number }>("/api/reservations", {
+      person_id: personId,
+      car_id: carId,
+      start_date: FUTURE_START,
+      end_date: FUTURE_END,
+      note: "E2E-test-reservation",
+    });
+    reservationId = res.id;
+  });
+
+  test.afterEach(async ({ request }) => {
+    if (!reservationId) return;
+    try {
+      // Use admin credentials for cleanup (reservation delete may be admin-only)
+      const adminEmail = process.env.TEST_ADMIN_EMAIL ?? process.env.TEST_EMAIL ?? "test@example.com";
+      const adminPassword = process.env.TEST_ADMIN_PASSWORD ?? process.env.TEST_PASSWORD ?? "changeme";
+      const cleanupCsrf = await loginAndGetCsrf(request, adminEmail, adminPassword);
+      const cleanupApi = makeApi(request, cleanupCsrf);
+      await cleanupApi.delete(`/api/reservations/${reservationId}`);
+    } catch {
+      // Ignore
+    }
+  });
+
+  test("pending reservation appears in admin inbox and can be approved", async ({ browser }) => {
+    const adminEmail = process.env.TEST_ADMIN_EMAIL ?? process.env.TEST_EMAIL ?? "test@example.com";
+    const adminPassword = process.env.TEST_ADMIN_PASSWORD ?? process.env.TEST_PASSWORD ?? "changeme";
+
+    // ── Admin context ──────────────────────────────────────────────────────────
+    const adminContext = await browser.newContext();
+    const adminPage = await adminContext.newPage();
+
+    try {
+      // Log in as admin
+      await adminPage.request.post("/api/auth/login", {
+        data: { username: adminEmail, password: adminPassword },
+      });
+
+      // Navigate to the admin inbox
+      await adminPage.goto("/admin");
+      await adminPage.waitForLoadState("networkidle");
+
+      // The pending reservation card should be visible.
+      // The admin inbox renders: person_name, start_date, end_date, note.
+      // We match on our unique note text.
+      const reservationNote = adminPage.locator("text=E2E-test-reservation");
+      await expect(reservationNote).toBeVisible({ timeout: 10_000 });
+
+      // Click the "Bevestigen" / "Confirm" button that sits next to our card.
+      // The confirm button text comes from t("admin.confirm") → "Bevestigen" (nl) / "Confirm" (en).
+      // There may be multiple pending reservations; click the first confirm button
+      // (our reservation was just inserted so it should be at the top).
+      const confirmBtn = adminPage
+        .getByRole("button", { name: /bevestigen|confirm/i })
+        .first();
+      await confirmBtn.click();
+
+      // After confirmation a toast appears and the card disappears from the inbox
+      // (or the list refreshes). Wait for the reservation to no longer be "pending"
+      // in the inbox by checking the API.
+      await adminPage.waitForTimeout(1000); // let the mutation settle
+
+      const reservationsAfter = await adminPage.request.get("/api/reservations");
+      const all = await reservationsAfter.json() as Array<{
+        id: number;
+        status: string;
+      }>;
+      const updated = all.find((r) => r.id === reservationId);
+      expect(updated?.status).toBe("confirmed");
+    } finally {
+      await adminContext.close();
+    }
+  });
+
+  test("user sees reservation as confirmed after admin approval", async ({ browser, request }) => {
+    const adminEmail = process.env.TEST_ADMIN_EMAIL ?? process.env.TEST_EMAIL ?? "test@example.com";
+    const adminPassword = process.env.TEST_ADMIN_PASSWORD ?? process.env.TEST_PASSWORD ?? "changeme";
+
+    // Approve via API (simulates admin action without needing UI)
+    const adminCsrf = await loginAndGetCsrf(request, adminEmail, adminPassword);
+    const adminApi = makeApi(request, adminCsrf);
+    await adminApi.patch(`/api/reservations/${reservationId}/status`, { status: "confirmed" });
+
+    // ── User context ───────────────────────────────────────────────────────────
+    const userContext = await browser.newContext();
+    const userPage = await userContext.newPage();
+
+    try {
+      await userPage.request.post("/api/auth/login", {
+        data: {
+          username: process.env.TEST_EMAIL ?? "test@example.com",
+          password: process.env.TEST_PASSWORD ?? "changeme",
+        },
+      });
+
+      // Navigate to the calendar page where reservations are listed
+      await userPage.goto("/calendar");
+      await userPage.waitForLoadState("networkidle");
+
+      // The ReservationCard renders a "✓" when status is "confirmed"
+      // and the person_name. Find our reservation by note text.
+      const noteText = userPage.locator("text=E2E-test-reservation");
+      await expect(noteText).toBeVisible({ timeout: 10_000 });
+
+      // The status indicator "✓" should be present near our reservation.
+      // ReservationCard renders it in the right-column when !isPending.
+      const checkmark = userPage.locator("text=✓").first();
+      await expect(checkmark).toBeVisible({ timeout: 5_000 });
+    } finally {
+      await userContext.close();
+    }
+  });
+
+  test("reservation is visible in pending state before admin action", async ({ page }) => {
+    // Log in as the regular user
+    await page.request.post("/api/auth/login", {
+      data: {
+        username: process.env.TEST_EMAIL ?? "test@example.com",
+        password: process.env.TEST_PASSWORD ?? "changeme",
+      },
+    });
+
+    await page.goto("/calendar");
+    await page.waitForLoadState("networkidle");
+
+    // The ReservationCard for a pending reservation renders "?" as the status indicator.
+    // Our note makes it uniquely identifiable.
+    await expect(page.locator("text=E2E-test-reservation").first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Fetch via API to confirm status is still pending
+    const res = await page.request.get("/api/reservations");
+    const all = await res.json() as Array<{ id: number; status: string }>;
+    const mine = all.find((r) => r.id === reservationId);
+    expect(mine?.status).toBe("pending");
+  });
+});

--- a/e2e/trips.spec.ts
+++ b/e2e/trips.spec.ts
@@ -1,0 +1,139 @@
+import { test, expect } from "@playwright/test";
+import { loginAndGetCsrf, makeApi, getTestEntities } from "./helpers";
+
+/**
+ * Trip CRUD + dashboard delta tests.
+ *
+ * Strategy:
+ * - Create a trip via the API in beforeEach (data isolation).
+ * - Assert it appears in the trips list UI.
+ * - Capture the dashboard km/amount delta before and after creation.
+ * - Delete via the API in afterEach (cleanup).
+ */
+
+const TODAY = new Date().toISOString().slice(0, 10);
+const YEAR = new Date().getFullYear();
+
+// Odometer values chosen so they don't collide with real records.
+// km = END - START = 42
+const START_ODO = 999_900;
+const END_ODO = 999_942;
+const LOCATION = "E2E-Test-Location-Trips";
+
+test.describe("trips CRUD", () => {
+  let csrf: string;
+  let api: ReturnType<typeof makeApi>;
+  let tripId: number;
+  let personId: number;
+  let carId: number;
+
+  test.beforeEach(async ({ request }) => {
+    csrf = await loginAndGetCsrf(request);
+    api = makeApi(request, csrf);
+
+    const entities = await getTestEntities(api);
+    personId = entities.personId;
+    carId = entities.carId;
+
+    // Create a trip via API
+    const res = await api.post<{ id: number }>("/api/trips", {
+      person_id: personId,
+      car_id: carId,
+      date: TODAY,
+      start_odometer: START_ODO,
+      end_odometer: END_ODO,
+      location: LOCATION,
+    });
+    tripId = res.id;
+  });
+
+  test.afterEach(async ({ request }) => {
+    // Best-effort cleanup — trip may already have been deleted by the test itself
+    if (!tripId) return;
+    try {
+      const cleanupCsrf = await loginAndGetCsrf(request);
+      const cleanupApi = makeApi(request, cleanupCsrf);
+      await cleanupApi.delete(`/api/trips/${tripId}`);
+    } catch {
+      // Ignore — trip already deleted
+    }
+  });
+
+  test("trip appears in the trips list after creation", async ({ page }) => {
+    // Log in first
+    await page.request.post("/api/auth/login", {
+      data: {
+        username: process.env.TEST_EMAIL ?? "test@example.com",
+        password: process.env.TEST_PASSWORD ?? "changeme",
+      },
+    });
+
+    await page.goto("/trips");
+    await page.waitForLoadState("networkidle");
+
+    // The TripCard renders the location as the primary text
+    await expect(page.locator(`text=${LOCATION}`).first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("dashboard km increases after trip creation", async ({ request }) => {
+    // Fetch dashboard before trip — re-fetch fresh to get baseline
+    // (trip was already inserted in beforeEach, so we compare before vs. after delete+re-add)
+    // Instead, we capture the current dashboard state which already has the trip,
+    // then delete the trip and re-fetch to confirm the km decreased.
+
+    const dashWithTrip = await api.get<Array<{
+      person_id: number;
+      trip_count: number;
+      trip_km: number;
+    }>>(`/api/dashboard?year=${YEAR}`);
+
+    const rowWith = dashWithTrip.find((r) => r.person_id === personId);
+    const kmWith = rowWith?.trip_km ?? 0;
+    const countWith = rowWith?.trip_count ?? 0;
+
+    // Now delete the trip
+    await api.delete(`/api/trips/${tripId}`);
+
+    const dashWithout = await api.get<Array<{
+      person_id: number;
+      trip_count: number;
+      trip_km: number;
+    }>>(`/api/dashboard?year=${YEAR}`);
+
+    const rowWithout = dashWithout.find((r) => r.person_id === personId);
+    const kmWithout = rowWithout?.trip_km ?? 0;
+    const countWithout = rowWithout?.trip_count ?? 0;
+
+    // After deleting our 42 km trip, total km should have gone down by exactly 42
+    expect(kmWith - kmWithout).toBe(END_ODO - START_ODO);
+    expect(countWith - countWithout).toBe(1);
+
+    // Mark as already deleted so afterEach doesn't try again
+    tripId = 0;
+  });
+
+  test("trip disappears from the list after deletion", async ({ page }) => {
+    // Log in
+    await page.request.post("/api/auth/login", {
+      data: {
+        username: process.env.TEST_EMAIL ?? "test@example.com",
+        password: process.env.TEST_PASSWORD ?? "changeme",
+      },
+    });
+
+    await page.goto("/trips");
+    await page.waitForLoadState("networkidle");
+
+    // Confirm trip is visible
+    await expect(page.locator(`text=${LOCATION}`).first()).toBeVisible({ timeout: 10_000 });
+
+    // Delete via API
+    await api.delete(`/api/trips/${tripId}`);
+    tripId = 0;
+
+    // Reload and confirm the trip is gone
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+    await expect(page.locator(`text=${LOCATION}`)).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
Closes #60

Adds four Playwright E2E specs covering core business flows:

- `e2e/helpers.ts` — shared `loginAndGetCsrf`, `makeApi` (CSRF-aware), `getTestEntities`
- `e2e/trips.spec.ts` — create/list/delete + dashboard km delta assertions
- `e2e/fuel.spec.ts` — create/list/delete + dashboard liters delta assertions
- `e2e/expenses.spec.ts` — create/list/delete + dashboard amount delta assertions
- `e2e/reservations.spec.ts` — user creates reservation → admin approves in second context → user sees confirmed

Data isolation via API calls in `beforeEach`/`afterEach`. Dashboard assertions use deltas, not absolute totals.