### PR TITLE
ux: admin header alignment, title update, and sticky behaviour (#96)

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -2,7 +2,7 @@
 import { Suspense } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { PageHeader } from "@/components/page-header";
+import { PageHeader, TITLE_BAR_HEIGHT } from "@/components/page-header";
 import { paper, fontMono } from "@/lib/paper-theme";
 import { useT } from "@/components/locale-provider";
 import { useReservations, useOwnerCarShorts } from "./_shared";
@@ -47,6 +47,9 @@ function SubNav() {
           gap: 0,
           borderBottom: `1.5px dashed ${paper.ink}`,
           background: paper.paper,
+          position: "sticky",
+          top: TITLE_BAR_HEIGHT,
+          zIndex: 19,
         }}
       >
         {SUB_PAGES.map((item) => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { useState, useEffect, useMemo } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { useDashboard, useEarliestDashboardYear } from "@/hooks/use-dashboard";
 import { useTrips } from "@/hooks/use-trips";
 import { useFuelFillups } from "@/hooks/use-fuel-fillups";
@@ -17,8 +16,7 @@ import { ExpenseForm } from "@/app/expenses/expense-form";
 import { ReservationForm } from "@/app/calendar/reservation-form";
 import { toast } from "sonner";
 import { useT } from "@/components/locale-provider";
-import { LangSwitcher } from "@/components/lang-switcher";
-import { OfflineBadge } from "@/components/offline-badge";
+import { PageHeader } from "@/components/page-header";
 import { TripCard } from "@/components/trip-card";
 import { FuelCard } from "@/components/fuel-card";
 import { ExpenseCard } from "@/components/expense-card";
@@ -625,7 +623,6 @@ function Sheets({ sheet, setSheet }: { sheet: SheetType; setSheet: (s: SheetType
 function DashboardContent() {
   const t = useT();
   const { data: me } = useMe();
-  const router = useRouter();
   const [sheet, setSheet] = useState<SheetType>(null);
 
   // Edit state
@@ -643,11 +640,6 @@ function DashboardContent() {
   const deleteExpense = useDeleteExpense();
   const updateRes = useUpdateReservation();
   const deleteRes = useDeleteReservation();
-
-  const handleLogout = async () => {
-    await fetch("/api/auth/logout", { method: "POST" });
-    router.replace("/login");
-  };
 
   const { data: trips = [] } = useTrips();
   const { data: fillups = [] } = useFuelFillups();
@@ -691,84 +683,11 @@ function DashboardContent() {
 
   return (
     <div style={{ background: paper.paperDeep, minHeight: "100dvh", paddingBottom: 80 }}>
-      {/* Header */}
-      <div
-        style={{
-          background: paper.paper,
-          padding: "22px 20px 20px",
-          borderBottom: `1.5px dashed ${paper.ink}`,
-        }}
-      >
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-            marginBottom: 12,
-          }}
-        >
-          <div
-            style={{
-              fontFamily: fontMono,
-              fontSize: 9,
-              color: paper.inkDim,
-              letterSpacing: 2,
-              textTransform: "uppercase",
-            }}
-          >
-            {t("brand.tagline")}
-          </div>
-          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            <OfflineBadge />
-            <LangSwitcher />
-            <button
-              onClick={handleLogout}
-              title={t("nav.logout")}
-              aria-label={t("nav.logout")}
-              style={{
-                padding: "3px 8px",
-                fontFamily: fontMono,
-                fontSize: 9,
-                fontWeight: 700,
-                letterSpacing: 1.5,
-                textTransform: "uppercase",
-                background: "transparent",
-                color: paper.inkDim,
-                border: `1.5px solid ${paper.paperDark}`,
-                cursor: "pointer",
-                lineHeight: 1.6,
-              }}
-            >
-              ⏻
-            </button>
-          </div>
-        </div>
-        <div
-          style={{
-            fontFamily: fontSerif,
-            fontSize: 32,
-            fontWeight: 700,
-            color: paper.ink,
-            letterSpacing: -0.8,
-            lineHeight: 1.05,
-          }}
-        >
-          {t("dashboard.hello")}
-          {me?.personName ? ` ${me.personName.split(" ")[0]}` : ""}
-        </div>
-        <div
-          style={{
-            fontFamily: fontMono,
-            fontSize: 10,
-            color: paper.inkDim,
-            letterSpacing: 2,
-            textTransform: "uppercase",
-            marginTop: 4,
-          }}
-        >
-          {t("dashboard.today")} · {todayFmt}
-        </div>
-      </div>
+      <PageHeader
+        title={`${t("dashboard.hello")}${me?.personName ? ` ${me.personName.split(" ")[0]}` : ""}`}
+        subtitle={`${t("dashboard.today")} · ${todayFmt}`}
+        titleSize={32}
+      />
 
       {/* Balance */}
       <BalanceReceipt personName={me?.personName ?? ""} />

--- a/components/page-header.tsx
+++ b/components/page-header.tsx
@@ -8,13 +8,18 @@ import pkg from "@/package.json";
 
 const version = pkg.version;
 
+// Height of the sticky title bar (padding 6+10 + font 26*1.1 ≈ 29 + border 1.5 ≈ 47px).
+// Used by consumers to offset a second sticky element below it.
+export const TITLE_BAR_HEIGHT = 47;
+
 interface Props {
   title: string;
   subtitle?: string;
   right?: React.ReactNode;
+  titleSize?: number;
 }
 
-export function PageHeader({ title, subtitle, right }: Props) {
+export function PageHeader({ title, subtitle, right, titleSize = 26 }: Props) {
   const t = useT();
   const router = useRouter();
 
@@ -24,24 +29,9 @@ export function PageHeader({ title, subtitle, right }: Props) {
   };
 
   return (
-    <header
-      style={{
-        background: paper.paper,
-        padding: "18px 20px 16px",
-        borderBottom: `1.5px dashed ${paper.ink}`,
-        position: "sticky",
-        top: 0,
-        zIndex: 20,
-      }}
-    >
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-          marginBottom: 4,
-        }}
-      >
+    <>
+      {/* Scrolls away: org name */}
+      <div style={{ background: paper.paper, padding: "18px 20px 4px" }}>
         <div
           style={{
             fontFamily: fontMono,
@@ -53,32 +43,60 @@ export function PageHeader({ title, subtitle, right }: Props) {
         >
           {t("brand.tagline")}
         </div>
-        <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 2 }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            <OfflineBadge />
-            {right}
-            <LangSwitcher />
-            <button
-              onClick={handleLogout}
-              title={t("nav.logout")}
-              aria-label={t("nav.logout")}
-              style={{
-                padding: "3px 8px",
-                fontFamily: fontMono,
-                fontSize: 9,
-                fontWeight: 700,
-                letterSpacing: 1.5,
-                textTransform: "uppercase",
-                background: "transparent",
-                color: paper.inkDim,
-                border: `1.5px solid ${paper.paperDark}`,
-                cursor: "pointer",
-                lineHeight: 1.6,
-              }}
-            >
-              ⏻
-            </button>
-          </div>
+      </div>
+
+      {/* Sticky: title + controls on same row */}
+      <div
+        style={{
+          position: "sticky",
+          top: 0,
+          zIndex: 20,
+          background: paper.paper,
+          borderBottom: `1.5px dashed ${paper.ink}`,
+          padding: "6px 20px 10px",
+          display: "flex",
+          alignItems: "baseline",
+          justifyContent: "space-between",
+        }}
+      >
+        <div
+          style={{
+            fontFamily: fontSerif,
+            fontSize: titleSize,
+            fontWeight: 700,
+            color: paper.ink,
+            letterSpacing: -0.5,
+            lineHeight: 1.1,
+          }}
+        >
+          {title}
+        </div>
+        <div
+          style={{ display: "flex", alignItems: "center", gap: 8, flexShrink: 0, paddingLeft: 12 }}
+        >
+          <OfflineBadge />
+          {right}
+          <LangSwitcher />
+          <button
+            onClick={handleLogout}
+            title={t("nav.logout")}
+            aria-label={t("nav.logout")}
+            style={{
+              padding: "3px 8px",
+              fontFamily: fontMono,
+              fontSize: 9,
+              fontWeight: 700,
+              letterSpacing: 1.5,
+              textTransform: "uppercase",
+              background: "transparent",
+              color: paper.inkDim,
+              border: `1.5px solid ${paper.paperDark}`,
+              cursor: "pointer",
+              lineHeight: 1.6,
+            }}
+          >
+            ⏻
+          </button>
           <span
             style={{ fontFamily: fontMono, fontSize: 8, color: paper.inkDim, letterSpacing: 1 }}
           >
@@ -86,32 +104,23 @@ export function PageHeader({ title, subtitle, right }: Props) {
           </span>
         </div>
       </div>
-      <div
-        style={{
-          fontFamily: fontSerif,
-          fontSize: 26,
-          fontWeight: 700,
-          color: paper.ink,
-          letterSpacing: -0.5,
-          lineHeight: 1.1,
-        }}
-      >
-        {title}
-      </div>
+
+      {/* Scrolls away: subtitle (admin only) */}
       {subtitle && (
-        <div
-          style={{
-            fontFamily: fontMono,
-            fontSize: 10,
-            color: paper.inkDim,
-            letterSpacing: 1.5,
-            textTransform: "uppercase" as const,
-            marginTop: 4,
-          }}
-        >
-          {subtitle}
+        <div style={{ background: paper.paper, padding: "6px 20px 10px" }}>
+          <div
+            style={{
+              fontFamily: fontMono,
+              fontSize: 10,
+              color: paper.inkDim,
+              letterSpacing: 1.5,
+              textTransform: "uppercase" as const,
+            }}
+          >
+            {subtitle}
+          </div>
         </div>
       )}
-    </header>
+    </>
   );
 }

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -4,7 +4,7 @@ export const en: Messages = {
   // Brand
   "brand.app": "Car Sharing",
   "brand.description": "Car sharing for a cooperative",
-  "brand.tagline": "Cooperative · Antwerp",
+  "brand.tagline": "Autodelen Cooperative · Antwerp",
 
   // Primary navigation
   "nav.menu": "Menu",

--- a/lib/i18n/messages/nl.ts
+++ b/lib/i18n/messages/nl.ts
@@ -2,7 +2,7 @@ export const nl = {
   // Brand
   "brand.app": "Autodelen",
   "brand.description": "Autodelen voor een coöperatieve",
-  "brand.tagline": "Coöperatieve · Antwerpen",
+  "brand.tagline": "Autodelen Coöperatieve · Antwerpen",
 
   // Primary navigation
   "nav.menu": "Menu",


### PR DESCRIPTION
## Summary

- **Org name updated** to "Autodelen Coöperatieve · Antwerpen" (nl + en)
- **Unified sticky header** across all pages: org name scrolls away, title + controls bar stays sticky at top
- **Home page** greeting ("Hallo 👋 Name") + lang/logout sticky; org name and date scroll
- **Admin page** title ("Beheer") + lang/logout sticky; org name and subtitle ("CO-OP ADMINISTRATIE · 2026") scroll; tab nav (Inbox / Wagens / …) sticks below the title bar
- **PageHeader refactored**: single component handles all pages, `titleSize` prop for home page (32px vs 26px default); home page no longer has duplicate inline header code

## Test plan

- [ ] Home page: scroll down — org name + date disappear, "Hallo 👋 Name" + controls stay fixed
- [ ] Admin page: scroll down — org name + subtitle disappear, "Beheer" + controls stay fixed, tab nav sticks below it
- [ ] Other pages (Ritten, Wagens, …): same split — org name scrolls, title + controls sticky
- [ ] Lang switcher and logout button work on all pages
- [ ] Org name shows "Autodelen Coöperatieve · Antwerpen" everywhere

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)