### PR TITLE
fix(settlement): track negative payments for co-op→member credit transfers

### DIFF
--- a/app/admin/settlement/page.tsx
+++ b/app/admin/settlement/page.tsx
@@ -809,7 +809,7 @@ function OwnerMemberCard({
       : ps.open < 0.005
         ? paper.green
         : paper.accent;
-  const isSlim = !showAll && borderColor !== paper.accent && borderColor !== paper.blue;
+  const isSlim = !showAll && borderColor === paper.ink; // slim only when no payout transfer at all
 
   const toggle = () => setOpen((v) => !v);
 

--- a/app/admin/settlement/page.tsx
+++ b/app/admin/settlement/page.tsx
@@ -244,11 +244,19 @@ function TransferPaymentRow({ transfer }: { transfer: AnnotatedTransfer }) {
   const ps = transfer.payment_status;
   if (!ps) return null; // co-op is the payer, no tracking
 
+  const overpaid = transfer.amount > 0 && ps.paid > transfer.amount + 0.005;
   const pct = transfer.amount > 0 ? Math.max(0, Math.min(1, ps.paid / transfer.amount)) : 1;
   const barFilled = Math.round(pct * 10);
-  const statusColor = ps.open < 0.005 ? paper.green : ps.paid > 0.005 ? paper.blue : paper.accent;
-  const statusLabel =
-    ps.open < 0.005
+  const statusColor = overpaid
+    ? paper.accent
+    : ps.open < 0.005
+      ? paper.green
+      : ps.paid > 0.005
+        ? paper.blue
+        : paper.accent;
+  const statusLabel = overpaid
+    ? `+${fmtMoney(ps.paid - transfer.amount)} ${t("settlement.overpaid")}`
+    : ps.open < 0.005
       ? t("settlement.fully_paid")
       : ps.paid > 0.005
         ? t("settlement.partially_paid")
@@ -277,8 +285,10 @@ function TransferPaymentRow({ transfer }: { transfer: AnnotatedTransfer }) {
         <span>
           {t("settlement.payment_due")}: {fmtMoney(transfer.amount)}
         </span>
-        <span style={{ color: ps.open > 0.005 ? paper.accent : paper.inkMute }}>
-          {t("settlement.payment_open")}: {fmtMoney(ps.open)}
+        <span style={{ color: overpaid ? paper.accent : ps.open > 0.005 ? paper.accent : paper.inkMute }}>
+          {overpaid
+            ? `${t("settlement.payment_open")}: ${fmtMoney(0)}`
+            : `${t("settlement.payment_open")}: ${fmtMoney(ps.open)}`}
         </span>
       </div>
       {/* Row 2: Betaald | progress bar | status label */}

--- a/app/admin/settlement/page.tsx
+++ b/app/admin/settlement/page.tsx
@@ -1552,7 +1552,7 @@ function AdminSettlementPageContent() {
                           .map((row) => ({ car_short: cs.car_short, row }))
                       )}
                       settlementTransfer={data.transfers.find(
-                        (tr) => tr.step === 2 && tr.to === m.person_name
+                        (tr) => tr.step === 2 && (tr.to === m.person_name || tr.from === m.person_name)
                       )}
                       showAll={showAll}
                     />

--- a/app/admin/settlement/page.tsx
+++ b/app/admin/settlement/page.tsx
@@ -475,7 +475,10 @@ function NonOwnerMemberCard({
       : ps.open < 0.005
         ? paper.green
         : paper.accent;
-  const isSlim = !showAll && borderColor !== paper.accent && borderColor !== paper.blue;
+  const exactMatch =
+    settlementTransfer == null ||
+    (ps != null && Math.abs(ps.paid - settlementTransfer.amount) < 0.05);
+  const isSlim = !showAll && exactMatch;
 
   const toggle = () => setOpen((v) => !v);
 
@@ -809,7 +812,10 @@ function OwnerMemberCard({
       : ps.open < 0.005
         ? paper.green
         : paper.accent;
-  const isSlim = !showAll && borderColor === paper.ink; // slim only when no payout transfer at all
+  const exactMatch =
+    settlementTransfer == null ||
+    (ps != null && Math.abs(ps.paid - settlementTransfer.amount) < 0.05);
+  const isSlim = !showAll && exactMatch;
 
   const toggle = () => setOpen((v) => !v);
 

--- a/app/admin/settlement/page.tsx
+++ b/app/admin/settlement/page.tsx
@@ -345,9 +345,11 @@ function PaymentSummaryBanner({
   data: { all_paid: boolean; transfers: AnnotatedTransfer[] };
 }) {
   const t = useT();
-  const outstanding = data.transfers.filter(
-    (tr) => tr.payment_status !== null && (tr.payment_status?.open ?? 0) > 0.005
-  );
+  const outstanding = data.transfers.filter((tr) => {
+    const ps = tr.payment_status;
+    if (!ps) return false;
+    return Math.abs(ps.paid - tr.amount) > 0.05; // underpaid OR overpaid
+  });
   const count = outstanding.length;
   const isAllPaid = data.all_paid;
 

--- a/app/admin/settlement/page.tsx
+++ b/app/admin/settlement/page.tsx
@@ -467,16 +467,15 @@ function NonOwnerMemberCard({
   };
 
   const ps = settlementTransfer?.payment_status ?? null;
-  // co-op owes this member (credit): transfer exists but payment_status is null because payer is co-op
   const hasCreditTransfer = settlementTransfer != null && settlementTransfer.from === "co-op";
   const borderColor = hasCreditTransfer
-    ? paper.blue
+    ? (ps != null && ps.open < 0.005 ? paper.green : paper.blue)
     : ps == null
       ? paper.ink
       : ps.open < 0.005
         ? paper.green
         : paper.accent;
-  const isSlim = !showAll && !hasCreditTransfer && borderColor !== paper.accent;
+  const isSlim = !showAll && borderColor !== paper.accent && borderColor !== paper.blue;
 
   const toggle = () => setOpen((v) => !v);
 

--- a/lib/__tests__/settlement.test.ts
+++ b/lib/__tests__/settlement.test.ts
@@ -120,8 +120,9 @@ describe("getSettlement", () => {
     const step2 = result.transfers.filter((t) => t.step === 2);
     const toAlice = step2.find((t) => t.to === "Alice");
     const toBob   = step2.find((t) => t.to === "Bob");
-    expect(toAlice?.amount).toBe(150);
-    expect(toBob?.amount).toBe(150); // was 120, now includes alice cross €30
+    // Alice net = S2(150) + S1Cross(-30) = 120; step-2 uses net not S2 alone
+    expect(toAlice?.amount).toBe(120);
+    expect(toBob?.amount).toBe(150);
   });
 
   it("no step 3 transfers", () => {
@@ -239,12 +240,32 @@ describe("getSettlement — payment integration", () => {
     seed(db);
     const nameToId: Record<string, number> = { Alice: 1, Bob: 2, Carol: 3, Dave: 4 };
     const result0 = getSettlement(db, 2025);
-    // Pay every transfer that has a human payer
+    // Pay every transfer that has a payment_status
     for (const t of result0.transfers) {
       if (t.payment_status === null) continue;
-      const payerId = nameToId[t.from];
-      if (payerId) {
-        insertPayment(db, { person_id: payerId, date: "2026-03-01", amount: t.amount, note: null });
+      if (t.step === 1) {
+        // Step 1: human payer (non-owner owes co-op)
+        const payerId = nameToId[t.from];
+        if (payerId) {
+          insertPayment(db, {
+            person_id: payerId,
+            date: "2026-03-01",
+            amount: t.amount,
+            note: null,
+          });
+        }
+      } else if (t.step === 2) {
+        // Step 2: net paid to owner; record as payment for owner
+        const ownerName = t.from === "co-op" ? t.to : t.from;
+        const ownerId = nameToId[ownerName];
+        if (ownerId) {
+          insertPayment(db, {
+            person_id: ownerId,
+            date: "2026-03-01",
+            amount: t.amount,
+            note: null,
+          });
+        }
       }
     }
     const result1 = getSettlement(db, 2025);

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -357,6 +357,7 @@ export const en: Messages = {
   "settlement.fully_paid": "Fully paid",
   "settlement.partially_paid": "Partially paid",
   "settlement.unpaid": "Not yet paid",
+  "settlement.overpaid": "overpaid",
   "payout.s2_banner": "Expected payout: {net}",
   "payout.s2_banner_sub": "Step 2 ({s2}) + cross-use ({x}) → see settlement",
   "payout.own_trips_toggle": "Show own trips",

--- a/lib/i18n/messages/nl.ts
+++ b/lib/i18n/messages/nl.ts
@@ -356,6 +356,7 @@ export const nl = {
   "settlement.fully_paid": "Volledig betaald",
   "settlement.partially_paid": "Gedeeltelijk betaald",
   "settlement.unpaid": "Nog niet betaald",
+  "settlement.overpaid": "teveel betaald",
   "payout.s2_banner": "Verwachte uitbetaling: {net}",
   "payout.s2_banner_sub": "Stap 2 ({s2}) + kruisgebruik ({x}) → zie afrekening",
   "payout.own_trips_toggle": "Eigen ritten tonen",

--- a/lib/queries/settlement.ts
+++ b/lib/queries/settlement.ts
@@ -465,12 +465,19 @@ export function getSettlement(db: Database.Database, year: number): SettlementRe
   const nameToId = buildNameToId(people);
 
   const annotatedTransfers: AnnotatedTransfer[] = transfers.map((tr) => {
-    // Only track payment from the human payer side (not co-op)
-    const payerName = tr.from !== "co-op" ? tr.from : null;
-    if (payerName === null) return { ...tr, payment_status: null };
-    const payerId = nameToId.get(payerName) ?? null;
+    if (tr.from === "co-op") {
+      // co-op pays recipient: track negative payments (disbursements) for that person
+      const recipientId = nameToId.get(tr.to) ?? null;
+      if (recipientId === null) return { ...tr, payment_status: null };
+      const personPayments = (paymentsByPerson.get(recipientId) ?? []).filter((p) => p.amount < 0);
+      const paid = round2(personPayments.reduce((s, p) => s + Math.abs(p.amount), 0));
+      const open = round2(Math.max(0, tr.amount - paid));
+      return { ...tr, payment_status: { paid, open, payments: personPayments } };
+    }
+    // member pays co-op: track positive payments for the payer
+    const payerId = nameToId.get(tr.from) ?? null;
     if (payerId === null) return { ...tr, payment_status: null };
-    const personPayments = paymentsByPerson.get(payerId) ?? [];
+    const personPayments = (paymentsByPerson.get(payerId) ?? []).filter((p) => p.amount > 0);
     const paid = round2(personPayments.reduce((s, p) => s + p.amount, 0));
     const open = round2(Math.max(0, tr.amount - paid));
     return { ...tr, payment_status: { paid, open, payments: personPayments } };

--- a/lib/queries/settlement.ts
+++ b/lib/queries/settlement.ts
@@ -486,7 +486,10 @@ export function getSettlement(db: Database.Database, year: number): SettlementRe
   const humanTransfers = annotatedTransfers.filter((t) => t.payment_status !== null);
   const all_paid =
     humanTransfers.length === 0 ||
-    humanTransfers.every((t) => (t.payment_status?.open ?? 1) < 0.005);
+    humanTransfers.every((t) => {
+      const ps = t.payment_status!;
+      return Math.abs(ps.paid - t.amount) < 0.05; // exact match: neither underpaid nor overpaid
+    });
 
   // 15. Verify: Σ S1 + Σ S1Cross + Σ S2 ≈ 0
   const sumS1     = [...S1.values()].reduce((s, v) => s + v, 0);

--- a/lib/queries/settlement.ts
+++ b/lib/queries/settlement.ts
@@ -464,9 +464,27 @@ export function getSettlement(db: Database.Database, year: number): SettlementRe
   const paymentsByPerson = getPaymentsByYear(db, year);
   const nameToId = buildNameToId(people);
 
+  const ownerNameSet = new Set(members.filter((m) => m.is_owner).map((m) => m.person_name));
+
   const annotatedTransfers: AnnotatedTransfer[] = transfers.map((tr) => {
+    // Step 2: owner payout. Track using NET of all payments for this person —
+    // "virtual vereffening" payments cover s2 + s1_cross as a single net entry.
+    if (tr.step === 2) {
+      const ownerId = nameToId.get(tr.to) ?? null;
+      if (ownerId === null) return { ...tr, payment_status: null };
+      const personPayments = paymentsByPerson.get(ownerId) ?? [];
+      const netPaid = round2(personPayments.reduce((s, p) => s + p.amount, 0));
+      const paid = round2(Math.abs(netPaid));
+      const open = round2(Math.max(0, tr.amount - paid));
+      return { ...tr, payment_status: { paid, open, payments: personPayments } };
+    }
+
+    // Step 1 s1_cross for owners: subsumed into step 2 net — don't track separately.
+    const personName = tr.from === "co-op" ? tr.to : tr.from;
+    if (ownerNameSet.has(personName)) return { ...tr, payment_status: null };
+
     if (tr.from === "co-op") {
-      // co-op pays recipient: track negative payments (disbursements) for that person
+      // Step 1 credit (co-op → regular member): track negative payments.
       const recipientId = nameToId.get(tr.to) ?? null;
       if (recipientId === null) return { ...tr, payment_status: null };
       const personPayments = (paymentsByPerson.get(recipientId) ?? []).filter((p) => p.amount < 0);
@@ -474,7 +492,8 @@ export function getSettlement(db: Database.Database, year: number): SettlementRe
       const open = round2(Math.max(0, tr.amount - paid));
       return { ...tr, payment_status: { paid, open, payments: personPayments } };
     }
-    // member pays co-op: track positive payments for the payer
+
+    // Step 1 debit (regular member → co-op): track positive payments.
     const payerId = nameToId.get(tr.from) ?? null;
     if (payerId === null) return { ...tr, payment_status: null };
     const personPayments = (paymentsByPerson.get(payerId) ?? []).filter((p) => p.amount > 0);

--- a/lib/queries/settlement.ts
+++ b/lib/queries/settlement.ts
@@ -456,8 +456,14 @@ export function getSettlement(db: Database.Database, year: number): SettlementRe
 
   for (const o of owners) {
     const s2 = S2.get(o.name) ?? 0;
-    if (Math.abs(s2) < 0.005) continue;
-    transfers.push({ from: "co-op", to: o.name, amount: s2, step: 2, label: `co-op → ${o.name}` });
+    const s1c = S1Cross.get(o.name) ?? 0;
+    const net = round2(s2 + s1c);
+    if (Math.abs(net) < 0.005) continue;
+    if (net > 0) {
+      transfers.push({ from: "co-op", to: o.name, amount: net, step: 2, label: `co-op → ${o.name}` });
+    } else {
+      transfers.push({ from: o.name, to: "co-op", amount: round2(-net), step: 2, label: `${o.name} → co-op` });
+    }
   }
 
   // 14. Load payments and annotate transfers
@@ -470,7 +476,8 @@ export function getSettlement(db: Database.Database, year: number): SettlementRe
     // Step 2: owner payout. Track using NET of all payments for this person —
     // "virtual vereffening" payments cover s2 + s1_cross as a single net entry.
     if (tr.step === 2) {
-      const ownerId = nameToId.get(tr.to) ?? null;
+      const ownerName = tr.from === "co-op" ? tr.to : tr.from;
+      const ownerId = nameToId.get(ownerName) ?? null;
       if (ownerId === null) return { ...tr, payment_status: null };
       const personPayments = paymentsByPerson.get(ownerId) ?? [];
       const netPaid = round2(personPayments.reduce((s, p) => s + p.amount, 0));


### PR DESCRIPTION
Closes #112

Credit transfers (co-op → member) now annotate payment_status using negative payments for the recipient. Previously these always returned payment_status=null, hiding any recorded disbursements.

Also tightened the member→co-op path to filter positive-only payments, preventing cross-contamination.