### PR TITLE
test(queries): increase unit test coverage to 80%

### DIFF
--- a/lib/__tests__/api_helpers.test.ts
+++ b/lib/__tests__/api_helpers.test.ts
@@ -1,0 +1,124 @@
+// lib/__tests__/api_helpers.test.ts
+// Tests for the pure/synchronous helpers in lib/api.ts
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { HttpError, notFound, badRequest, forbidden, readBody, readId } from "../api";
+
+describe("HttpError", () => {
+  it("creates an error with the given status and message", () => {
+    const err = new HttpError(404, "Not found");
+    expect(err.status).toBe(404);
+    expect(err.message).toBe("Not found");
+    expect(err instanceof Error).toBe(true);
+  });
+});
+
+describe("notFound", () => {
+  it("throws an HttpError with status 404", () => {
+    expect(() => notFound()).toThrow(HttpError);
+    try {
+      notFound();
+    } catch (err) {
+      expect((err as HttpError).status).toBe(404);
+    }
+  });
+
+  it("uses the provided message", () => {
+    try {
+      notFound("Custom not found");
+    } catch (err) {
+      expect((err as HttpError).message).toBe("Custom not found");
+    }
+  });
+});
+
+describe("badRequest", () => {
+  it("throws an HttpError with status 400", () => {
+    expect(() => badRequest()).toThrow(HttpError);
+    try {
+      badRequest();
+    } catch (err) {
+      expect((err as HttpError).status).toBe(400);
+    }
+  });
+
+  it("uses the provided message", () => {
+    try {
+      badRequest("Missing field");
+    } catch (err) {
+      expect((err as HttpError).message).toBe("Missing field");
+    }
+  });
+});
+
+describe("forbidden", () => {
+  it("throws an HttpError with status 403", () => {
+    expect(() => forbidden()).toThrow(HttpError);
+    try {
+      forbidden();
+    } catch (err) {
+      expect((err as HttpError).status).toBe(403);
+    }
+  });
+});
+
+describe("readBody", () => {
+  it("parses and validates a valid JSON body", async () => {
+    const schema = z.object({ name: z.string(), amount: z.number() });
+    const req = new Request("http://localhost/api/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Alice", amount: 42 }),
+    });
+    const body = await readBody(req, schema);
+    expect(body.name).toBe("Alice");
+    expect(body.amount).toBe(42);
+  });
+
+  it("throws a ZodError for invalid body", async () => {
+    const schema = z.object({ name: z.string(), amount: z.number() });
+    const req = new Request("http://localhost/api/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Alice" }), // missing amount
+    });
+    await expect(readBody(req, schema)).rejects.toThrow();
+  });
+
+  it("calls badRequest for invalid JSON", async () => {
+    const schema = z.object({ name: z.string() });
+    const req = new Request("http://localhost/api/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-valid-json",
+    });
+    await expect(readBody(req, schema)).rejects.toThrow(HttpError);
+  });
+});
+
+describe("readId", () => {
+  it("parses a valid positive integer id", async () => {
+    const ctx = { params: Promise.resolve({ id: "42" }) };
+    expect(await readId(ctx)).toBe(42);
+  });
+
+  it("throws badRequest for non-numeric id", async () => {
+    const ctx = { params: Promise.resolve({ id: "abc" }) };
+    await expect(readId(ctx)).rejects.toThrow(HttpError);
+  });
+
+  it("throws badRequest for zero id", async () => {
+    const ctx = { params: Promise.resolve({ id: "0" }) };
+    await expect(readId(ctx)).rejects.toThrow(HttpError);
+  });
+
+  it("throws badRequest for negative id", async () => {
+    const ctx = { params: Promise.resolve({ id: "-5" }) };
+    await expect(readId(ctx)).rejects.toThrow(HttpError);
+  });
+
+  it("throws badRequest for float id", async () => {
+    const ctx = { params: Promise.resolve({ id: "3.14" }) };
+    await expect(readId(ctx)).rejects.toThrow(HttpError);
+  });
+});

--- a/lib/__tests__/paper_theme.test.ts
+++ b/lib/__tests__/paper_theme.test.ts
@@ -1,0 +1,81 @@
+// lib/__tests__/paper_theme.test.ts
+import { describe, it, expect } from "vitest";
+import { fmtMoney, fmtKm, fmtDate, fmtYearMonth } from "../paper-theme";
+
+describe("fmtMoney", () => {
+  it("formats a positive euro amount", () => {
+    // nl-BE: 1234.56 → "€ 1.234,56"
+    const result = fmtMoney(1234.56);
+    expect(result).toContain("€");
+    expect(result).toContain("1");
+    expect(result).toContain("234");
+  });
+
+  it("formats zero as two decimal places", () => {
+    expect(fmtMoney(0)).toContain("0,00");
+  });
+
+  it("uses absolute value (no minus sign)", () => {
+    const pos = fmtMoney(50);
+    const neg = fmtMoney(-50);
+    expect(pos).toBe(neg);
+  });
+});
+
+describe("fmtKm", () => {
+  it("appends km unit", () => {
+    expect(fmtKm(100)).toContain("km");
+  });
+
+  it("formats zero km", () => {
+    expect(fmtKm(0)).toContain("0");
+  });
+
+  it("formats large values with thousands separator", () => {
+    const result = fmtKm(12000);
+    expect(result).toContain("12");
+    expect(result).toContain("km");
+  });
+});
+
+describe("fmtDate", () => {
+  it("formats a date in Dutch (default)", () => {
+    const result = fmtDate("2026-06-01");
+    // June 1 2026 is a Monday → 'ma' in nl
+    expect(result).toContain("ma");
+    expect(result).toContain("jun");
+    expect(result).toContain("1");
+  });
+
+  it("formats a date in English", () => {
+    const result = fmtDate("2026-06-01", "en");
+    expect(result).toContain("Mon");
+    expect(result).toContain("Jun");
+  });
+
+  it("handles different months", () => {
+    const jan = fmtDate("2026-01-15", "nl");
+    expect(jan).toContain("jan");
+    const dec = fmtDate("2026-12-25", "nl");
+    expect(dec).toContain("dec");
+  });
+});
+
+describe("fmtYearMonth", () => {
+  it("formats year-month in Dutch", () => {
+    const result = fmtYearMonth("2026-03", "nl");
+    expect(result).toContain("mrt");
+    expect(result).toContain("2026");
+  });
+
+  it("formats year-month in English", () => {
+    const result = fmtYearMonth("2026-03", "en");
+    expect(result).toContain("Mar");
+    expect(result).toContain("2026");
+  });
+
+  it("uses Dutch as default locale", () => {
+    const result = fmtYearMonth("2026-05");
+    expect(result).toContain("mei");
+  });
+});

