### PR TITLE
fix(settlement): show step 1 & 2 totals from coop perspective

### DIFF
--- a/app/admin/settlement/page.tsx
+++ b/app/admin/settlement/page.tsx
@@ -926,8 +926,11 @@ export default function AdminSettlementPage() {
               Math.round(nonOwnerMembers.reduce((s, m) => s + (m.s1 ?? 0), 0) * 100) / 100;
             const step2Total =
               Math.round(ownerMembers.reduce((s, m) => s + (m.net ?? m.s2 ?? 0), 0) * 100) / 100;
-            const step1Color = amtColor(step1Total);
-            // step2Total is negative when coop pays out (expected flow) → invert for display
+            // step1Total is sum of member s1 (member-perspective: negative = they owe)
+            // invert to show coop-perspective: coop receives = positive
+            const step1Color = amtColor(-step1Total);
+            // step2Total is sum of owner net (owner-perspective: positive = they receive)
+            // invert to show coop-perspective: coop pays out = negative
             const step2Color = amtColor(-step2Total);
             return (
               <>
@@ -951,7 +954,7 @@ export default function AdminSettlementPage() {
                       color: step1Color,
                     }}
                   >
-                    {step1Total >= 0 ? "+" : "−"}
+                    {step1Total <= 0 ? "+" : "−"}
                     {fmtMoney(Math.abs(step1Total))}
                   </span>
                 </div>


### PR DESCRIPTION
## Summary
- Step 1 section header was showing negative/red (member POV: members owe). Flipped to coop POV: coop receives = positive/green.
- Step 2 was already correct (coop pays out = negative/red).
- Result: **+€X (Step 1) + −€X (Step 2) = 0**, logically consistent with the balance bar.

## Change
3 lines in `app/admin/settlement/page.tsx`:
- `amtColor(step1Total)` → `amtColor(-step1Total)`
- `step1Total >= 0 ? "+" : "−"` → `step1Total <= 0 ? "+" : "−"`

## Test plan
- [ ] Settlement page: Step 1 header shows green `+€X`
- [ ] Settlement page: Step 2 header shows red `−€X`
- [ ] Balance bar: Saldo = €0,00