### PR TITLE
feat(dashboard): owner card with per-car breakdown

### DIFF
--- a/app/expenses/page.tsx
+++ b/app/expenses/page.tsx
@@ -66,6 +66,7 @@ function ExpensesContent() {
     !isLoading && editingId ? (expenses.find((e) => e.id === editingId) ?? null) : null;
 
   const isMine = mineParam === "true";
+  const isOthers = mineParam === "false";
   const canFilter = me?.personId != null;
   const cars = Array.from(
     new Set(expenses.map((e) => e.car_short).filter((s): s is string => !!s))
@@ -75,7 +76,11 @@ function ExpensesContent() {
     .reverse();
 
   const visible = expenses
-    .filter((e) => (isMine && canFilter ? e.person_id === me!.personId : true))
+    .filter((e) => {
+      if (isMine && canFilter) return e.person_id === me!.personId;
+      if (isOthers && canFilter) return e.person_id !== me!.personId;
+      return true;
+    })
     .filter((e) => (carFilter ? e.car_short === carFilter : true))
     .filter((e) => (yearFilter ? e.date.startsWith(yearFilter) : true));
 

--- a/app/fuel/page.tsx
+++ b/app/fuel/page.tsx
@@ -66,6 +66,7 @@ function FuelContent() {
     !isLoading && editingId ? (fillups.find((f) => f.id === editingId) ?? null) : null;
 
   const isMine = mineParam === "true";
+  const isOthers = mineParam === "false";
   const canFilter = me?.personId != null;
   const cars = Array.from(
     new Set(fillups.map((f) => f.car_short).filter((s): s is string => !!s))
@@ -75,7 +76,11 @@ function FuelContent() {
     .reverse();
 
   const visible = fillups
-    .filter((f) => (isMine && canFilter ? f.person_id === me!.personId : true))
+    .filter((f) => {
+      if (isMine && canFilter) return f.person_id === me!.personId;
+      if (isOthers && canFilter) return f.person_id !== me!.personId;
+      return true;
+    })
     .filter((f) => (carFilter ? f.car_short === carFilter : true))
     .filter((f) => (yearFilter ? f.date.startsWith(yearFilter) : true));
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,16 @@ import { useFuelFillups } from "@/hooks/use-fuel-fillups";
 import { useReservations } from "@/hooks/use-reservations";
 import { useExpenses } from "@/hooks/use-expenses";
 import { MultiFab } from "@/components/fab";
-import { paper, fontMono, fontSerif, fmtMoney, fmtDate, fmtKm, amtColor, signPrefix } from "@/lib/paper-theme";
+import {
+  paper,
+  fontMono,
+  fontSerif,
+  fmtMoney,
+  fmtDate,
+  fmtKm,
+  amtColor,
+  signPrefix,
+} from "@/lib/paper-theme";
 import type { Trip, FuelFillup, Reservation, Expense } from "@/types";
 import * as Dialog from "@radix-ui/react-dialog";
 import { TripForm } from "@/app/trips/trip-form";
@@ -22,6 +31,8 @@ import { FuelCard } from "@/components/fuel-card";
 import { ExpenseCard } from "@/components/expense-card";
 import { ReservationCard } from "@/components/reservation-card";
 import { useMe } from "@/hooks/use-me";
+import { useSettlement } from "@/hooks/use-settlement";
+import type { CarDashboardBreakdown } from "@/types";
 import {
   useCreateTrip,
   useUpdateTrip,
@@ -53,7 +64,7 @@ function ReceiptRow({
   href,
 }: {
   label: string;
-  value: string;
+  value?: string;
   big?: boolean;
   color?: string;
   href?: string;
@@ -102,7 +113,7 @@ function ReceiptRow({
           color: c,
         }}
       >
-        {value}
+        {value ?? ""}
       </span>
     </div>
   );
@@ -121,6 +132,169 @@ function ReceiptRow({
   return inner;
 }
 
+// ── Car Breakdown Section ─────────────────────────────────────────
+function CarBreakdownSection({ bd, year }: { bd: CarDashboardBreakdown; year: number }) {
+  const fmtL = (l: number) => l.toFixed(0);
+  const headerLabel = `${bd.car_short} — ${bd.car_name}`;
+  const headerNet = bd.net_car;
+
+  if (bd.is_own_car) {
+    const othersHasData = bd.trip_count > 0 || bd.fuel_count > 0 || bd.expense_count > 0;
+    const ownHasData = bd.own_trip_count > 0 || bd.own_fuel_count > 0 || bd.own_expense_count > 0;
+
+    return (
+      <div>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            fontFamily: fontMono,
+            fontSize: 11,
+            fontWeight: 700,
+            color: paper.ink,
+            padding: "4px 0 2px",
+          }}
+        >
+          <span>{headerLabel}</span>
+          <span style={{ color: amtColor(headerNet) }}>
+            {headerNet >= 0 ? `+ ${fmtMoney(headerNet)}` : `− ${fmtMoney(Math.abs(headerNet))}`}
+          </span>
+        </div>
+
+        {othersHasData && (
+          <div style={{ paddingLeft: 8, marginTop: 2 }}>
+            <div
+              style={{
+                fontFamily: fontMono,
+                fontSize: 9,
+                letterSpacing: 1,
+                color: paper.inkMute,
+                textTransform: "uppercase",
+                marginBottom: 2,
+              }}
+            >
+              Anderen
+            </div>
+            {bd.trip_count > 0 && (
+              <ReceiptRow
+                href={`/trips?mine=false&car=${bd.car_short}&year=${year}`}
+                label={`${bd.trip_count} ritten · ${bd.trip_km.toLocaleString("nl-BE")} km`}
+                value={`+ ${fmtMoney(bd.trip_amount)}`}
+                color={paper.green}
+              />
+            )}
+            {bd.fuel_count > 0 && (
+              <ReceiptRow
+                href={`/fuel?mine=false&car=${bd.car_short}&year=${year}`}
+                label={`${bd.fuel_count} tankbeurten, ${fmtL(bd.fuel_liters)} L`}
+                value={`− ${fmtMoney(bd.fuel_amount)}`}
+                color={paper.accent}
+              />
+            )}
+            {bd.expense_count > 0 && (
+              <ReceiptRow
+                href={`/expenses?mine=false&car=${bd.car_short}&year=${year}`}
+                label={`${bd.expense_count} kosten`}
+                value={`− ${fmtMoney(bd.expense_amount)}`}
+                color={paper.accent}
+              />
+            )}
+          </div>
+        )}
+
+        {ownHasData && (
+          <div style={{ paddingLeft: 8, marginTop: 4 }}>
+            <div
+              style={{
+                fontFamily: fontMono,
+                fontSize: 9,
+                letterSpacing: 1,
+                color: paper.inkMute,
+                textTransform: "uppercase",
+                marginBottom: 2,
+              }}
+            >
+              Eigen
+            </div>
+            {bd.own_trip_count > 0 && (
+              <ReceiptRow
+                href={`/trips?mine=true&car=${bd.car_short}&year=${year}`}
+                label={`${bd.own_trip_count} ritten · ${bd.own_trip_km.toLocaleString("nl-BE")} km`}
+                color={paper.inkMute}
+              />
+            )}
+            {bd.own_fuel_count > 0 && (
+              <ReceiptRow
+                href={`/fuel?mine=true&car=${bd.car_short}&year=${year}`}
+                label={`${bd.own_fuel_count} tankbeurten, ${fmtL(bd.own_fuel_liters)} L`}
+                color={paper.inkMute}
+              />
+            )}
+            {bd.own_expense_count > 0 && (
+              <ReceiptRow
+                href={`/expenses?mine=true&car=${bd.car_short}&year=${year}`}
+                label={`${bd.own_expense_count} kosten`}
+                color={paper.inkMute}
+              />
+            )}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // Cross-car section
+  const hasData = bd.trip_count > 0 || bd.fuel_count > 0 || bd.expense_count > 0;
+  if (!hasData) return null;
+
+  return (
+    <div>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          fontFamily: fontMono,
+          fontSize: 11,
+          fontWeight: 700,
+          color: paper.ink,
+          padding: "4px 0 2px",
+        }}
+      >
+        <span>{headerLabel}</span>
+        <span style={{ color: amtColor(headerNet) }}>
+          {headerNet >= 0 ? `+ ${fmtMoney(headerNet)}` : `− ${fmtMoney(Math.abs(headerNet))}`}
+        </span>
+      </div>
+      <div style={{ paddingLeft: 8 }}>
+        {bd.trip_count > 0 && (
+          <ReceiptRow
+            href={`/trips?mine=true&year=${year}`}
+            label={`${bd.trip_count} ritten · ${bd.trip_km.toLocaleString("nl-BE")} km`}
+            value={`− ${fmtMoney(bd.trip_amount)}`}
+            color={paper.accent}
+          />
+        )}
+        {bd.fuel_count > 0 && (
+          <ReceiptRow
+            href={`/fuel?mine=true&car=${bd.car_short}&year=${year}`}
+            label={`${bd.fuel_count} tankbeurten, ${fmtL(bd.fuel_liters)} L`}
+            value={`+ ${fmtMoney(bd.fuel_amount)}`}
+            color={paper.green}
+          />
+        )}
+        {bd.expense_count > 0 && (
+          <ReceiptRow
+            href={`/expenses?mine=true&car=${bd.car_short}&year=${year}`}
+            label={`${bd.expense_count} kosten`}
+            value={`+ ${fmtMoney(bd.expense_amount)}`}
+            color={paper.green}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
 // ── Balance Receipt ───────────────────────────────────────────────
 function BalanceReceipt({ personName }: { personName: string }) {
   const t = useT();
@@ -129,6 +303,9 @@ function BalanceReceipt({ personName }: { personName: string }) {
   const { data: earliestYear = currentYear } = useEarliestDashboardYear();
   const { data: rows = [] } = useDashboard(year);
   const myRow = rows.find((r) => r.person_name === personName);
+  const { data: settlement } = useSettlement(year);
+  const myStatement = settlement?.members.find((m) => m.person_name === personName);
+  const owner_net: number | null = myRow?.is_owner ? (myStatement?.net ?? null) : null;
   if (!myRow) return null;
 
   const pl = (n: number, s: string, p: string) => (n === 1 ? s : p);
@@ -208,11 +385,33 @@ function BalanceReceipt({ personName }: { personName: string }) {
       {/* Receipt card */}
       <div
         style={{
+          position: "relative",
           background: paper.paper,
           padding: "20px 18px 22px",
           boxShadow: "0 1px 2px rgba(0,0,0,0.05), 0 8px 24px rgba(0,0,0,0.07)",
         }}
       >
+        {/* Owner badge */}
+        {myRow.is_owner && (
+          <span
+            style={{
+              position: "absolute",
+              top: 16,
+              right: 16,
+              fontFamily: fontMono,
+              fontSize: 8,
+              fontWeight: 700,
+              letterSpacing: 1.5,
+              textTransform: "uppercase",
+              color: paper.paper,
+              background: paper.green,
+              padding: "2px 7px",
+            }}
+          >
+            eigenaar
+          </span>
+        )}
+
         {/* Title */}
         <div
           style={{
@@ -229,87 +428,180 @@ function BalanceReceipt({ personName }: { personName: string }) {
         </div>
         <Perf margin="10px 0 12px" />
 
-        {/* Activity lines */}
-        <ReceiptRow
-          href={`/trips?mine=true&year=${year}`}
-          label={tripLabel}
-          value={`− ${fmtMoney(Math.abs(myRow.trip_amount))}`}
-          color={paper.accent}
-        />
-        <ReceiptRow
-          href={`/fuel?mine=true&year=${year}`}
-          label={fuelLabel}
-          value={`+ ${fmtMoney(myRow.fuel_amount)}`}
-          color={paper.green}
-        />
-        <ReceiptRow
-          href={`/expenses?mine=true&year=${year}`}
-          label={expenseLabel}
-          value={`+ ${fmtMoney(myRow.expense_amount)}`}
-          color={paper.green}
-        />
-
-        {/* Total */}
-        <Perf margin="10px 0" />
-        <ReceiptRow
-          label={t("dashboard.total_label")}
-          value={`${signPrefix(myRow.total_amount)}${fmtMoney(myRow.total_amount)}`}
-          color={amtColor(myRow.total_amount)}
-          big
-        />
-
-        {/* Payment row — always shown */}
-        <Perf margin="10px 0" />
-        {myRow.paid_amount !== 0 ? (
-          <ReceiptRow
-            label={t("dashboard.paid_label")}
-            value={`${signPrefix(-myRow.paid_amount)}${fmtMoney(myRow.paid_amount)}`}
-          />
-        ) : (
-          <ReceiptRow label={t("dashboard.not_yet_paid")} value="—" color={paper.inkMute} />
-        )}
-
-        {/* Balance row — only when a payment has been recorded */}
-        {myRow.paid_amount !== 0 && (
+        {myRow.is_owner ? (
           <>
+            {/* Per-car breakdowns */}
+            {myRow.car_breakdowns.map((bd, i) => (
+              <div key={bd.car_short}>
+                {i > 0 && <Perf margin="10px 0" />}
+                <CarBreakdownSection bd={bd} year={year} />
+              </div>
+            ))}
+
+            {/* Total */}
             <Perf margin="10px 0" />
-            <div
-              style={{
-                display: "flex",
-                justifyContent: "space-between",
-                alignItems: "baseline",
-                padding: "4px 0",
-              }}
-            >
-              <span
-                style={{
-                  fontFamily: fontMono,
-                  fontSize: 10,
-                  letterSpacing: 2,
-                  textTransform: "uppercase",
-                  color: paper.inkDim,
-                  whiteSpace: "nowrap",
-                  marginRight: 12,
-                }}
-              >
-                {t("dashboard.balance_label")}
-              </span>
-              <span
-                style={{
-                  fontFamily: fontSerif,
-                  fontSize: 28,
-                  fontWeight: 700,
-                  color: balanceColor,
-                  letterSpacing: -1,
-                  lineHeight: 1,
-                  whiteSpace: "nowrap",
-                }}
-              >
-                {settled
-                  ? `${fmtMoney(0)} ✓`
-                  : `${signPrefix(myRow.balance)}${fmtMoney(myRow.balance)}`}
-              </span>
-            </div>
+            <ReceiptRow
+              label={t("dashboard.total_label")}
+              value={
+                owner_net !== null
+                  ? owner_net >= 0
+                    ? `+ ${fmtMoney(owner_net)}`
+                    : `− ${fmtMoney(Math.abs(owner_net))}`
+                  : "—"
+              }
+              color={owner_net !== null ? amtColor(owner_net) : paper.inkMute}
+              big
+            />
+
+            {/* Payment */}
+            <Perf margin="10px 0" />
+            {myRow.paid_amount !== 0 ? (
+              <ReceiptRow
+                label={t("dashboard.paid_label")}
+                value={`${signPrefix(-myRow.paid_amount)}${fmtMoney(myRow.paid_amount)}`}
+              />
+            ) : (
+              <ReceiptRow label={t("dashboard.not_yet_paid")} value="—" color={paper.inkMute} />
+            )}
+
+            {/* Balance = owner_net + paid_amount */}
+            {myRow.paid_amount !== 0 &&
+              owner_net !== null &&
+              (() => {
+                const saldo = Math.round((owner_net + myRow.paid_amount) * 100) / 100;
+                const isSettled = Math.abs(saldo) <= 0.05;
+                return (
+                  <>
+                    <Perf margin="10px 0" />
+                    <div
+                      style={{
+                        display: "flex",
+                        justifyContent: "space-between",
+                        alignItems: "baseline",
+                        padding: "4px 0",
+                      }}
+                    >
+                      <span
+                        style={{
+                          fontFamily: fontMono,
+                          fontSize: 10,
+                          letterSpacing: 2,
+                          textTransform: "uppercase",
+                          color: paper.inkDim,
+                          whiteSpace: "nowrap",
+                          marginRight: 12,
+                        }}
+                      >
+                        {t("dashboard.balance_label")}
+                      </span>
+                      <span
+                        style={{
+                          fontFamily: fontSerif,
+                          fontSize: 28,
+                          fontWeight: 700,
+                          color: isSettled ? paper.green : paper.accent,
+                          letterSpacing: -1,
+                          lineHeight: 1,
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {isSettled
+                          ? `${fmtMoney(0)} ✓`
+                          : saldo >= 0
+                            ? `+ ${fmtMoney(saldo)}`
+                            : `− ${fmtMoney(Math.abs(saldo))}`}
+                      </span>
+                    </div>
+                  </>
+                );
+              })()}
+          </>
+        ) : (
+          <>
+            {/* ── NON-OWNER: existing code ── */}
+            {/* Activity lines */}
+            <ReceiptRow
+              href={`/trips?mine=true&year=${year}`}
+              label={tripLabel}
+              value={`− ${fmtMoney(Math.abs(myRow.trip_amount))}`}
+              color={paper.accent}
+            />
+            <ReceiptRow
+              href={`/fuel?mine=true&year=${year}`}
+              label={fuelLabel}
+              value={`+ ${fmtMoney(myRow.fuel_amount)}`}
+              color={paper.green}
+            />
+            <ReceiptRow
+              href={`/expenses?mine=true&year=${year}`}
+              label={expenseLabel}
+              value={`+ ${fmtMoney(myRow.expense_amount)}`}
+              color={paper.green}
+            />
+
+            {/* Total */}
+            <Perf margin="10px 0" />
+            <ReceiptRow
+              label={t("dashboard.total_label")}
+              value={`${signPrefix(myRow.total_amount)}${fmtMoney(myRow.total_amount)}`}
+              color={amtColor(myRow.total_amount)}
+              big
+            />
+
+            {/* Payment row — always shown */}
+            <Perf margin="10px 0" />
+            {myRow.paid_amount !== 0 ? (
+              <ReceiptRow
+                label={t("dashboard.paid_label")}
+                value={`${signPrefix(-myRow.paid_amount)}${fmtMoney(myRow.paid_amount)}`}
+              />
+            ) : (
+              <ReceiptRow label={t("dashboard.not_yet_paid")} value="—" color={paper.inkMute} />
+            )}
+
+            {/* Balance row — only when a payment has been recorded */}
+            {myRow.paid_amount !== 0 && (
+              <>
+                <Perf margin="10px 0" />
+                <div
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "baseline",
+                    padding: "4px 0",
+                  }}
+                >
+                  <span
+                    style={{
+                      fontFamily: fontMono,
+                      fontSize: 10,
+                      letterSpacing: 2,
+                      textTransform: "uppercase",
+                      color: paper.inkDim,
+                      whiteSpace: "nowrap",
+                      marginRight: 12,
+                    }}
+                  >
+                    {t("dashboard.balance_label")}
+                  </span>
+                  <span
+                    style={{
+                      fontFamily: fontSerif,
+                      fontSize: 28,
+                      fontWeight: 700,
+                      color: balanceColor,
+                      letterSpacing: -1,
+                      lineHeight: 1,
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {settled
+                      ? `${fmtMoney(0)} ✓`
+                      : `${signPrefix(myRow.balance)}${fmtMoney(myRow.balance)}`}
+                  </span>
+                </div>
+              </>
+            )}
           </>
         )}
       </div>

--- a/app/trips/page.tsx
+++ b/app/trips/page.tsx
@@ -63,6 +63,7 @@ function TripsContent() {
     !isLoading && editingId ? (trips.find((tr) => tr.id === editingId) ?? null) : null;
 
   const isMine = mineParam === "true";
+  const isOthers = mineParam === "false";
   const canFilter = me?.personId != null;
   const cars = Array.from(
     new Set(trips.map((tr) => tr.car_short).filter((s): s is string => !!s))
@@ -72,7 +73,11 @@ function TripsContent() {
     .reverse();
 
   const visible = trips
-    .filter((tr) => (isMine && canFilter ? tr.person_id === me!.personId : true))
+    .filter((tr) => {
+      if (isMine && canFilter) return tr.person_id === me!.personId;
+      if (isOthers && canFilter) return tr.person_id !== me!.personId;
+      return true;
+    })
     .filter((tr) => (carFilter ? tr.car_short === carFilter : true))
     .filter((tr) => (yearFilter ? tr.date.startsWith(yearFilter) : true));
 

--- a/lib/queries/dashboard.ts
+++ b/lib/queries/dashboard.ts
@@ -23,6 +23,41 @@ interface PaymentAgg {
   paid_amount: number;
 }
 
+interface OwnCarRow {
+  owner_person_id: number;
+  car_id: number;
+  car_short: string;
+  car_name: string;
+  others_trip_count: number;
+  others_trip_km: number;
+  others_trip_amount: number;
+  others_fuel_count: number;
+  others_fuel_liters: number;
+  others_fuel_amount: number;
+  others_expense_count: number;
+  others_expense_amount: number;
+  own_trip_count: number;
+  own_trip_km: number;
+  own_fuel_count: number;
+  own_fuel_liters: number;
+  own_expense_count: number;
+}
+
+interface CrossCarRow {
+  person_id: number;
+  car_id: number;
+  car_short: string;
+  car_name: string;
+  trip_count: number;
+  trip_km: number;
+  trip_amount: number;
+  fuel_count: number;
+  fuel_liters: number;
+  fuel_amount: number;
+  expense_count: number;
+  expense_amount: number;
+}
+
 export function getEarliestYear(db: Database.Database): number {
   const row = db
     .prepare(
@@ -101,6 +136,116 @@ export function getDashboard(db: Database.Database, year: number): DashboardRow[
     )
     .all(year) as PaymentAgg[];
 
+  // Owners: per-car breakdown for cars they own
+  const ownCarRows = db
+    .prepare(
+      `
+      SELECT
+        p_owner.id                                                          AS owner_person_id,
+        c.id                                                                AS car_id,
+        c.short                                                             AS car_short,
+        c.name                                                              AS car_name,
+        COUNT(CASE WHEN t.person_id != p_owner.id THEN 1 END)              AS others_trip_count,
+        COALESCE(SUM(CASE WHEN t.person_id != p_owner.id THEN t.km END), 0)     AS others_trip_km,
+        COALESCE(SUM(CASE WHEN t.person_id != p_owner.id THEN t.amount END), 0) AS others_trip_amount,
+        COALESCE((SELECT COUNT(*) FROM fuel_fillups f
+          WHERE f.car_id = c.id AND f.person_id != p_owner.id
+            AND f.settled_outside = 0 AND strftime('%Y', f.date) = ?), 0)  AS others_fuel_count,
+        COALESCE((SELECT SUM(f.liters) FROM fuel_fillups f
+          WHERE f.car_id = c.id AND f.person_id != p_owner.id
+            AND f.settled_outside = 0 AND strftime('%Y', f.date) = ?), 0)  AS others_fuel_liters,
+        COALESCE((SELECT SUM(f.amount) FROM fuel_fillups f
+          WHERE f.car_id = c.id AND f.person_id != p_owner.id
+            AND f.settled_outside = 0 AND strftime('%Y', f.date) = ?), 0)  AS others_fuel_amount,
+        COALESCE((SELECT COUNT(*) FROM expenses e
+          WHERE e.car_id = c.id AND e.person_id != p_owner.id
+            AND e.settled_outside = 0 AND strftime('%Y', e.date) = ?), 0)  AS others_expense_count,
+        COALESCE((SELECT SUM(e.amount) FROM expenses e
+          WHERE e.car_id = c.id AND e.person_id != p_owner.id
+            AND e.settled_outside = 0 AND strftime('%Y', e.date) = ?), 0)  AS others_expense_amount,
+        COUNT(CASE WHEN t.person_id = p_owner.id THEN 1 END)               AS own_trip_count,
+        COALESCE(SUM(CASE WHEN t.person_id = p_owner.id THEN t.km END), 0) AS own_trip_km,
+        COALESCE((SELECT COUNT(*) FROM fuel_fillups f
+          WHERE f.car_id = c.id AND f.person_id = p_owner.id
+            AND strftime('%Y', f.date) = ?), 0)                            AS own_fuel_count,
+        COALESCE((SELECT SUM(f.liters) FROM fuel_fillups f
+          WHERE f.car_id = c.id AND f.person_id = p_owner.id
+            AND strftime('%Y', f.date) = ?), 0)                            AS own_fuel_liters,
+        COALESCE((SELECT COUNT(*) FROM expenses e
+          WHERE e.car_id = c.id AND e.person_id = p_owner.id
+            AND strftime('%Y', e.date) = ?), 0)                            AS own_expense_count
+      FROM cars c
+      JOIN people p_owner ON c.owner_name = p_owner.name
+      LEFT JOIN trips t ON t.car_id = c.id AND strftime('%Y', t.date) = ?
+      WHERE c.owner_name IS NOT NULL
+      GROUP BY c.id, p_owner.id
+      `
+    )
+    .all(
+      yearStr,
+      yearStr,
+      yearStr,
+      yearStr,
+      yearStr,
+      yearStr,
+      yearStr,
+      yearStr,
+      yearStr
+    ) as OwnCarRow[];
+  // bind count: 5 subquery params (fuel_count,liters,amount,expense_count,amount) + 2 own subqueries (fuel,expense) + 1 own expense count + 1 LEFT JOIN = 9
+
+  // Owners: trips/fuel/expenses on OTHER owners' cars
+  const crossCarRows = db
+    .prepare(
+      `
+      SELECT
+        t.person_id                                                         AS person_id,
+        c.id                                                                AS car_id,
+        c.short                                                             AS car_short,
+        c.name                                                              AS car_name,
+        COUNT(t.id)                                                         AS trip_count,
+        COALESCE(SUM(t.km), 0)                                             AS trip_km,
+        COALESCE(SUM(t.amount), 0)                                         AS trip_amount,
+        COALESCE((SELECT COUNT(*) FROM fuel_fillups f
+          WHERE f.car_id = c.id AND f.person_id = t.person_id
+            AND f.settled_outside = 0 AND strftime('%Y', f.date) = ?), 0)  AS fuel_count,
+        COALESCE((SELECT SUM(f.liters) FROM fuel_fillups f
+          WHERE f.car_id = c.id AND f.person_id = t.person_id
+            AND f.settled_outside = 0 AND strftime('%Y', f.date) = ?), 0)  AS fuel_liters,
+        COALESCE((SELECT SUM(f.amount) FROM fuel_fillups f
+          WHERE f.car_id = c.id AND f.person_id = t.person_id
+            AND f.settled_outside = 0 AND strftime('%Y', f.date) = ?), 0)  AS fuel_amount,
+        COALESCE((SELECT COUNT(*) FROM expenses e
+          WHERE e.car_id = c.id AND e.person_id = t.person_id
+            AND e.settled_outside = 0 AND strftime('%Y', e.date) = ?), 0)  AS expense_count,
+        COALESCE((SELECT SUM(e.amount) FROM expenses e
+          WHERE e.car_id = c.id AND e.person_id = t.person_id
+            AND e.settled_outside = 0 AND strftime('%Y', e.date) = ?), 0)  AS expense_amount
+      FROM trips t
+      JOIN cars c ON t.car_id = c.id
+      JOIN people p_owner ON c.owner_name = p_owner.name
+      WHERE t.person_id != p_owner.id
+        AND c.owner_name IS NOT NULL
+        AND strftime('%Y', t.date) = ?
+      GROUP BY t.person_id, c.id
+      `
+    )
+    .all(yearStr, yearStr, yearStr, yearStr, yearStr, yearStr) as CrossCarRow[];
+
+  const ownCarByPerson = new Map<number, OwnCarRow[]>();
+  for (const row of ownCarRows) {
+    const list = ownCarByPerson.get(row.owner_person_id) ?? [];
+    list.push(row);
+    ownCarByPerson.set(row.owner_person_id, list);
+  }
+
+  const crossCarByPerson = new Map<number, CrossCarRow[]>();
+  for (const row of crossCarRows) {
+    const list = crossCarByPerson.get(row.person_id) ?? [];
+    list.push(row);
+    crossCarByPerson.set(row.person_id, list);
+  }
+
   const byId = <T extends { person_id: number }>(rows: T[]) =>
     new Map<number, T>(rows.map((r) => [r.person_id, r]));
   const trips = byId(tripRows);
@@ -122,6 +267,54 @@ export function getDashboard(db: Database.Database, year: number): DashboardRow[
     const total_amount = trip_amount + fuel_amount + expense_amount;
     const balance = total_amount + paid_amount;
 
+    const ownCars = ownCarByPerson.get(person.id) ?? [];
+    const crossCars = crossCarByPerson.get(person.id) ?? [];
+    const is_owner = ownCars.length > 0;
+
+    const car_breakdowns: import("@/types").CarDashboardBreakdown[] = [
+      ...ownCars.map((c) => ({
+        car_short: c.car_short,
+        car_name: c.car_name,
+        is_own_car: true as const,
+        trip_count: c.others_trip_count,
+        trip_km: c.others_trip_km,
+        trip_amount: c.others_trip_amount,
+        fuel_count: c.others_fuel_count,
+        fuel_liters: c.others_fuel_liters,
+        fuel_amount: c.others_fuel_amount,
+        expense_count: c.others_expense_count,
+        expense_amount: c.others_expense_amount,
+        net_car:
+          Math.round(
+            (c.others_trip_amount - c.others_fuel_amount - c.others_expense_amount) * 100
+          ) / 100,
+        own_trip_count: c.own_trip_count,
+        own_trip_km: c.own_trip_km,
+        own_fuel_count: c.own_fuel_count,
+        own_fuel_liters: c.own_fuel_liters,
+        own_expense_count: c.own_expense_count,
+      })),
+      ...crossCars.map((c) => ({
+        car_short: c.car_short,
+        car_name: c.car_name,
+        is_own_car: false as const,
+        trip_count: c.trip_count,
+        trip_km: c.trip_km,
+        trip_amount: c.trip_amount,
+        fuel_count: c.fuel_count,
+        fuel_liters: c.fuel_liters,
+        fuel_amount: c.fuel_amount,
+        expense_count: c.expense_count,
+        expense_amount: c.expense_amount,
+        net_car: Math.round((-c.trip_amount + c.fuel_amount + c.expense_amount) * 100) / 100,
+        own_trip_count: 0,
+        own_trip_km: 0,
+        own_fuel_count: 0,
+        own_fuel_liters: 0,
+        own_expense_count: 0,
+      })),
+    ];
+
     return {
       person_id: person.id,
       person_name: person.name,
@@ -137,6 +330,8 @@ export function getDashboard(db: Database.Database, year: number): DashboardRow[
       total_amount,
       paid_amount,
       balance,
+      is_owner,
+      car_breakdowns,
     };
   });
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -119,6 +119,31 @@ export interface Payment {
   person_name?: string;
 }
 
+export interface CarDashboardBreakdown {
+  car_short: string;
+  car_name: string;
+  is_own_car: boolean; // true = person owns this car; false = drove another owner's car
+
+  // Own car: others' activity. Cross-car: own activity.
+  trip_count: number;
+  trip_km: number;
+  trip_amount: number; // own car: +N (revenue). cross-car: + raw (negate for display)
+  fuel_count: number;
+  fuel_liters: number;
+  fuel_amount: number; // own car: + raw (negate for display). cross-car: + (advance)
+  expense_count: number;
+  expense_amount: number; // same sign as fuel_amount
+
+  net_car: number; // own car: N(c). cross-car: −trip + fuel + expense
+
+  // Own usage on own car (€0 in settlement — stats only, no amounts shown):
+  own_trip_count: number;
+  own_trip_km: number;
+  own_fuel_count: number;
+  own_fuel_liters: number;
+  own_expense_count: number;
+}
+
 export interface DashboardRow {
   person_id: number;
   person_name: string;
@@ -134,6 +159,8 @@ export interface DashboardRow {
   total_amount: number; // trip_amount + fuel_amount + expense_amount
   paid_amount: number; // settlement payments
   balance: number; // total_amount + paid_amount
+  is_owner: boolean;
+  car_breakdowns: CarDashboardBreakdown[];
 }
 
 // Form input types (no id, no computed fields)


### PR DESCRIPTION
## Summary

- Adds `CarDashboardBreakdown` type and extends `DashboardRow` with `is_owner` + `car_breakdowns`
- New SQL queries in `getDashboard`: per-car aggregates for owned cars (others' trips/fuel/expenses + own stats) and cross-car activity
- `mine=false` filter on trips, fuel, and expenses pages to show others' activity on a car
- Owner branch in `BalanceReceipt`: `[eigenaar]` badge, per-car sections (Anderen / Eigen), total from settlement net, betaald/saldo

## Test plan

- [ ] Non-owner dashboard card unchanged
- [ ] Owner dashboard shows `[eigenaar]` badge
- [ ] Per-car sections show correct Anderen (revenue/cost) and Eigen (stats only) rows
- [ ] Links navigate to correct filtered pages (`mine=false&car=X`, `mine=true&car=X`)
- [ ] `/trips?mine=false` shows only others' trips
- [ ] All 329 tests passing

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)