--- a/lib/__tests__/queries_admin.test.ts
+++ b/lib/__tests__/queries_admin.test.ts
@@ -1,0 +1,503 @@
+// lib/__tests__/queries_admin.test.ts
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../db/migrate";
+import { insertPerson } from "../queries/people";
+import { insertCar } from "../queries/cars";
+import { insertTrip } from "../queries/trips";
+import { insertFuelFillup } from "../queries/fuel-fillups";
+import { insertExpense } from "../queries/expenses";
+import {
+  getCarPnL,
+  getMonthlyCarKm,
+  getPersonContributions,
+  getHistoricalCarKm,
+  getPriceHistory,
+  getZeroKmTrips,
+  getKmGaps,
+} from "../queries/admin";
+
+function makeDb() {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  runMigrations(db);
+  return db;
+}
+
+const basePerson = {
+  discount: 0,
+  discount_long: 0,
+  active: 1 as const,
+  username: null,
+  password_hash: null,
+  is_admin: 0 as const,
+};
+
+describe("getCarPnL", () => {
+  it("returns empty array when no cars exist", () => {
+    const db = makeDb();
+    expect(getCarPnL(db, 2026)).toEqual([]);
+  });
+
+  it("returns a car with zero aggregates when no trips/fuel/expenses", () => {
+    const db = makeDb();
+    insertCar(db, { short: "CA", name: "Car A", price_per_km: 0.2, brand: null, color: null });
+    const pnl = getCarPnL(db, 2026);
+    expect(pnl).toHaveLength(1);
+    expect(pnl[0].car_short).toBe("CA");
+    expect(pnl[0].trip_count).toBe(0);
+    expect(pnl[0].trip_km).toBe(0);
+    expect(pnl[0].cost_per_km).toBe(0);
+  });
+
+  it("aggregates trips, fuel and expenses for the correct year", () => {
+    const db = makeDb();
+    const pid = insertPerson(db, { ...basePerson, name: "Alice" });
+    const cid = insertCar(db, {
+      short: "CA",
+      name: "Car A",
+      price_per_km: 0.2,
+      brand: null,
+      color: null,
+    });
+    insertTrip(db, {
+      person_id: pid,
+      car_id: cid,
+      date: "2026-03-01",
+      start_odometer: 0,
+      end_odometer: 100,
+      location: null,
+    });
+    insertFuelFillup(db, {
+      person_id: pid,
+      car_id: cid,
+      date: "2026-04-01",
+      amount: 60,
+      liters: 40,
+      odometer: null,
+      receipt: null,
+      location: null,
+    });
+    insertExpense(db, {
+      person_id: pid,
+      car_id: cid,
+      date: "2026-05-01",
+      amount: 30,
+      description: "Oil",
+    });
+    const pnl = getCarPnL(db, 2026);
+    expect(pnl[0].trip_count).toBe(1);
+    expect(pnl[0].trip_km).toBe(100);
+    expect(pnl[0].fuel_count).toBe(1);
+    expect(pnl[0].fuel_amount).toBe(60);
+    expect(pnl[0].expense_count).toBe(1);
+    expect(pnl[0].expense_amount).toBe(30);
+    expect(pnl[0].variable_total).toBe(90);
+    expect(pnl[0].total_cost).toBe(90);
+    expect(pnl[0].cost_per_km).toBeCloseTo(0.9);
+  });
+
+  it("does not include activities from other years", () => {
+    const db = makeDb();
+    const pid = insertPerson(db, { ...basePerson, name: "Alice" });
+    const cid = insertCar(db, {
+      short: "CA",
+      name: "Car A",
+      price_per_km: 0.2,
+      brand: null,
+      color: null,
+    });
+    insertTrip(db, {
+      person_id: pid,
+      car_id: cid,
+      date: "2025-03-01",
+      start_odometer: 0,
+      end_odometer: 200,
+      location: null,
+    });
+    const pnl = getCarPnL(db, 2026);
+    expect(pnl[0].trip_count).toBe(0);
+  });
+
+  it("parses fixed_costs_json (array format)", () => {
+    const db = makeDb();
+    const fixedCosts = JSON.stringify([
+      { id: "f1", category: "verzekeringen", description: "Insurance", amount: 500 },
+      { id: "f2", category: "belastingen", description: "Tax", amount: 200 },
+    ]);
+    insertCar(db, {
+      short: "CA",
+      name: "Car A",
+      price_per_km: 0.2,
+      brand: null,
+      color: null,
+      fixed_costs_json: fixedCosts,
+    });
+    const pnl = getCarPnL(db, 2026);
+    expect(pnl[0].fixed_costs).toHaveLength(2);
+    expect(pnl[0].fixed_total).toBe(700);
+  });
+
+  it("handles legacy fixed_costs_json format", () => {
+    const db = makeDb();
+    const legacyCosts = JSON.stringify({
+      verzekering: 300,
+      belasting: 150,
+      keuring: 100,
+      afschrijving: 0,
+    });
+    insertCar(db, {
+      short: "CA",
+      name: "Car A",
+      price_per_km: 0.2,
+      brand: null,
+      color: null,
+      fixed_costs_json: legacyCosts,
+    });
+    const pnl = getCarPnL(db, 2026);
+    // Entries with value > 0 only: verzekering(300) + belasting(150) + keuring(100) = 3 items
+    expect(pnl[0].fixed_costs.length).toBeGreaterThanOrEqual(3);
+    expect(pnl[0].fixed_total).toBe(550);
+  });
+
+  it("handles invalid fixed_costs_json gracefully", () => {
+    const db = makeDb();
+    db.exec(
+      `INSERT INTO cars (short,name,price_per_km,fixed_costs_json) VALUES ('CA','Car A',0.2,'not-json')`
+    );
+    const pnl = getCarPnL(db, 2026);
+    expect(pnl[0].fixed_costs).toEqual([]);
+    expect(pnl[0].fixed_total).toBe(0);
+  });
+
+  it("computes owner_trip_amount for owner's own car trips", () => {
+    const db = makeDb();
+    const pid = insertPerson(db, { ...basePerson, name: "Alice" });
+    insertCar(db, {
+      short: "CA",
+      name: "Car A",
+      price_per_km: 0.2,
+      brand: null,
+      color: null,
+      owner_name: "Alice",
+    });
+    const cid = (db.prepare("SELECT id FROM cars WHERE short='CA'").get() as any).id;
+    insertTrip(db, {
+      person_id: pid,
+      car_id: cid,
+      date: "2026-01-01",
+      start_odometer: 0,
+      end_odometer: 100,
+      location: null,
+    });
+    const pnl = getCarPnL(db, 2026);
+    expect(pnl[0].owner_trip_amount).toBeGreaterThan(0);
+  });
+
+  it("includes previous year km in prev_year_trip_km", () => {
+    const db = makeDb();
+    const pid = insertPerson(db, { ...basePerson, name: "Alice" });
+    const cid = insertCar(db, {
+      short: "CA",
+      name: "Car A",
+      price_per_km: 0.2,
+      brand: null,
+      color: null,
+    });
+    insertTrip(db, {
+      person_id: pid,
+      car_id: cid,
+      date: "2025-06-01",
+      start_odometer: 0,
+      end_odometer: 300,
+      location: null,
+    });
+    const pnl = getCarPnL(db, 2026);
+    expect(pnl[0].prev_year_trip_km).toBe(300);
+  });
+});
+
+describe("getMonthlyCarKm", () => {
+  it("returns empty array when no trips for a year with no activity", () => {
+    const db = makeDb();
+    // 2020 has no trips in the migration data — safe year to use
+    expect(getMonthlyCarKm(db, 2020)).toEqual([]);
+  });
+
+  it("returns monthly km per car for the inserted car only", () => {
+    const db = makeDb();
+    const pid = insertPerson(db, { ...basePerson, name: "Alice" });
+    const cid = insertCar(db, {
+      short: "CA",
+      name: "Car A",
+      price_per_km: 0.2,
+      brand: null,
+      color: null,
+    });
+    insertTrip(db, {
+      person_id: pid,
+      car_id: cid,
+      date: "2026-03-01",
+      start_odometer: 0,
+      end_odometer: 100,
+      location: null,
+    });
+    insertTrip(db, {
+      person_id: pid,
+      car_id: cid,
+      date: "2026-03-15",
+      start_odometer: 100,
+      end_odometer: 200,
+      location: null,
+    });
+    insertTrip(db, {
+      person_id: pid,
+      car_id: cid,
+      date: "2026-04-01",
+      start_odometer: 200,
+      end_odometer: 350,
+      location: null,
+    });
+    const monthly = getMonthlyCarKm(db, 2026);
+    // Filter to only the car we inserted (migration data may include other car_ids)
+    const ourMonthly = monthly.filter((m) => m.car_id === cid);
+    expect(ourMonthly).toHaveLength(2);
+    const march = ourMonthly.find((m) => m.year_month === "2026-03");
+    const april = ourMonthly.find((m) => m.year_month === "2026-04");
+    expect(march?.km).toBe(200);
+    expect(april?.km).toBe(150);
+  });
+});
+
+describe("getPersonContributions", () => {
+  it("returns empty array when no trips", () => {
+    const db = makeDb();
+    expect(getPersonContributions(db, 2026)).toEqual([]);
+  });
+
+  it("returns contributions per person per car", () => {
+    const db = makeDb();
+    const pid1 = insertPerson(db, { ...basePerson, name: "Alice" });
+    const pid2 = insertPerson(db, { ...basePerson, name: "Bob" });
+    const cid = insertCar(db, {
+      short: "CA",
+      name: "Car A",
+      price_per_km: 0.2,
+      brand: null,
+      color: null,
+    });
+    insertTrip(db, {
+      person_id: pid1,
+      car_id: cid,
+      date: "2026-03-01",
+      start_odometer: 0,
+      end_odometer: 100,
+      location: null,
+    });
+    insertTrip(db, {
+      person_id: pid2,
+      car_id: cid,
+      date: "2026-03-02",
+      start_odometer: 100,
+      end_odometer: 250,
+      location: null,
+    });
+    const contribs = getPersonContributions(db, 2026);
+    expect(contribs).toHaveLength(2);
+    const bob = contribs.find((c) => c.person_name === "Bob");
+    expect(bob?.km).toBe(150);
+  });
+});
+
+describe("getHistoricalCarKm", () => {
+  it("returns empty array when no trips in the 6-year window (far future year)", () => {
+    const db = makeDb();
+    // 2060: migration data (2022, 2023, 2026) falls outside the window 2054-2059
+    expect(getHistoricalCarKm(db, 2060)).toEqual([]);
+  });
+
+  it("returns km grouped by car and year for past 6 years", () => {
+    const db = makeDb();
+    const pid = insertPerson(db, { ...basePerson, name: "Alice" });
+    const cid = insertCar(db, {
+      short: "CA",
+      name: "Car A",
+      price_per_km: 0.2,
+      brand: null,
+      color: null,
+    });
+    insertTrip(db, {
+      person_id: pid,
+      car_id: cid,
+      date: "2022-06-01",
+      start_odometer: 0,
+      end_odometer: 500,
+      location: null,
+    });
+    const hist = getHistoricalCarKm(db, 2026);
+    // Filter to the car we inserted; migration data may have other entries for car_id=2
+    const ourHist = hist.filter((h) => h.car_id === cid);
+    expect(ourHist.some((h) => h.year === 2022 && h.km === 500)).toBe(true);
+  });
+});
+
+describe("getPriceHistory", () => {
+  it("returns empty array when no cars", () => {
+    const db = makeDb();
+    expect(getPriceHistory(db)).toEqual([]);
+  });
+
+  it("returns price history entries from car inserts", () => {
+    const db = makeDb();
+    insertCar(db, { short: "CA", name: "Car A", price_per_km: 0.25, brand: null, color: null });
+    const history = getPriceHistory(db);
+    expect(history).toHaveLength(1);
+    expect(history[0].price_per_km).toBe(0.25);
+  });
+});
+
+describe("getZeroKmTrips", () => {
+  it("returns empty array when no zero-km trips", () => {
+    const db = makeDb();
+    const pid = insertPerson(db, { ...basePerson, name: "Alice" });
+    const cid = insertCar(db, {
+      short: "CA",
+      name: "Car A",
+      price_per_km: 0.2,
+      brand: null,
+      color: null,
+    });
+    insertTrip(db, {
+      person_id: pid,
+      car_id: cid,
+      date: "2026-01-01",
+      start_odometer: 0,
+      end_odometer: 100,
+      location: null,
+    });
+    expect(getZeroKmTrips(db)).toEqual([]);
+  });
+
+  it("returns trips where km=0", () => {
+    const db = makeDb();
+    const pid = insertPerson(db, { ...basePerson, name: "Alice" });
+    const cid = insertCar(db, {
+      short: "CA",
+      name: "Car A",
+      price_per_km: 0.2,
+      brand: null,
+      color: null,
+    });
+    // Insert a trip with start == end (0 km)
+    insertTrip(db, {
+      person_id: pid,
+      car_id: cid,
+      date: "2026-01-01",
+      start_odometer: 100,
+      end_odometer: 100,
+      location: null,
+    });
+    const zeros = getZeroKmTrips(db);
+    expect(zeros).toHaveLength(1);
+    expect(zeros[0].car_short).toBe("CA");
+    expect(zeros[0].person_name).toBe("Alice");
+  });
+});
+
+describe("getKmGaps", () => {
+  it("returns empty array when no cars", () => {
+    const db = makeDb();
+    expect(getKmGaps(db)).toEqual([]);
+  });
+
+  it("returns empty array when trips are contiguous", () => {
+    const db = makeDb();
+    const pid = insertPerson(db, { ...basePerson, name: "Alice" });
+    const cid = insertCar(db, {
+      short: "CA",
+      name: "Car A",
+      price_per_km: 0.2,
+      brand: null,
+      color: null,
+    });
+    insertTrip(db, {
+      person_id: pid,
+      car_id: cid,
+      date: "2026-01-01",
+      start_odometer: 0,
+      end_odometer: 100,
+      location: null,
+    });
+    insertTrip(db, {
+      person_id: pid,
+      car_id: cid,
+      date: "2026-01-02",
+      start_odometer: 100,
+      end_odometer: 200,
+      location: null,
+    });
+    expect(getKmGaps(db)).toHaveLength(0);
+  });
+
+  it("detects gaps between non-contiguous trips", () => {
+    const db = makeDb();
+    const pid = insertPerson(db, { ...basePerson, name: "Alice" });
+    const cid = insertCar(db, {
+      short: "CA",
+      name: "Car A",
+      price_per_km: 0.2,
+      brand: null,
+      color: null,
+    });
+    insertTrip(db, {
+      person_id: pid,
+      car_id: cid,
+      date: "2026-01-01",
+      start_odometer: 0,
+      end_odometer: 100,
+      location: null,
+    });
+    insertTrip(db, {
+      person_id: pid,
+      car_id: cid,
+      date: "2026-01-10",
+      start_odometer: 150,
+      end_odometer: 200,
+      location: null,
+    });
+    const gaps = getKmGaps(db);
+    expect(gaps).toHaveLength(1);
+    expect(gaps[0].car_short).toBe("CA");
+    expect(gaps[0].missing_km).toBe(50);
+  });
+
+  it("does not flag a gap when difference is <=1 km", () => {
+    const db = makeDb();
+    const pid = insertPerson(db, { ...basePerson, name: "Alice" });
+    const cid = insertCar(db, {
+      short: "CA",
+      name: "Car A",
+      price_per_km: 0.2,
+      brand: null,
+      color: null,
+    });
+    insertTrip(db, {
+      person_id: pid,
+      car_id: cid,
+      date: "2026-01-01",
+      start_odometer: 0,
+      end_odometer: 100,
+      location: null,
+    });
+    // start_odometer exactly 1 more than end_odometer of previous — boundary case
+    insertTrip(db, {
+      person_id: pid,
+      car_id: cid,
+      date: "2026-01-10",
+      start_odometer: 101,
+      end_odometer: 200,
+      location: null,
+    });
+    expect(getKmGaps(db)).toHaveLength(0);
+  });
+});

