### PR TITLE
chore(ci): upgrade to Node.js 24 and pin action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ jobs:
   quality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v4.2.2
+      - uses: actions/setup-node@v4.4.0
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
       - run: npm ci
       - name: Lint

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Summary

- Pin `actions/checkout` to `v4.2.2` and `actions/setup-node` to `v4.4.0` (Node 24-compatible patch releases)
- Bump `node-version: 20` → `24` in CI workflow
- Same checkout pin in docker workflow

## Test plan

- [ ] CI quality check passes on this PR with Node 24

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)