### PR TITLE
ci(docker): fix if-expression syntax

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(main): release')
+    if: ${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(main): release') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- Fix `!startsWith` in unquoted YAML `if:` value — `!` is a YAML tag indicator and caused all Docker builds to fail at 0s since #78
- Wrap the expression with `${{ }}` so GitHub Actions parses it as an expression, not raw YAML

## Impact

All Docker builds have been failing silently since commit `4f4e138`. This fix restores Docker builds on push to main and on release events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)