--- a/lib/__tests__/queries_cars.test.ts
+++ b/lib/__tests__/queries_cars.test.ts
@@ -1,0 +1,155 @@
+// lib/__tests__/queries_cars.test.ts
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../db/migrate";
+import { getCars, getCarById, insertCar, updateCar } from "../queries/cars";
+
+function makeDb() {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  runMigrations(db);
+  return db;
+}
+
+const baseCar = {
+  short: "CA",
+  name: "Car A",
+  price_per_km: 0.2,
+  brand: "Toyota" as string | null,
+  color: "red" as string | null,
+};
+
+describe("getCars", () => {
+  it("returns empty array when no cars exist", () => {
+    const db = makeDb();
+    expect(getCars(db)).toEqual([]);
+  });
+
+  it("returns all cars ordered by short", () => {
+    const db = makeDb();
+    insertCar(db, { ...baseCar, short: "ZZ", name: "Zara" });
+    insertCar(db, { ...baseCar, short: "AA", name: "Alpha" });
+    const cars = getCars(db);
+    expect(cars[0].short).toBe("AA");
+    expect(cars[1].short).toBe("ZZ");
+  });
+});
+
+describe("getCarById", () => {
+  it("returns the correct car", () => {
+    const db = makeDb();
+    const id = insertCar(db, baseCar);
+    const car = getCarById(db, id);
+    expect(car?.id).toBe(id);
+    expect(car?.short).toBe("CA");
+    expect(car?.price_per_km).toBe(0.2);
+  });
+
+  it("returns null for a non-existent id", () => {
+    const db = makeDb();
+    expect(getCarById(db, 9999)).toBeNull();
+  });
+});
+
+describe("insertCar", () => {
+  it("returns a numeric id", () => {
+    const db = makeDb();
+    const id = insertCar(db, baseCar);
+    expect(typeof id).toBe("number");
+    expect(id).toBeGreaterThan(0);
+  });
+
+  it("records price history on insert", () => {
+    const db = makeDb();
+    const id = insertCar(db, { ...baseCar, price_per_km: 0.3 });
+    const history = db.prepare("SELECT * FROM car_price_history WHERE car_id=?").all(id) as any[];
+    expect(history).toHaveLength(1);
+    expect(history[0].price_per_km).toBe(0.3);
+  });
+
+  it("uses default long_threshold of 500 when not provided", () => {
+    const db = makeDb();
+    const id = insertCar(db, baseCar);
+    const car = getCarById(db, id);
+    expect(car?.long_threshold).toBe(500);
+  });
+
+  it("stores owner_name when provided", () => {
+    const db = makeDb();
+    const id = insertCar(db, { ...baseCar, owner_name: "Alice" });
+    const car = getCarById(db, id);
+    expect(car?.owner_name).toBe("Alice");
+  });
+
+  it("stores null brand and color", () => {
+    const db = makeDb();
+    const id = insertCar(db, { ...baseCar, brand: null, color: null });
+    const car = getCarById(db, id);
+    expect(car?.brand).toBeNull();
+    expect(car?.color).toBeNull();
+  });
+});
+
+describe("updateCar", () => {
+  it("updates car fields", () => {
+    const db = makeDb();
+    const id = insertCar(db, baseCar);
+    updateCar(db, id, {
+      ...baseCar,
+      short: "CB",
+      name: "Car B",
+      price_per_km: 0.25,
+      brand: "Ford",
+      color: "blue",
+    });
+    const car = getCarById(db, id);
+    expect(car?.short).toBe("CB");
+    expect(car?.name).toBe("Car B");
+    expect(car?.price_per_km).toBe(0.25);
+    expect(car?.brand).toBe("Ford");
+    expect(car?.color).toBe("blue");
+  });
+
+  it("records price history when price changes", () => {
+    const db = makeDb();
+    const id = insertCar(db, { ...baseCar, price_per_km: 0.2 });
+    // Update with a different price
+    updateCar(db, id, { ...baseCar, price_per_km: 0.35 });
+    const history = db
+      .prepare("SELECT * FROM car_price_history WHERE car_id=? ORDER BY id")
+      .all(id) as any[];
+    // One from insert, one from update
+    expect(history).toHaveLength(2);
+    expect(history[1].price_per_km).toBe(0.35);
+  });
+
+  it("does NOT record price history when price stays the same", () => {
+    const db = makeDb();
+    const id = insertCar(db, { ...baseCar, price_per_km: 0.2 });
+    updateCar(db, id, { ...baseCar, price_per_km: 0.2 });
+    const history = db.prepare("SELECT * FROM car_price_history WHERE car_id=?").all(id) as any[];
+    // Only the initial insert entry
+    expect(history).toHaveLength(1);
+  });
+
+  it("sets active flag", () => {
+    const db = makeDb();
+    const id = insertCar(db, baseCar);
+    updateCar(db, id, { ...baseCar, active: 0 });
+    const car = getCarById(db, id);
+    expect(car?.active).toBe(0);
+  });
+
+  it("sets expected_km when provided", () => {
+    const db = makeDb();
+    const id = insertCar(db, baseCar);
+    updateCar(db, id, { ...baseCar, expected_km: 15000 });
+    const car = getCarById(db, id);
+    expect(car?.expected_km).toBe(15000);
+  });
+
+  it("does nothing for non-existent id without throwing", () => {
+    const db = makeDb();
+    expect(() => updateCar(db, 9999, baseCar)).not.toThrow();
+  });
+});

