### PR TITLE
fix(settlement): non-owner credit card no longer collapses to slim

### DIFF
--- a/app/admin/settlement/page.tsx
+++ b/app/admin/settlement/page.tsx
@@ -461,8 +461,16 @@ function NonOwnerMemberCard({
   };
 
   const ps = settlementTransfer?.payment_status ?? null;
-  const borderColor = ps == null ? paper.ink : ps.open < 0.005 ? paper.green : paper.accent;
-  const isSlim = !showAll && borderColor !== paper.accent;
+  // co-op owes this member (credit): transfer exists but payment_status is null because payer is co-op
+  const hasCreditTransfer = settlementTransfer != null && settlementTransfer.from === "co-op";
+  const borderColor = hasCreditTransfer
+    ? paper.blue
+    : ps == null
+      ? paper.ink
+      : ps.open < 0.005
+        ? paper.green
+        : paper.accent;
+  const isSlim = !showAll && !hasCreditTransfer && borderColor !== paper.accent;
 
   const toggle = () => setOpen((v) => !v);
 

--- a/app/admin/settlement/page.tsx
+++ b/app/admin/settlement/page.tsx
@@ -1222,7 +1222,7 @@ function AdminSettlementPageContent() {
                       year={year}
                       bankAccount={settings?.coop_bank_account ?? ""}
                       settlementTransfer={data.transfers.find(
-                        (tr) => tr.step === 1 && tr.from === m.person_name
+                        (tr) => tr.step === 1 && (tr.from === m.person_name || tr.to === m.person_name)
                       )}
                       showAll={showAll}
                     />


### PR DESCRIPTION
## Problem

Non-owner members with credit (s1 > 0, co-op owes them) showed as slim/collapsed card — visually identical to fully resolved.

Root cause: transfer has from="co-op" → payment_status=null → same code path as "no transfer" → isSlim=true.

## Fix

Detect hasCreditTransfer (transfer exists AND from="co-op"). Render with paper.blue border and keep full card.

## Test

Member with s1 > 0 should show blue-bordered full card, not thin line.