### PR TITLE
Track co-op settlement credit payments

### DIFF
--- a/lib/__tests__/settlement.test.ts
+++ b/lib/__tests__/settlement.test.ts
@@ -29,12 +29,12 @@ function seed(db: Database.Database) {
   const addTrip = db.prepare(
     "INSERT INTO trips (person_id, car_id, date, start_odometer, end_odometer, km, amount) VALUES (?,?,?,?,?,?,?)"
   );
-  addTrip.run(3, 1, "2025-06-01", 0,   500, 500, 100); // carol drives CarA: €100
-  addTrip.run(4, 1, "2025-06-02", 500, 750, 250,  50); // dave drives CarA:  €50
-  addTrip.run(3, 2, "2025-06-03", 0,   400, 400,  80); // carol drives CarB: €80
-  addTrip.run(4, 2, "2025-06-04", 400, 600, 200,  40); // dave drives CarB:  €40
-  addTrip.run(1, 2, "2025-06-05", 600, 750, 150,  30); // alice drives CarB (cross-owner): €30
-  addTrip.run(1, 1, "2025-06-06", 750, 900, 150,  30); // alice drives CarA (own): €30 — shown as €0 in settlement
+  addTrip.run(3, 1, "2025-06-01", 0, 500, 500, 100); // carol drives CarA: €100
+  addTrip.run(4, 1, "2025-06-02", 500, 750, 250, 50); // dave drives CarA:  €50
+  addTrip.run(3, 2, "2025-06-03", 0, 400, 400, 80); // carol drives CarB: €80
+  addTrip.run(4, 2, "2025-06-04", 400, 600, 200, 40); // dave drives CarB:  €40
+  addTrip.run(1, 2, "2025-06-05", 600, 750, 150, 30); // alice drives CarB (cross-owner): €30
+  addTrip.run(1, 1, "2025-06-06", 750, 900, 150, 30); // alice drives CarA (own): €30 — shown as €0 in settlement
 }
 
 describe("getSettlement", () => {
@@ -57,7 +57,7 @@ describe("getSettlement", () => {
     const carol = result.members.find((m) => m.person_name === "Carol")!;
     const dave = result.members.find((m) => m.person_name === "Dave")!;
     expect(carol.s1).toBe(-180); // -(100+80)
-    expect(dave.s1).toBe(-90);   // -(50+40)
+    expect(dave.s1).toBe(-90); // -(50+40)
   });
 
   it("S₂ for owners uses N_new", () => {
@@ -67,7 +67,7 @@ describe("getSettlement", () => {
     const alice = result.members.find((m) => m.person_name === "Alice")!;
     const bob = result.members.find((m) => m.person_name === "Bob")!;
     expect(alice.s2).toBe(150); // N_new(CarA) = 150
-    expect(bob.s2).toBe(150);   // N_new(CarB) = 150 (includes alice cross €30)
+    expect(bob.s2).toBe(150); // N_new(CarB) = 150 (includes alice cross €30)
   });
 
   it("s1_cross for owners: their balance for using other cars", () => {
@@ -77,7 +77,7 @@ describe("getSettlement", () => {
     const alice = result.members.find((m) => m.person_name === "Alice")!;
     const bob = result.members.find((m) => m.person_name === "Bob")!;
     expect(alice.s1_cross).toBe(-30); // alice drove CarB: owes €30 to co-op
-    expect(bob.s1_cross).toBe(0);     // bob drove no other cars
+    expect(bob.s1_cross).toBe(0); // bob drove no other cars
   });
 
   it("net for owners: s2 + s1_cross", () => {
@@ -87,7 +87,7 @@ describe("getSettlement", () => {
     const alice = result.members.find((m) => m.person_name === "Alice")!;
     const bob = result.members.find((m) => m.person_name === "Bob")!;
     expect(alice.net).toBe(120); // 150 + (-30)
-    expect(bob.net).toBe(150);   // 150 + 0
+    expect(bob.net).toBe(150); // 150 + 0
   });
 
   it("verify_ok: co-op in = co-op out", () => {
@@ -103,7 +103,7 @@ describe("getSettlement", () => {
     const result = getSettlement(db, 2025);
     const step1 = result.transfers.filter((t) => t.step === 1);
     const carol = step1.find((t) => t.from === "Carol");
-    const dave  = step1.find((t) => t.from === "Dave");
+    const dave = step1.find((t) => t.from === "Dave");
     const alice = step1.find((t) => t.from === "Alice");
     expect(carol?.amount).toBe(180);
     expect(carol?.to).toBe("co-op");
@@ -119,7 +119,7 @@ describe("getSettlement", () => {
     const result = getSettlement(db, 2025);
     const step2 = result.transfers.filter((t) => t.step === 2);
     const toAlice = step2.find((t) => t.to === "Alice");
-    const toBob   = step2.find((t) => t.to === "Bob");
+    const toBob = step2.find((t) => t.to === "Bob");
     expect(toAlice?.amount).toBe(150);
     expect(toBob?.amount).toBe(150); // was 120, now includes alice cross €30
   });
@@ -137,9 +137,9 @@ describe("getSettlement", () => {
     const result = getSettlement(db, 2025);
     const carB = result.car_settlements.find((c) => c.car_short === "CB")!;
     expect(carB.total_balance).toBe(150);
-    const members    = carB.rows.filter((r) => r.row_type === "member");
+    const members = carB.rows.filter((r) => r.row_type === "member");
     const crossOwner = carB.rows.filter((r) => r.row_type === "cross_owner");
-    const own        = carB.rows.filter((r) => r.row_type === "own");
+    const own = carB.rows.filter((r) => r.row_type === "own");
     expect(members.map((r) => r.person_name).sort()).toEqual(["Carol", "Dave"]);
     expect(crossOwner).toHaveLength(1);
     expect(crossOwner[0].person_name).toBe("Alice");
@@ -172,7 +172,7 @@ describe("getSettlement", () => {
     const carol = result.members.find((m) => m.person_name === "Carol")!;
     expect(carol.s1).toBe(-160); // was -180, +20 fuel credit
     const alice = result.members.find((m) => m.person_name === "Alice")!;
-    expect(alice.s2).toBe(130);  // N_new(CarA): 150 - 20 = 130
+    expect(alice.s2).toBe(130); // N_new(CarA): 150 - 20 = 130
   });
 
   it("returns empty result when no car eras exist for the year", () => {
@@ -204,9 +204,7 @@ describe("getSettlement — payment integration", () => {
     seed(db);
     const result0 = getSettlement(db, 2025);
     // Find Carol's step-1 transfer (Carol has s1 < 0 → she owes the co-op)
-    const carolTransfer = result0.transfers.find(
-      (t) => t.step === 1 && t.from === "Carol"
-    );
+    const carolTransfer = result0.transfers.find((t) => t.step === 1 && t.from === "Carol");
     if (!carolTransfer) return; // skip if Carol has no debt
     const carolId = 3; // from seed
     // Carol pays half
@@ -222,6 +220,46 @@ describe("getSettlement — payment integration", () => {
     expect(carolT.payment_status).not.toBeNull();
     expect(carolT.payment_status!.paid).toBeCloseTo(halfAmount, 2);
     expect(carolT.payment_status!.open).toBeCloseTo(halfAmount, 2);
+  });
+
+  it("tracks co-op credit transfers with negative payments", () => {
+    const db = makeDb();
+    seed(db);
+    insertPayment(db, {
+      person_id: 2,
+      date: "2026-03-01",
+      amount: -150,
+      note: "co-op payout",
+    });
+
+    const result = getSettlement(db, 2025);
+    const bobCredit = result.transfers.find(
+      (t) => t.step === 2 && t.from === "co-op" && t.to === "Bob"
+    )!;
+
+    expect(bobCredit.amount).toBe(150);
+    expect(bobCredit.payment_status).not.toBeNull();
+    expect(bobCredit.payment_status!.paid).toBe(150);
+    expect(bobCredit.payment_status!.open).toBe(0);
+    expect(bobCredit.payment_status!.payments[0].amount).toBe(-150);
+  });
+
+  it("ignores opposite-signed payments when annotating transfer status", () => {
+    const db = makeDb();
+    seed(db);
+    insertPayment(db, { person_id: 3, date: "2026-03-01", amount: -40, note: null });
+    insertPayment(db, { person_id: 2, date: "2026-03-01", amount: 40, note: null });
+
+    const result = getSettlement(db, 2025);
+    const carolDebit = result.transfers.find((t) => t.step === 1 && t.from === "Carol")!;
+    const bobCredit = result.transfers.find(
+      (t) => t.step === 2 && t.from === "co-op" && t.to === "Bob"
+    )!;
+
+    expect(carolDebit.payment_status!.paid).toBe(0);
+    expect(carolDebit.payment_status!.open).toBe(180);
+    expect(bobCredit.payment_status!.paid).toBe(0);
+    expect(bobCredit.payment_status!.open).toBe(150);
   });
 
   it("reports all_paid=false when outstanding payments remain", () => {
@@ -242,9 +280,26 @@ describe("getSettlement — payment integration", () => {
     // Pay every transfer that has a human payer
     for (const t of result0.transfers) {
       if (t.payment_status === null) continue;
-      const payerId = nameToId[t.from];
-      if (payerId) {
-        insertPayment(db, { person_id: payerId, date: "2026-03-01", amount: t.amount, note: null });
+      if (t.from === "co-op") {
+        const recipientId = nameToId[t.to];
+        if (recipientId) {
+          insertPayment(db, {
+            person_id: recipientId,
+            date: "2026-03-01",
+            amount: -t.amount,
+            note: null,
+          });
+        }
+      } else {
+        const payerId = nameToId[t.from];
+        if (payerId) {
+          insertPayment(db, {
+            person_id: payerId,
+            date: "2026-03-01",
+            amount: t.amount,
+            note: null,
+          });
+        }
       }
     }
     const result1 = getSettlement(db, 2025);

--- a/lib/queries/settlement.ts
+++ b/lib/queries/settlement.ts
@@ -70,6 +70,25 @@ function buildNameToId(people: PersonRow[]): Map<string, number> {
   return new Map(people.map((p) => [p.name, p.id]));
 }
 
+function getTransferPaymentStatus(
+  paymentsByPerson: Map<number, { id: number; date: string; amount: number }[]>,
+  nameToId: Map<string, number>,
+  tr: Omit<AnnotatedTransfer, "payment_status">
+): AnnotatedTransfer["payment_status"] {
+  const personName = tr.from === "co-op" ? tr.to : tr.from;
+  const personId = nameToId.get(personName) ?? null;
+  if (personId === null) return null;
+
+  const personPayments = paymentsByPerson.get(personId) ?? [];
+  const matchingPayments = personPayments.filter((p) =>
+    tr.from === "co-op" ? p.amount < 0 : p.amount > 0
+  );
+  const paid = round2(matchingPayments.reduce((s, p) => s + Math.abs(p.amount), 0));
+  const open = round2(Math.max(0, tr.amount - paid));
+
+  return { paid, open, payments: matchingPayments };
+}
+
 function reduceDebts(
   positions: Map<string, number>
 ): { from: string; to: string; amount: number }[] {
@@ -225,13 +244,13 @@ export function getSettlement(db: Database.Database, year: number): SettlementRe
     )
     .all(yearStr) as AmountRow[];
 
-  const trips       = buildMap(tripRows);
-  const tripKm      = buildMap(tripKmRows);
-  const fuel        = buildMap(fuelRows);
-  const fuelLiters  = buildMap(fuelLiterRows);
-  const exp         = buildMap(expRows);
+  const trips = buildMap(tripRows);
+  const tripKm = buildMap(tripKmRows);
+  const fuel = buildMap(fuelRows);
+  const fuelLiters = buildMap(fuelLiterRows);
+  const exp = buildMap(expRows);
   const fuelSettled = buildSettledMap(fuelSettledRows);
-  const expSettled  = buildSettledMap(expSettledRows);
+  const expSettled = buildSettledMap(expSettledRows);
 
   // 6. Car-era lookup by owner
   const carsByOwner = new Map<string, CarEraRow[]>();
@@ -248,7 +267,7 @@ export function getSettlement(db: Database.Database, year: number): SettlementRe
   ): import("@/types").CarParticipantRow {
     const tripAmt = rowType === "own" ? 0 : get(trips, p.id, era.id);
     const fuelAmt = rowType === "own" ? 0 : get(fuel, p.id, era.id);
-    const expAmt  = rowType === "own" ? 0 : get(exp, p.id, era.id);
+    const expAmt = rowType === "own" ? 0 : get(exp, p.id, era.id);
     const fs = fuelSettled.get(p.id)?.get(era.id);
     const es = expSettled.get(p.id)?.get(era.id);
     return {
@@ -302,7 +321,8 @@ export function getSettlement(db: Database.Database, year: number): SettlementRe
     let s1c = 0;
     for (const era of carEras) {
       if (era.owner_name === owner.name) continue; // skip own car
-      s1c += -get(trips, owner.id, era.id) + get(fuel, owner.id, era.id) + get(exp, owner.id, era.id);
+      s1c +=
+        -get(trips, owner.id, era.id) + get(fuel, owner.id, era.id) + get(exp, owner.id, era.id);
     }
     S1Cross.set(owner.name, round2(s1c));
   }
@@ -315,7 +335,7 @@ export function getSettlement(db: Database.Database, year: number): SettlementRe
     for (const p of nonOwners) {
       const tripAmt = get(trips, p.id, era.id);
       const fuelAmt = get(fuel, p.id, era.id);
-      const expAmt  = get(exp, p.id, era.id);
+      const expAmt = get(exp, p.id, era.id);
       if (tripAmt === 0 && fuelAmt === 0 && expAmt === 0) continue;
       rows.push(makeRow(p, era, "member"));
     }
@@ -325,7 +345,7 @@ export function getSettlement(db: Database.Database, year: number): SettlementRe
       if (o.name === era.owner_name) continue;
       const tripAmt = get(trips, o.id, era.id);
       const fuelAmt = get(fuel, o.id, era.id);
-      const expAmt  = get(exp, o.id, era.id);
+      const expAmt = get(exp, o.id, era.id);
       if (tripAmt === 0 && fuelAmt === 0 && expAmt === 0) continue;
       rows.push(makeRow(o, era, "cross_owner"));
     }
@@ -364,19 +384,25 @@ export function getSettlement(db: Database.Database, year: number): SettlementRe
       .map((era) => {
         const tripAmt = get(trips, p.id, era.id);
         const fuelAmt = get(fuel, p.id, era.id);
-        const expAmt  = get(exp, p.id, era.id);
+        const expAmt = get(exp, p.id, era.id);
         const fs = fuelSettled.get(p.id)?.get(era.id);
         const es = expSettled.get(p.id)?.get(era.id);
         return {
-          car_name: era.name, car_short: era.short,
-          owner_name: era.owner_name, owner_from: era.owner_from,
+          car_name: era.name,
+          car_short: era.short,
+          owner_name: era.owner_name,
+          owner_from: era.owner_from,
           owner_to: era.owner_to === "9999-12-31" ? null : era.owner_to,
-          trip_amount: tripAmt, trip_km: get(tripKm, p.id, era.id),
-          fuel_amount: fuelAmt, fuel_liters: get(fuelLiters, p.id, era.id),
+          trip_amount: tripAmt,
+          trip_km: get(tripKm, p.id, era.id),
+          fuel_amount: fuelAmt,
+          fuel_liters: get(fuelLiters, p.id, era.id),
           expense_amount: expAmt,
           balance: round2(-tripAmt + fuelAmt + expAmt),
-          fuel_settled_count: fs?.cnt, fuel_settled_liters: fs?.amount,
-          expense_settled_count: es?.cnt, expense_settled_amount: es?.amount,
+          fuel_settled_count: fs?.cnt,
+          fuel_settled_liters: fs?.amount,
+          expense_settled_count: es?.cnt,
+          expense_settled_amount: es?.amount,
         };
       })
       .filter((e) => e.trip_amount > 0 || e.fuel_amount > 0 || e.expense_amount > 0);
@@ -387,14 +413,20 @@ export function getSettlement(db: Database.Database, year: number): SettlementRe
   }
 
   for (const o of owners) {
-    const s2       = S2.get(o.name) ?? 0;
+    const s2 = S2.get(o.name) ?? 0;
     const s1_cross = S1Cross.get(o.name) ?? 0;
     const ownedCars = carsByOwner.get(o.name) ?? [];
     const car_eras: CarEraBalance[] = ownedCars.map((era) => ({
-      car_name: era.name, car_short: era.short,
-      owner_name: era.owner_name, owner_from: era.owner_from,
+      car_name: era.name,
+      car_short: era.short,
+      owner_name: era.owner_name,
+      owner_from: era.owner_from,
       owner_to: era.owner_to === "9999-12-31" ? null : era.owner_to,
-      trip_amount: 0, trip_km: 0, fuel_amount: 0, fuel_liters: 0, expense_amount: 0,
+      trip_amount: 0,
+      trip_km: 0,
+      fuel_amount: 0,
+      fuel_liters: 0,
+      expense_amount: 0,
       balance: N.get(era.id) ?? 0,
       n_c_star: N.get(era.id) ?? 0,
       member_contributions: [...nonOwners, ...owners.filter((j) => j.name !== o.name)]
@@ -406,7 +438,9 @@ export function getSettlement(db: Database.Database, year: number): SettlementRe
             trip_km: get(tripKm, p.id, era.id),
             fuel_liters: get(fuelLiters, p.id, era.id),
             expense_amount: get(exp, p.id, era.id),
-            contribution: round2(get(trips, p.id, era.id) - get(fuel, p.id, era.id) - get(exp, p.id, era.id)),
+            contribution: round2(
+              get(trips, p.id, era.id) - get(fuel, p.id, era.id) - get(exp, p.id, era.id)
+            ),
             fuel_settled_count: fs?.cnt ?? 0,
             fuel_settled_liters: fs?.amount ?? 0,
             expense_settled_count: es?.cnt ?? 0,
@@ -418,8 +452,13 @@ export function getSettlement(db: Database.Database, year: number): SettlementRe
     }));
 
     members.push({
-      person_id: o.id, person_name: o.name, is_owner: true,
-      s2, s1_cross, net: round2(s2 + s1_cross), car_eras,
+      person_id: o.id,
+      person_name: o.name,
+      is_owner: true,
+      s2,
+      s1_cross,
+      net: round2(s2 + s1_cross),
+      car_eras,
     });
   }
 
@@ -438,9 +477,21 @@ export function getSettlement(db: Database.Database, year: number): SettlementRe
     const s1 = S1.get(p.id) ?? 0;
     if (Math.abs(s1) < 0.005) continue;
     if (s1 < 0) {
-      transfers.push({ from: p.name, to: "co-op", amount: round2(-s1), step: 1, label: `${p.name} → co-op` });
+      transfers.push({
+        from: p.name,
+        to: "co-op",
+        amount: round2(-s1),
+        step: 1,
+        label: `${p.name} → co-op`,
+      });
     } else {
-      transfers.push({ from: "co-op", to: p.name, amount: s1, step: 1, label: `co-op → ${p.name}` });
+      transfers.push({
+        from: "co-op",
+        to: p.name,
+        amount: s1,
+        step: 1,
+        label: `co-op → ${p.name}`,
+      });
     }
   }
 
@@ -448,9 +499,21 @@ export function getSettlement(db: Database.Database, year: number): SettlementRe
     const s1c = S1Cross.get(o.name) ?? 0;
     if (Math.abs(s1c) < 0.005) continue;
     if (s1c < 0) {
-      transfers.push({ from: o.name, to: "co-op", amount: round2(-s1c), step: 1, label: `${o.name} → co-op` });
+      transfers.push({
+        from: o.name,
+        to: "co-op",
+        amount: round2(-s1c),
+        step: 1,
+        label: `${o.name} → co-op`,
+      });
     } else {
-      transfers.push({ from: "co-op", to: o.name, amount: s1c, step: 1, label: `co-op → ${o.name}` });
+      transfers.push({
+        from: "co-op",
+        to: o.name,
+        amount: s1c,
+        step: 1,
+        label: `co-op → ${o.name}`,
+      });
     }
   }
 
@@ -465,15 +528,8 @@ export function getSettlement(db: Database.Database, year: number): SettlementRe
   const nameToId = buildNameToId(people);
 
   const annotatedTransfers: AnnotatedTransfer[] = transfers.map((tr) => {
-    // Only track payment from the human payer side (not co-op)
-    const payerName = tr.from !== "co-op" ? tr.from : null;
-    if (payerName === null) return { ...tr, payment_status: null };
-    const payerId = nameToId.get(payerName) ?? null;
-    if (payerId === null) return { ...tr, payment_status: null };
-    const personPayments = paymentsByPerson.get(payerId) ?? [];
-    const paid = round2(personPayments.reduce((s, p) => s + p.amount, 0));
-    const open = round2(Math.max(0, tr.amount - paid));
-    return { ...tr, payment_status: { paid, open, payments: personPayments } };
+    const payment_status = getTransferPaymentStatus(paymentsByPerson, nameToId, tr);
+    return { ...tr, payment_status };
   });
 
   const humanTransfers = annotatedTransfers.filter((t) => t.payment_status !== null);
@@ -482,18 +538,25 @@ export function getSettlement(db: Database.Database, year: number): SettlementRe
     humanTransfers.every((t) => (t.payment_status?.open ?? 1) < 0.005);
 
   // 15. Verify: Σ S1 + Σ S1Cross + Σ S2 ≈ 0
-  const sumS1     = [...S1.values()].reduce((s, v) => s + v, 0);
-  const sumS1c    = [...S1Cross.values()].reduce((s, v) => s + v, 0);
-  const sumS2     = [...S2.values()].reduce((s, v) => s + v, 0);
+  const sumS1 = [...S1.values()].reduce((s, v) => s + v, 0);
+  const sumS1c = [...S1Cross.values()].reduce((s, v) => s + v, 0);
+  const sumS2 = [...S2.values()].reduce((s, v) => s + v, 0);
   const verify_ok = Math.abs(sumS1 + sumS1c + sumS2) < 0.05;
 
   return {
-    year, frozen: !!lock,
+    year,
+    frozen: !!lock,
     settled_at: lock?.settled_at ?? null,
     settled_by: lock?.settled_by ?? null,
-    members, car_settlements, transfers: annotatedTransfers, verify_ok,
+    members,
+    car_settlements,
+    transfers: annotatedTransfers,
+    verify_ok,
     payments_by_person: Object.fromEntries(
-      [...paymentsByPerson.entries()].map(([id, rows]) => [id, rows.reduce((s, p) => s + p.amount, 0)])
+      [...paymentsByPerson.entries()].map(([id, rows]) => [
+        id,
+        rows.reduce((s, p) => s + p.amount, 0),
+      ])
     ),
     all_paid,
   };


### PR DESCRIPTION
﻿## Summary
- annotate `co-op -> member` settlement transfers with payment status instead of leaving them untracked
- count negative payments on the recipient as co-op disbursements, while normal member-to-co-op transfers only count positive payments
- add regressions for resolved co-op credits, opposite-signed payment isolation, and all-paid settlement coverage

Fixes #112.

## Validation
- npm test -- lib/__tests__/settlement.test.ts
- npx tsc --noEmit --pretty false
- npm run lint
- npm run test:coverage