--- a/lib/__tests__/queries_expenses.test.ts
+++ b/lib/__tests__/queries_expenses.test.ts
@@ -1,0 +1,286 @@
+// lib/__tests__/queries_expenses.test.ts
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../db/migrate";
+import {
+  getExpenses,
+  getExpenseById,
+  insertExpense,
+  updateExpense,
+  deleteExpense,
+  ConflictError,
+} from "../queries/expenses";
+
+function makeDb() {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  runMigrations(db);
+  return db;
+}
+
+function seed(db: Database.Database) {
+  db.exec(`INSERT INTO people (id, name, active) VALUES (1, 'Alice', 1), (2, 'Bob', 1)`);
+  db.exec(
+    `INSERT INTO cars (id, short, name, price_per_km, owner_name, owner_from, active) VALUES (1, 'CA', 'Car A', 0.2, 'Alice', '2020-01-01', 1)`
+  );
+}
+
+describe("getExpenses", () => {
+  it("returns empty array when no expenses exist", () => {
+    const db = makeDb();
+    seed(db);
+    expect(getExpenses(db)).toEqual([]);
+  });
+
+  it("returns all expenses with joined person_name and car_short", () => {
+    const db = makeDb();
+    seed(db);
+    insertExpense(db, {
+      person_id: 1,
+      car_id: 1,
+      date: "2026-03-01",
+      amount: 50,
+      description: "Oil change",
+    });
+    const list = getExpenses(db);
+    expect(list).toHaveLength(1);
+    expect(list[0].person_name).toBe("Alice");
+    expect(list[0].car_short).toBe("CA");
+    expect(list[0].amount).toBe(50);
+  });
+
+  it("orders by date DESC then id DESC", () => {
+    const db = makeDb();
+    seed(db);
+    insertExpense(db, {
+      person_id: 1,
+      car_id: 1,
+      date: "2026-03-01",
+      amount: 10,
+      description: "First",
+    });
+    insertExpense(db, {
+      person_id: 1,
+      car_id: 1,
+      date: "2026-04-01",
+      amount: 20,
+      description: "Second",
+    });
+    const list = getExpenses(db);
+    expect(list[0].description).toBe("Second");
+    expect(list[1].description).toBe("First");
+  });
+});
+
+describe("getExpenseById", () => {
+  it("returns the correct expense", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertExpense(db, {
+      person_id: 1,
+      car_id: 1,
+      date: "2026-03-01",
+      amount: 75,
+      description: "Tires",
+    });
+    const expense = getExpenseById(db, id);
+    expect(expense?.id).toBe(id);
+    expect(expense?.amount).toBe(75);
+    expect(expense?.description).toBe("Tires");
+    expect(expense?.person_name).toBe("Alice");
+  });
+
+  it("returns null for a non-existent id", () => {
+    const db = makeDb();
+    seed(db);
+    expect(getExpenseById(db, 9999)).toBeNull();
+  });
+});
+
+describe("insertExpense", () => {
+  it("returns a numeric id", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertExpense(db, {
+      person_id: 1,
+      car_id: 1,
+      date: "2026-01-01",
+      amount: 30,
+      description: "wash",
+    });
+    expect(typeof id).toBe("number");
+    expect(id).toBeGreaterThan(0);
+  });
+
+  it("stores category when provided", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertExpense(db, {
+      person_id: 1,
+      car_id: 1,
+      date: "2026-01-01",
+      amount: 100,
+      description: "Insurance",
+      category: "verzekering",
+    });
+    expect(getExpenseById(db, id)?.category).toBe("verzekering");
+  });
+
+  it("stores settled_outside flag", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertExpense(db, {
+      person_id: 1,
+      car_id: 1,
+      date: "2026-01-01",
+      amount: 50,
+      description: "External",
+      settled_outside: 1,
+    });
+    expect(getExpenseById(db, id)?.settled_outside).toBe(1);
+  });
+
+  it("idempotency: returns existing id when client_id already exists", () => {
+    const db = makeDb();
+    seed(db);
+    const id1 = insertExpense(db, {
+      person_id: 1,
+      car_id: 1,
+      date: "2026-01-01",
+      amount: 50,
+      description: "First",
+      client_id: "expense-abc",
+    });
+    const id2 = insertExpense(db, {
+      person_id: 1,
+      car_id: 1,
+      date: "2026-02-01",
+      amount: 99,
+      description: "Second",
+      client_id: "expense-abc",
+    });
+    expect(id2).toBe(id1);
+    expect(getExpenses(db)).toHaveLength(1);
+  });
+
+  it("stores null description when not provided", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertExpense(db, {
+      person_id: 1,
+      car_id: 1,
+      date: "2026-01-01",
+      amount: 40,
+      description: null,
+    });
+    expect(getExpenseById(db, id)?.description).toBeNull();
+  });
+});
+
+describe("updateExpense", () => {
+  it("updates all fields of an expense", () => {
+    const db = makeDb();
+    seed(db);
+    db.exec(`INSERT INTO people (id, name, active) VALUES (3, 'Carol', 1)`);
+    const id = insertExpense(db, {
+      person_id: 1,
+      car_id: 1,
+      date: "2026-01-01",
+      amount: 30,
+      description: "Old",
+    });
+    updateExpense(db, id, {
+      person_id: 3,
+      car_id: 1,
+      date: "2026-06-01",
+      amount: 99,
+      description: "New description",
+      category: "onderhoud",
+      settled_outside: 1,
+    });
+    const expense = getExpenseById(db, id);
+    expect(expense?.person_name).toBe("Carol");
+    expect(expense?.date).toBe("2026-06-01");
+    expect(expense?.amount).toBe(99);
+    expect(expense?.description).toBe("New description");
+    expect(expense?.category).toBe("onderhoud");
+    expect(expense?.settled_outside).toBe(1);
+  });
+
+  it("with expectedUpdatedAt: succeeds when timestamp matches", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertExpense(db, {
+      person_id: 1,
+      car_id: 1,
+      date: "2026-01-01",
+      amount: 30,
+      description: "Check",
+    });
+    const expense = getExpenseById(db, id)!;
+    expect(() =>
+      updateExpense(
+        db,
+        id,
+        { person_id: 1, car_id: 1, date: "2026-01-01", amount: 30, description: "Updated" },
+        { expectedUpdatedAt: expense.updated_at }
+      )
+    ).not.toThrow();
+  });
+
+  it("with expectedUpdatedAt: throws ConflictError when timestamp mismatches", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertExpense(db, {
+      person_id: 1,
+      car_id: 1,
+      date: "2026-01-01",
+      amount: 30,
+      description: "Check",
+    });
+    expect(() =>
+      updateExpense(
+        db,
+        id,
+        { person_id: 1, car_id: 1, date: "2026-01-01", amount: 30, description: "X" },
+        { expectedUpdatedAt: "1999-01-01 00:00:00" }
+      )
+    ).toThrow(ConflictError);
+  });
+
+  it("with expectedUpdatedAt: throws ConflictError when expense no longer exists", () => {
+    const db = makeDb();
+    seed(db);
+    expect(() =>
+      updateExpense(
+        db,
+        9999,
+        { person_id: 1, car_id: 1, date: "2026-01-01", amount: 10, description: "Ghost" },
+        { expectedUpdatedAt: "2026-01-01 00:00:00" }
+      )
+    ).toThrow(ConflictError);
+  });
+});
+
+describe("deleteExpense", () => {
+  it("removes the expense from the DB", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertExpense(db, {
+      person_id: 1,
+      car_id: 1,
+      date: "2026-01-01",
+      amount: 30,
+      description: "Delete me",
+    });
+    deleteExpense(db, id);
+    expect(getExpenseById(db, id)).toBeNull();
+    expect(getExpenses(db)).toHaveLength(0);
+  });
+
+  it("does not throw for non-existent id", () => {
+    const db = makeDb();
+    seed(db);
+    expect(() => deleteExpense(db, 9999)).not.toThrow();
+  });
+});

