### PR TITLE
fix(dashboard): show offline badge on root page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,6 +18,7 @@ import { ReservationForm } from "@/app/calendar/reservation-form";
 import { toast } from "sonner";
 import { useT } from "@/components/locale-provider";
 import { LangSwitcher } from "@/components/lang-switcher";
+import { OfflineBadge } from "@/components/offline-badge";
 import { TripCard } from "@/components/trip-card";
 import { FuelCard } from "@/components/fuel-card";
 import { ExpenseCard } from "@/components/expense-card";
@@ -718,6 +719,7 @@ function DashboardContent() {
             {t("brand.tagline")}
           </div>
           <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <OfflineBadge />
             <LangSwitcher />
             <button
               onClick={handleLogout}


### PR DESCRIPTION
## Summary
- The `OfflineBadge` was only rendered inside `PageHeader`, which the dashboard doesn't use
- Added `OfflineBadge` directly to the dashboard's custom header, alongside `LangSwitcher` and the logout button

## Test plan
- [ ] Go offline (production build with service worker active)
- [ ] Badge appears on root page `/` immediately
- [ ] Badge also visible on `/trips`, `/fuel`, etc. as before