--- a/lib/__tests__/queries_fuel_fillups.test.ts
+++ b/lib/__tests__/queries_fuel_fillups.test.ts
@@ -1,0 +1,229 @@
+// lib/__tests__/queries_fuel_fillups.test.ts
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../db/migrate";
+import {
+  getFuelFillups,
+  getFuelFillupById,
+  insertFuelFillup,
+  updateFuelFillup,
+  deleteFuelFillup,
+  ConflictError,
+} from "../queries/fuel-fillups";
+
+function makeDb() {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  runMigrations(db);
+  return db;
+}
+
+function seed(db: Database.Database) {
+  db.exec(`INSERT INTO people (id, name, active) VALUES (1, 'Alice', 1), (2, 'Bob', 1)`);
+  db.exec(
+    `INSERT INTO cars (id, short, name, price_per_km, owner_name, owner_from, active) VALUES (1, 'CA', 'Car A', 0.2, 'Alice', '2020-01-01', 1)`
+  );
+}
+
+const baseFillup = {
+  person_id: 1,
+  car_id: 1,
+  date: "2026-03-15",
+  amount: 60,
+  liters: 40,
+  odometer: 12000,
+  receipt: null,
+  location: "Shell Station",
+};
+
+describe("getFuelFillups", () => {
+  it("returns empty array when no fillups exist", () => {
+    const db = makeDb();
+    seed(db);
+    expect(getFuelFillups(db)).toEqual([]);
+  });
+
+  it("returns fillups with joined person_name and car_short", () => {
+    const db = makeDb();
+    seed(db);
+    insertFuelFillup(db, baseFillup);
+    const list = getFuelFillups(db);
+    expect(list).toHaveLength(1);
+    expect(list[0].person_name).toBe("Alice");
+    expect(list[0].car_short).toBe("CA");
+    expect(list[0].amount).toBe(60);
+  });
+
+  it("orders by date DESC then id DESC", () => {
+    const db = makeDb();
+    seed(db);
+    insertFuelFillup(db, { ...baseFillup, date: "2026-01-01", amount: 30 });
+    insertFuelFillup(db, { ...baseFillup, date: "2026-05-01", amount: 70 });
+    const list = getFuelFillups(db);
+    expect(list[0].amount).toBe(70);
+    expect(list[1].amount).toBe(30);
+  });
+});
+
+describe("getFuelFillupById", () => {
+  it("returns the correct fillup", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertFuelFillup(db, baseFillup);
+    const fillup = getFuelFillupById(db, id);
+    expect(fillup?.id).toBe(id);
+    expect(fillup?.liters).toBe(40);
+    expect(fillup?.location).toBe("Shell Station");
+    expect(fillup?.person_name).toBe("Alice");
+  });
+
+  it("returns null for a non-existent id", () => {
+    const db = makeDb();
+    seed(db);
+    expect(getFuelFillupById(db, 9999)).toBeNull();
+  });
+});
+
+describe("insertFuelFillup", () => {
+  it("returns a numeric id", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertFuelFillup(db, baseFillup);
+    expect(typeof id).toBe("number");
+    expect(id).toBeGreaterThan(0);
+  });
+
+  it("computes price_per_liter automatically", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertFuelFillup(db, { ...baseFillup, amount: 60, liters: 40 });
+    const fillup = getFuelFillupById(db, id);
+    expect(fillup?.price_per_liter).toBeCloseTo(1.5);
+  });
+
+  it("stores full_tank flag", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertFuelFillup(db, { ...baseFillup, full_tank: 1 });
+    expect(getFuelFillupById(db, id)?.full_tank).toBe(1);
+  });
+
+  it("stores settled_outside flag", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertFuelFillup(db, { ...baseFillup, settled_outside: 1 });
+    expect(getFuelFillupById(db, id)?.settled_outside).toBe(1);
+  });
+
+  it("stores gps_coords when provided", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertFuelFillup(db, { ...baseFillup, gps_coords: "51.2,4.4" });
+    expect(getFuelFillupById(db, id)?.gps_coords).toBe("51.2,4.4");
+  });
+
+  it("idempotency: returns existing id when client_id already exists", () => {
+    const db = makeDb();
+    seed(db);
+    const id1 = insertFuelFillup(db, { ...baseFillup, client_id: "fuel-xyz" });
+    const id2 = insertFuelFillup(db, { ...baseFillup, amount: 99, client_id: "fuel-xyz" });
+    expect(id2).toBe(id1);
+    expect(getFuelFillups(db)).toHaveLength(1);
+  });
+
+  it("creates a new row when client_id is null", () => {
+    const db = makeDb();
+    seed(db);
+    insertFuelFillup(db, { ...baseFillup });
+    insertFuelFillup(db, { ...baseFillup });
+    expect(getFuelFillups(db)).toHaveLength(2);
+  });
+});
+
+describe("updateFuelFillup", () => {
+  it("updates all fields of a fillup", () => {
+    const db = makeDb();
+    seed(db);
+    db.exec(`INSERT INTO people (id, name, active) VALUES (3, 'Carol', 1)`);
+    const id = insertFuelFillup(db, baseFillup);
+    updateFuelFillup(db, id, {
+      person_id: 3,
+      car_id: 1,
+      date: "2026-06-20",
+      amount: 80,
+      liters: 50,
+      odometer: 15000,
+      receipt: "receipt.pdf",
+      location: "Total Station",
+      gps_coords: "51.1,4.5",
+      full_tank: 1,
+      settled_outside: 1,
+    });
+    const fillup = getFuelFillupById(db, id);
+    expect(fillup?.person_name).toBe("Carol");
+    expect(fillup?.date).toBe("2026-06-20");
+    expect(fillup?.amount).toBe(80);
+    expect(fillup?.liters).toBe(50);
+    expect(fillup?.odometer).toBe(15000);
+    expect(fillup?.receipt).toBe("receipt.pdf");
+    expect(fillup?.location).toBe("Total Station");
+    expect(fillup?.full_tank).toBe(1);
+    expect(fillup?.settled_outside).toBe(1);
+    // price_per_liter recalculated: 80/50 = 1.6
+    expect(fillup?.price_per_liter).toBeCloseTo(1.6);
+  });
+
+  it("with expectedUpdatedAt: succeeds when timestamp matches", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertFuelFillup(db, baseFillup);
+    const fillup = getFuelFillupById(db, id)!;
+    expect(() =>
+      updateFuelFillup(
+        db,
+        id,
+        { ...baseFillup, amount: 55, liters: 35 },
+        { expectedUpdatedAt: fillup.updated_at }
+      )
+    ).not.toThrow();
+  });
+
+  it("with expectedUpdatedAt: throws ConflictError when timestamp mismatches", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertFuelFillup(db, baseFillup);
+    expect(() =>
+      updateFuelFillup(
+        db,
+        id,
+        { ...baseFillup, amount: 55, liters: 35 },
+        { expectedUpdatedAt: "1999-01-01 00:00:00" }
+      )
+    ).toThrow(ConflictError);
+  });
+
+  it("with expectedUpdatedAt: throws ConflictError when fillup no longer exists", () => {
+    const db = makeDb();
+    seed(db);
+    expect(() =>
+      updateFuelFillup(db, 9999, { ...baseFillup }, { expectedUpdatedAt: "2026-01-01 00:00:00" })
+    ).toThrow(ConflictError);
+  });
+});
+
+describe("deleteFuelFillup", () => {
+  it("removes the fillup from the DB", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertFuelFillup(db, baseFillup);
+    deleteFuelFillup(db, id);
+    expect(getFuelFillupById(db, id)).toBeNull();
+    expect(getFuelFillups(db)).toHaveLength(0);
+  });
+
+  it("does not throw for non-existent id", () => {
+    const db = makeDb();
+    seed(db);
+    expect(() => deleteFuelFillup(db, 9999)).not.toThrow();
+  });
+});

--- a/lib/__tests__/queries_payments.test.ts
+++ b/lib/__tests__/queries_payments.test.ts
@@ -1,0 +1,173 @@
+// lib/__tests__/queries_payments.test.ts
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../db/migrate";
+import {
+  getPayments,
+  getPaymentById,
+  insertPayment,
+  updatePayment,
+  deletePayment,
+} from "../queries/payments";
+
+function makeDb() {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  runMigrations(db);
+  return db;
+}
+
+function seed(db: Database.Database) {
+  db.exec(`INSERT INTO people (id, name, active) VALUES (1, 'Alice', 1), (2, 'Bob', 1)`);
+}
+
+describe("getPayments", () => {
+  it("returns empty array when no payments exist", () => {
+    const db = makeDb();
+    seed(db);
+    expect(getPayments(db)).toEqual([]);
+  });
+
+  it("returns all payments with joined person_name", () => {
+    const db = makeDb();
+    seed(db);
+    insertPayment(db, { person_id: 1, date: "2027-03-01", amount: 150, note: null });
+    const list = getPayments(db);
+    expect(list).toHaveLength(1);
+    expect(list[0].person_name).toBe("Alice");
+    expect(list[0].amount).toBe(150);
+  });
+
+  it("orders by date DESC then id DESC", () => {
+    const db = makeDb();
+    seed(db);
+    insertPayment(db, { person_id: 1, date: "2027-01-01", amount: 10, note: null });
+    insertPayment(db, { person_id: 1, date: "2027-06-01", amount: 20, note: null });
+    const list = getPayments(db);
+    expect(list[0].amount).toBe(20);
+    expect(list[1].amount).toBe(10);
+  });
+});
+
+describe("getPaymentById", () => {
+  it("returns the correct payment", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertPayment(db, {
+      person_id: 1,
+      date: "2027-03-01",
+      amount: 200,
+      note: "Settlement",
+    });
+    const payment = getPaymentById(db, id);
+    expect(payment?.id).toBe(id);
+    expect(payment?.amount).toBe(200);
+    expect(payment?.note).toBe("Settlement");
+    expect(payment?.person_name).toBe("Alice");
+  });
+
+  it("returns null for a non-existent id", () => {
+    const db = makeDb();
+    seed(db);
+    expect(getPaymentById(db, 9999)).toBeNull();
+  });
+});
+
+describe("insertPayment", () => {
+  it("returns a numeric id", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertPayment(db, { person_id: 1, date: "2027-03-01", amount: 100, note: null });
+    expect(typeof id).toBe("number");
+    expect(id).toBeGreaterThan(0);
+  });
+
+  it("computes year as date.year - 1 (payment settles previous year)", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertPayment(db, { person_id: 1, date: "2027-03-15", amount: 100, note: null });
+    const payment = getPaymentById(db, id);
+    expect(payment?.year).toBe(2026);
+  });
+
+  it("stores note when provided", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertPayment(db, {
+      person_id: 1,
+      date: "2027-03-01",
+      amount: 50,
+      note: "Annual settlement",
+    });
+    expect(getPaymentById(db, id)?.note).toBe("Annual settlement");
+  });
+
+  it("stores null note", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertPayment(db, { person_id: 1, date: "2027-03-01", amount: 50, note: null });
+    expect(getPaymentById(db, id)?.note).toBeNull();
+  });
+
+  it("inserts multiple payments for different people", () => {
+    const db = makeDb();
+    seed(db);
+    insertPayment(db, { person_id: 1, date: "2027-03-01", amount: 100, note: null });
+    insertPayment(db, { person_id: 2, date: "2027-03-02", amount: 200, note: null });
+    expect(getPayments(db)).toHaveLength(2);
+  });
+});
+
+describe("updatePayment", () => {
+  it("updates all fields of a payment", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertPayment(db, {
+      person_id: 1,
+      date: "2027-03-01",
+      amount: 100,
+      note: "Old note",
+    });
+    updatePayment(db, id, { person_id: 2, date: "2028-06-15", amount: 250, note: "New note" });
+    const payment = getPaymentById(db, id);
+    expect(payment?.person_name).toBe("Bob");
+    expect(payment?.date).toBe("2028-06-15");
+    expect(payment?.amount).toBe(250);
+    expect(payment?.note).toBe("New note");
+    // year = 2028 - 1 = 2027
+    expect(payment?.year).toBe(2027);
+  });
+
+  it("recalculates year on update", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertPayment(db, { person_id: 1, date: "2027-03-01", amount: 100, note: null });
+    updatePayment(db, id, { person_id: 1, date: "2029-01-10", amount: 100, note: null });
+    expect(getPaymentById(db, id)?.year).toBe(2028);
+  });
+
+  it("does nothing for non-existent id without throwing", () => {
+    const db = makeDb();
+    seed(db);
+    expect(() =>
+      updatePayment(db, 9999, { person_id: 1, date: "2027-01-01", amount: 50, note: null })
+    ).not.toThrow();
+  });
+});
+
+describe("deletePayment", () => {
+  it("removes the payment from the DB", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertPayment(db, { person_id: 1, date: "2027-03-01", amount: 100, note: null });
+    deletePayment(db, id);
+    expect(getPaymentById(db, id)).toBeNull();
+    expect(getPayments(db)).toHaveLength(0);
+  });
+
+  it("does not throw for non-existent id", () => {
+    const db = makeDb();
+    seed(db);
+    expect(() => deletePayment(db, 9999)).not.toThrow();
+  });
+});

--- a/lib/__tests__/queries_people.test.ts
+++ b/lib/__tests__/queries_people.test.ts
@@ -1,0 +1,243 @@
+// lib/__tests__/queries_people.test.ts
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../db/migrate";
+import {
+  getPeople,
+  getActivePeople,
+  getPersonById,
+  getPersonByUsername,
+  insertPerson,
+  updatePerson,
+  setPasswordHash,
+  isOwner,
+  createInviteToken,
+  getInviteToken,
+  deleteInviteToken,
+} from "../queries/people";
+
+function makeDb() {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  runMigrations(db);
+  return db;
+}
+
+const basePerson = {
+  discount: 0,
+  discount_long: 0,
+  active: 1 as const,
+  username: null,
+  password_hash: null,
+  is_admin: 0 as const,
+};
+
+describe("getPeople", () => {
+  it("returns empty array when no people exist", () => {
+    const db = makeDb();
+    expect(getPeople(db)).toEqual([]);
+  });
+
+  it("returns all people ordered by name", () => {
+    const db = makeDb();
+    insertPerson(db, { ...basePerson, name: "Zara" });
+    insertPerson(db, { ...basePerson, name: "Alice" });
+    insertPerson(db, { ...basePerson, name: "Bob" });
+    const people = getPeople(db);
+    expect(people.map((p) => p.name)).toEqual(["Alice", "Bob", "Zara"]);
+  });
+
+  it("strips password_hash from results", () => {
+    const db = makeDb();
+    const id = insertPerson(db, { ...basePerson, name: "Alice" });
+    db.prepare("UPDATE people SET password_hash=? WHERE id=?").run("hashed!", id);
+    const people = getPeople(db);
+    expect((people[0] as any).password_hash).toBeUndefined();
+  });
+});
+
+describe("getActivePeople", () => {
+  it("returns only active people", () => {
+    const db = makeDb();
+    insertPerson(db, { ...basePerson, name: "Active", active: 1 });
+    insertPerson(db, { ...basePerson, name: "Inactive", active: 0 });
+    const people = getActivePeople(db);
+    expect(people).toHaveLength(1);
+    expect(people[0].name).toBe("Active");
+  });
+
+  it("returns empty array when no active people", () => {
+    const db = makeDb();
+    insertPerson(db, { ...basePerson, name: "Inactive", active: 0 });
+    expect(getActivePeople(db)).toHaveLength(0);
+  });
+});
+
+describe("getPersonById", () => {
+  it("returns the correct person by id", () => {
+    const db = makeDb();
+    const id = insertPerson(db, { ...basePerson, name: "Alice" });
+    const person = getPersonById(db, id);
+    expect(person?.name).toBe("Alice");
+    expect(person?.id).toBe(id);
+  });
+
+  it("returns null for a non-existent id", () => {
+    const db = makeDb();
+    expect(getPersonById(db, 9999)).toBeNull();
+  });
+
+  it("strips password_hash", () => {
+    const db = makeDb();
+    const id = insertPerson(db, { ...basePerson, name: "Alice" });
+    db.prepare("UPDATE people SET password_hash=? WHERE id=?").run("secret", id);
+    const person = getPersonById(db, id);
+    expect((person as any)?.password_hash).toBeUndefined();
+  });
+});
+
+describe("getPersonByUsername", () => {
+  it("returns person matching username", () => {
+    const db = makeDb();
+    insertPerson(db, { ...basePerson, name: "Alice", username: "alice_user" });
+    const person = getPersonByUsername(db, "alice_user");
+    expect(person?.name).toBe("Alice");
+  });
+
+  it("returns null for unknown username", () => {
+    const db = makeDb();
+    expect(getPersonByUsername(db, "nobody")).toBeNull();
+  });
+
+  it("returns password_hash (used for auth)", () => {
+    const db = makeDb();
+    const id = insertPerson(db, { ...basePerson, name: "Alice", username: "alice" });
+    db.prepare("UPDATE people SET password_hash=? WHERE id=?").run("hashed_pw", id);
+    const person = getPersonByUsername(db, "alice");
+    expect((person as any)?.password_hash).toBe("hashed_pw");
+  });
+});
+
+describe("insertPerson", () => {
+  it("returns a numeric id", () => {
+    const db = makeDb();
+    const id = insertPerson(db, { ...basePerson, name: "Alice" });
+    expect(typeof id).toBe("number");
+    expect(id).toBeGreaterThan(0);
+  });
+
+  it("stores is_admin flag correctly", () => {
+    const db = makeDb();
+    const id = insertPerson(db, { ...basePerson, name: "Admin", is_admin: 1 });
+    const row = db.prepare("SELECT is_admin FROM people WHERE id=?").get(id) as any;
+    expect(row.is_admin).toBe(1);
+  });
+
+  it("stores discount values", () => {
+    const db = makeDb();
+    const id = insertPerson(db, {
+      ...basePerson,
+      name: "Discounted",
+      discount: 10,
+      discount_long: 20,
+    });
+    const row = db.prepare("SELECT discount, discount_long FROM people WHERE id=?").get(id) as any;
+    expect(row.discount).toBe(10);
+    expect(row.discount_long).toBe(20);
+  });
+});
+
+describe("updatePerson", () => {
+  it("updates person fields", () => {
+    const db = makeDb();
+    const id = insertPerson(db, { ...basePerson, name: "Old Name" });
+    updatePerson(db, id, { ...basePerson, name: "New Name", active: 0 });
+    const person = getPersonById(db, id);
+    expect(person?.name).toBe("New Name");
+    expect(person?.active).toBe(0);
+  });
+
+  it("updates username", () => {
+    const db = makeDb();
+    const id = insertPerson(db, { ...basePerson, name: "Alice" });
+    updatePerson(db, id, { ...basePerson, name: "Alice", username: "alice_updated" });
+    const person = getPersonByUsername(db, "alice_updated");
+    expect(person?.id).toBe(id);
+  });
+
+  it("does nothing for non-existent id", () => {
+    const db = makeDb();
+    // should not throw
+    updatePerson(db, 9999, { ...basePerson, name: "Ghost" });
+    expect(getPeople(db)).toHaveLength(0);
+  });
+});
+
+describe("setPasswordHash", () => {
+  it("sets the password_hash on the person row", () => {
+    const db = makeDb();
+    const id = insertPerson(db, { ...basePerson, name: "Alice" });
+    setPasswordHash(db, id, "bcrypt_hash_here");
+    const row = db.prepare("SELECT password_hash FROM people WHERE id=?").get(id) as any;
+    expect(row.password_hash).toBe("bcrypt_hash_here");
+  });
+});
+
+describe("isOwner", () => {
+  it("returns false when person owns no active cars", () => {
+    const db = makeDb();
+    insertPerson(db, { ...basePerson, name: "Alice" });
+    expect(isOwner(db, "Alice")).toBe(false);
+  });
+
+  it("returns true when person owns an active car", () => {
+    const db = makeDb();
+    insertPerson(db, { ...basePerson, name: "Alice" });
+    db.exec(
+      `INSERT INTO cars (short,name,price_per_km,owner_name,owner_from,active) VALUES ('CA','Car A',0.2,'Alice','2020-01-01',1)`
+    );
+    expect(isOwner(db, "Alice")).toBe(true);
+  });
+
+  it("returns false when person only owns inactive cars", () => {
+    const db = makeDb();
+    insertPerson(db, { ...basePerson, name: "Alice" });
+    db.exec(
+      `INSERT INTO cars (short,name,price_per_km,owner_name,owner_from,active) VALUES ('CA','Car A',0.2,'Alice','2020-01-01',0)`
+    );
+    expect(isOwner(db, "Alice")).toBe(false);
+  });
+});
+
+describe("invite tokens", () => {
+  it("creates and retrieves an invite token", () => {
+    const db = makeDb();
+    const id = insertPerson(db, { ...basePerson, name: "Alice" });
+    createInviteToken(db, id, "tok123", "2030-01-01T00:00:00");
+    const row = getInviteToken(db, "tok123");
+    expect(row?.person_id).toBe(id);
+    expect(row?.expires_at).toBe("2030-01-01T00:00:00");
+  });
+
+  it("returns null for unknown token", () => {
+    const db = makeDb();
+    expect(getInviteToken(db, "unknown")).toBeNull();
+  });
+
+  it("deletes an invite token", () => {
+    const db = makeDb();
+    const id = insertPerson(db, { ...basePerson, name: "Alice" });
+    createInviteToken(db, id, "tok456", "2030-01-01T00:00:00");
+    deleteInviteToken(db, "tok456");
+    expect(getInviteToken(db, "tok456")).toBeNull();
+  });
+
+  it("upserts on duplicate token (INSERT OR REPLACE)", () => {
+    const db = makeDb();
+    const id = insertPerson(db, { ...basePerson, name: "Alice" });
+    createInviteToken(db, id, "duptoken", "2030-01-01T00:00:00");
+    createInviteToken(db, id, "duptoken", "2031-06-01T00:00:00");
+    const row = getInviteToken(db, "duptoken");
+    expect(row?.expires_at).toBe("2031-06-01T00:00:00");
+  });
+});

--- a/lib/__tests__/queries_reservations.test.ts
+++ b/lib/__tests__/queries_reservations.test.ts
@@ -1,0 +1,308 @@
+// lib/__tests__/queries_reservations.test.ts
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../db/migrate";
+import {
+  getReservations,
+  getReservationById,
+  insertReservation,
+  updateReservation,
+  updateReservationStatus,
+  deleteReservation,
+  ConflictError,
+} from "../queries/reservations";
+
+function makeDb() {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  runMigrations(db);
+  return db;
+}
+
+function seed(db: Database.Database) {
+  db.exec(`INSERT INTO people (id, name, active) VALUES (1, 'Alice', 1), (2, 'Bob', 1)`);
+  db.exec(
+    `INSERT INTO cars (id, short, name, price_per_km, owner_name, owner_from, active) VALUES (1, 'CA', 'Car A', 0.2, 'Alice', '2020-01-01', 1)`
+  );
+}
+
+describe("getReservations", () => {
+  it("returns empty array when no reservations exist", () => {
+    const db = makeDb();
+    seed(db);
+    expect(getReservations(db)).toEqual([]);
+  });
+
+  it("returns all reservations with joined person_name and car_short", () => {
+    const db = makeDb();
+    seed(db);
+    insertReservation(db, {
+      person_id: 1,
+      car_id: 1,
+      start_date: "2026-06-01",
+      end_date: "2026-06-03",
+    });
+    const list = getReservations(db);
+    expect(list).toHaveLength(1);
+    expect(list[0].person_name).toBe("Alice");
+    expect(list[0].car_short).toBe("CA");
+  });
+
+  it("orders by start_date DESC", () => {
+    const db = makeDb();
+    seed(db);
+    insertReservation(db, {
+      person_id: 1,
+      car_id: 1,
+      start_date: "2026-06-01",
+      end_date: "2026-06-02",
+    });
+    insertReservation(db, {
+      person_id: 1,
+      car_id: 1,
+      start_date: "2026-07-01",
+      end_date: "2026-07-02",
+    });
+    const list = getReservations(db);
+    expect(list[0].start_date).toBe("2026-07-01");
+    expect(list[1].start_date).toBe("2026-06-01");
+  });
+});
+
+describe("getReservationById", () => {
+  it("returns the correct reservation", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertReservation(db, {
+      person_id: 1,
+      car_id: 1,
+      start_date: "2026-06-01",
+      end_date: "2026-06-05",
+    });
+    const res = getReservationById(db, id);
+    expect(res?.id).toBe(id);
+    expect(res?.person_name).toBe("Alice");
+    expect(res?.car_short).toBe("CA");
+  });
+
+  it("returns null for a non-existent id", () => {
+    const db = makeDb();
+    seed(db);
+    expect(getReservationById(db, 9999)).toBeNull();
+  });
+});
+
+describe("insertReservation", () => {
+  it("creates a reservation with default status=pending", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertReservation(db, {
+      person_id: 1,
+      car_id: 1,
+      start_date: "2026-06-01",
+      end_date: "2026-06-03",
+    });
+    const res = getReservationById(db, id);
+    expect(res?.status).toBe("pending");
+  });
+
+  it("respects provided status", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertReservation(db, {
+      person_id: 1,
+      car_id: 1,
+      start_date: "2026-06-01",
+      end_date: "2026-06-03",
+      status: "confirmed",
+    });
+    expect(getReservationById(db, id)?.status).toBe("confirmed");
+  });
+
+  it("stores note when provided", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertReservation(db, {
+      person_id: 1,
+      car_id: 1,
+      start_date: "2026-06-01",
+      end_date: "2026-06-03",
+      note: "Please confirm ASAP",
+    });
+    expect(getReservationById(db, id)?.note).toBe("Please confirm ASAP");
+  });
+
+  it("idempotency: returns existing id when client_id already exists", () => {
+    const db = makeDb();
+    seed(db);
+    const id1 = insertReservation(db, {
+      person_id: 1,
+      car_id: 1,
+      start_date: "2026-06-01",
+      end_date: "2026-06-03",
+      client_id: "client-abc",
+    });
+    const id2 = insertReservation(db, {
+      person_id: 1,
+      car_id: 1,
+      start_date: "2026-07-01",
+      end_date: "2026-07-03",
+      client_id: "client-abc",
+    });
+    expect(id2).toBe(id1);
+    expect(getReservations(db)).toHaveLength(1);
+  });
+
+  it("creates a new row when client_id is null", () => {
+    const db = makeDb();
+    seed(db);
+    insertReservation(db, {
+      person_id: 1,
+      car_id: 1,
+      start_date: "2026-06-01",
+      end_date: "2026-06-02",
+    });
+    insertReservation(db, {
+      person_id: 1,
+      car_id: 1,
+      start_date: "2026-07-01",
+      end_date: "2026-07-02",
+    });
+    expect(getReservations(db)).toHaveLength(2);
+  });
+});
+
+describe("updateReservation", () => {
+  it("updates all fields of a reservation", () => {
+    const db = makeDb();
+    seed(db);
+    db.exec(`INSERT INTO people (id, name, active) VALUES (3, 'Carol', 1)`);
+    const id = insertReservation(db, {
+      person_id: 1,
+      car_id: 1,
+      start_date: "2026-06-01",
+      end_date: "2026-06-03",
+    });
+    updateReservation(db, id, {
+      person_id: 3,
+      car_id: 1,
+      start_date: "2026-06-10",
+      end_date: "2026-06-12",
+      status: "confirmed",
+      note: "Updated note",
+    });
+    const res = getReservationById(db, id);
+    expect(res?.person_name).toBe("Carol");
+    expect(res?.start_date).toBe("2026-06-10");
+    expect(res?.status).toBe("confirmed");
+    expect(res?.note).toBe("Updated note");
+  });
+
+  it("with expectedUpdatedAt: succeeds when timestamp matches", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertReservation(db, {
+      person_id: 1,
+      car_id: 1,
+      start_date: "2026-06-01",
+      end_date: "2026-06-03",
+    });
+    const res = getReservationById(db, id)!;
+    expect(() =>
+      updateReservation(
+        db,
+        id,
+        {
+          person_id: 1,
+          car_id: 1,
+          start_date: "2026-06-01",
+          end_date: "2026-06-03",
+          status: "confirmed",
+        },
+        { expectedUpdatedAt: res.updated_at }
+      )
+    ).not.toThrow();
+  });
+
+  it("with expectedUpdatedAt: throws ConflictError when timestamp mismatches", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertReservation(db, {
+      person_id: 1,
+      car_id: 1,
+      start_date: "2026-06-01",
+      end_date: "2026-06-03",
+    });
+    expect(() =>
+      updateReservation(
+        db,
+        id,
+        { person_id: 1, car_id: 1, start_date: "2026-06-01", end_date: "2026-06-03" },
+        { expectedUpdatedAt: "2000-01-01 00:00:00" }
+      )
+    ).toThrow(ConflictError);
+  });
+
+  it("with expectedUpdatedAt: throws ConflictError when reservation no longer exists", () => {
+    const db = makeDb();
+    seed(db);
+    expect(() =>
+      updateReservation(
+        db,
+        9999,
+        { person_id: 1, car_id: 1, start_date: "2026-06-01", end_date: "2026-06-03" },
+        { expectedUpdatedAt: "2000-01-01 00:00:00" }
+      )
+    ).toThrow(ConflictError);
+  });
+});
+
+describe("updateReservationStatus", () => {
+  it("updates only the status field", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertReservation(db, {
+      person_id: 1,
+      car_id: 1,
+      start_date: "2026-06-01",
+      end_date: "2026-06-03",
+    });
+    updateReservationStatus(db, id, "confirmed");
+    expect(getReservationById(db, id)?.status).toBe("confirmed");
+  });
+
+  it("can set status to rejected", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertReservation(db, {
+      person_id: 1,
+      car_id: 1,
+      start_date: "2026-06-01",
+      end_date: "2026-06-03",
+    });
+    updateReservationStatus(db, id, "rejected");
+    expect(getReservationById(db, id)?.status).toBe("rejected");
+  });
+});
+
+describe("deleteReservation", () => {
+  it("removes the reservation from the DB", () => {
+    const db = makeDb();
+    seed(db);
+    const id = insertReservation(db, {
+      person_id: 1,
+      car_id: 1,
+      start_date: "2026-06-01",
+      end_date: "2026-06-03",
+    });
+    deleteReservation(db, id);
+    expect(getReservationById(db, id)).toBeNull();
+    expect(getReservations(db)).toHaveLength(0);
+  });
+
+  it("does not throw for non-existent id", () => {
+    const db = makeDb();
+    seed(db);
+    expect(() => deleteReservation(db, 9999)).not.toThrow();
+  });
+});

--- a/lib/__tests__/queries_settings.test.ts
+++ b/lib/__tests__/queries_settings.test.ts
@@ -1,0 +1,48 @@
+// lib/__tests__/queries_settings.test.ts
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../db/migrate";
+import { getSetting, setSetting } from "../queries/settings";
+
+function makeDb() {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  runMigrations(db);
+  return db;
+}
+
+describe("getSetting", () => {
+  it("returns empty string when key does not exist", () => {
+    const db = makeDb();
+    expect(getSetting(db, "nonexistent_key")).toBe("");
+  });
+
+  it("returns the stored value for an existing key", () => {
+    const db = makeDb();
+    setSetting(db, "theme", "dark");
+    expect(getSetting(db, "theme")).toBe("dark");
+  });
+});
+
+describe("setSetting", () => {
+  it("creates a new setting", () => {
+    const db = makeDb();
+    setSetting(db, "locale", "nl");
+    expect(getSetting(db, "locale")).toBe("nl");
+  });
+
+  it("updates an existing setting (upsert)", () => {
+    const db = makeDb();
+    setSetting(db, "locale", "nl");
+    setSetting(db, "locale", "en");
+    expect(getSetting(db, "locale")).toBe("en");
+  });
+
+  it("stores multiple distinct keys", () => {
+    const db = makeDb();
+    setSetting(db, "key1", "val1");
+    setSetting(db, "key2", "val2");
+    expect(getSetting(db, "key1")).toBe("val1");
+    expect(getSetting(db, "key2")).toBe("val2");
+  });
+});

--- a/lib/__tests__/queries_trips.test.ts
+++ b/lib/__tests__/queries_trips.test.ts
@@ -1,0 +1,222 @@
+// lib/__tests__/queries_trips.test.ts
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../db/migrate";
+import { insertPerson } from "../queries/people";
+import { insertCar } from "../queries/cars";
+import {
+  getTrips,
+  getTripById,
+  insertTrip,
+  updateTrip,
+  deleteTrip,
+  ConflictError,
+} from "../queries/trips";
+
+function makeDb() {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  runMigrations(db);
+  return db;
+}
+
+const basePerson = {
+  discount: 0,
+  discount_long: 0,
+  active: 1 as const,
+  username: null,
+  password_hash: null,
+  is_admin: 0 as const,
+};
+
+describe("getTripById", () => {
+  it("returns the correct trip with joined fields", () => {
+    const db = makeDb();
+    const pid = insertPerson(db, { ...basePerson, name: "Alice" });
+    const cid = insertCar(db, {
+      short: "CA",
+      name: "Car A",
+      price_per_km: 0.2,
+      brand: null,
+      color: null,
+    });
+    const tid = insertTrip(db, {
+      person_id: pid,
+      car_id: cid,
+      date: "2026-05-01",
+      start_odometer: 0,
+      end_odometer: 100,
+      location: null,
+    });
+    const trip = getTripById(db, tid);
+    expect(trip?.id).toBe(tid);
+    expect(trip?.person_name).toBe("Alice");
+    expect(trip?.car_short).toBe("CA");
+    expect(trip?.km).toBe(100);
+  });
+
+  it("returns null for a non-existent id", () => {
+    const db = makeDb();
+    expect(getTripById(db, 9999)).toBeNull();
+  });
+});
+
+describe("updateTrip", () => {
+  it("with expectedUpdatedAt: succeeds when timestamp matches", () => {
+    const db = makeDb();
+    const pid = insertPerson(db, { ...basePerson, name: "Alice" });
+    const cid = insertCar(db, {
+      short: "CA",
+      name: "Car A",
+      price_per_km: 0.2,
+      brand: null,
+      color: null,
+    });
+    const tid = insertTrip(db, {
+      person_id: pid,
+      car_id: cid,
+      date: "2026-05-01",
+      start_odometer: 0,
+      end_odometer: 100,
+      location: null,
+    });
+    const trip = getTripById(db, tid)!;
+    expect(() =>
+      updateTrip(
+        db,
+        tid,
+        {
+          person_id: pid,
+          car_id: cid,
+          date: "2026-05-01",
+          start_odometer: 0,
+          end_odometer: 200,
+          location: null,
+        },
+        { expectedUpdatedAt: trip.updated_at }
+      )
+    ).not.toThrow();
+    expect(getTripById(db, tid)?.km).toBe(200);
+  });
+
+  it("with expectedUpdatedAt: throws ConflictError when timestamp mismatches", () => {
+    const db = makeDb();
+    const pid = insertPerson(db, { ...basePerson, name: "Alice" });
+    const cid = insertCar(db, {
+      short: "CA",
+      name: "Car A",
+      price_per_km: 0.2,
+      brand: null,
+      color: null,
+    });
+    const tid = insertTrip(db, {
+      person_id: pid,
+      car_id: cid,
+      date: "2026-05-01",
+      start_odometer: 0,
+      end_odometer: 100,
+      location: null,
+    });
+    expect(() =>
+      updateTrip(
+        db,
+        tid,
+        {
+          person_id: pid,
+          car_id: cid,
+          date: "2026-05-01",
+          start_odometer: 0,
+          end_odometer: 200,
+          location: null,
+        },
+        { expectedUpdatedAt: "1999-01-01 00:00:00" }
+      )
+    ).toThrow(ConflictError);
+  });
+
+  it("with expectedUpdatedAt: throws ConflictError when trip no longer exists", () => {
+    const db = makeDb();
+    const pid = insertPerson(db, { ...basePerson, name: "Alice" });
+    const cid = insertCar(db, {
+      short: "CA",
+      name: "Car A",
+      price_per_km: 0.2,
+      brand: null,
+      color: null,
+    });
+    expect(() =>
+      updateTrip(
+        db,
+        9999,
+        {
+          person_id: pid,
+          car_id: cid,
+          date: "2026-05-01",
+          start_odometer: 0,
+          end_odometer: 100,
+          location: null,
+        },
+        { expectedUpdatedAt: "2026-01-01 00:00:00" }
+      )
+    ).toThrow(ConflictError);
+  });
+
+  it("throws when invalid person_id or car_id", () => {
+    const db = makeDb();
+    const pid = insertPerson(db, { ...basePerson, name: "Alice" });
+    const cid = insertCar(db, {
+      short: "CA",
+      name: "Car A",
+      price_per_km: 0.2,
+      brand: null,
+      color: null,
+    });
+    const tid = insertTrip(db, {
+      person_id: pid,
+      car_id: cid,
+      date: "2026-05-01",
+      start_odometer: 0,
+      end_odometer: 100,
+      location: null,
+    });
+    expect(() =>
+      updateTrip(db, tid, {
+        person_id: 9999,
+        car_id: cid,
+        date: "2026-05-01",
+        start_odometer: 0,
+        end_odometer: 100,
+        location: null,
+      })
+    ).toThrow("Invalid person_id or car_id");
+  });
+});
+
+describe("deleteTrip", () => {
+  it("removes the trip from the DB", () => {
+    const db = makeDb();
+    const pid = insertPerson(db, { ...basePerson, name: "Alice" });
+    const cid = insertCar(db, {
+      short: "CA",
+      name: "Car A",
+      price_per_km: 0.2,
+      brand: null,
+      color: null,
+    });
+    const tid = insertTrip(db, {
+      person_id: pid,
+      car_id: cid,
+      date: "2026-05-01",
+      start_odometer: 0,
+      end_odometer: 100,
+      location: null,
+    });
+    deleteTrip(db, tid);
+    expect(getTripById(db, tid)).toBeNull();
+  });
+
+  it("does not throw for non-existent id", () => {
+    const db = makeDb();
+    expect(() => deleteTrip(db, 9999)).not.toThrow();
+  });
+});

--- a/lib/__tests__/uuid.test.ts
+++ b/lib/__tests__/uuid.test.ts
@@ -1,0 +1,39 @@
+// lib/__tests__/uuid.test.ts
+import { describe, it, expect } from "vitest";
+import { newUuid } from "../offline/uuid";
+
+describe("newUuid", () => {
+  it("returns a string", () => {
+    expect(typeof newUuid()).toBe("string");
+  });
+
+  it("returns a valid UUID v4 format (xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx)", () => {
+    const uuid = newUuid();
+    expect(uuid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  });
+
+  it("returns unique values on each call", () => {
+    const ids = new Set(Array.from({ length: 100 }, () => newUuid()));
+    expect(ids.size).toBe(100);
+  });
+
+  it("uses the fallback path when crypto.randomUUID is not available", () => {
+    // Temporarily override randomUUID to undefined on the crypto object
+    const originalRandomUUID = (globalThis as any).crypto?.randomUUID;
+    Object.defineProperty((globalThis as any).crypto, "randomUUID", {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+    try {
+      const uuid = newUuid();
+      expect(uuid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    } finally {
+      Object.defineProperty((globalThis as any).crypto, "randomUUID", {
+        value: originalRandomUUID,
+        configurable: true,
+        writable: true,
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds unit tests for all query modules: reservations, expenses, fuel-fillups, payments, people, cars, trips, admin, settings
- Adds tests for utility modules: API helpers, paper theme, UUID
- Brings test coverage from ~60% to 80%+

Closes #86

## Test Plan

- [ ] `npm test` — all 298 tests pass