### PR TITLE
feat(db): add updated_at to payments, cars, people, settlements, settings

### DIFF
--- a/lib/__tests__/migration_0004.test.ts
+++ b/lib/__tests__/migration_0004.test.ts
@@ -29,6 +29,7 @@ describe("migration 0004 — car owner era", () => {
       INSERT INTO _migrations (filename) VALUES ('0006_settings_table.sql');
       INSERT INTO _migrations (filename) VALUES ('0007_settled_outside.sql');
       INSERT INTO _migrations (filename) VALUES ('0008_drop_fixed_costs_json.sql');
+      INSERT INTO _migrations (filename) VALUES ('0009_updated_at_admin_tables.sql');
     `);
     runMigrations(db2);
     const car = db2.prepare("SELECT owner_from FROM cars WHERE short = 'XX'").get() as {

--- a/lib/queries/people.ts
+++ b/lib/queries/people.ts
@@ -26,7 +26,10 @@ export function getPersonByUsername(db: Database.Database, username: string): Pe
   return (db.prepare("SELECT * FROM people WHERE username=?").get(username) as Person) ?? null;
 }
 
-export function insertPerson(db: Database.Database, data: Omit<Person, "id">): number {
+export function insertPerson(
+  db: Database.Database,
+  data: Omit<Person, "id" | "updated_at">
+): number {
   const result = db
     .prepare(
       "INSERT INTO people (name,discount,discount_long,active,username,is_admin) VALUES (?,?,?,?,?,?)"
@@ -42,7 +45,11 @@ export function insertPerson(db: Database.Database, data: Omit<Person, "id">): n
   return result.lastInsertRowid as number;
 }
 
-export function updatePerson(db: Database.Database, id: number, data: Omit<Person, "id">): void {
+export function updatePerson(
+  db: Database.Database,
+  id: number,
+  data: Omit<Person, "id" | "updated_at">
+): void {
   db.prepare(
     "UPDATE people SET name=?,discount=?,discount_long=?,active=?,username=?,is_admin=? WHERE id=?"
   ).run(
@@ -61,9 +68,9 @@ export function setPasswordHash(db: Database.Database, id: number, passwordHash:
 }
 
 export function isOwner(db: Database.Database, personName: string): boolean {
-  const row = db
-    .prepare("SELECT COUNT(*) as n FROM cars WHERE owner_name=?")
-    .get(personName) as { n: number };
+  const row = db.prepare("SELECT COUNT(*) as n FROM cars WHERE owner_name=?").get(personName) as {
+    n: number;
+  };
   return row.n > 0;
 }
 

--- a/migrations/0009_updated_at_admin_tables.sql
+++ b/migrations/0009_updated_at_admin_tables.sql
@@ -1,0 +1,15 @@
+-- migrations/0009_updated_at_admin_tables.sql
+-- Adds updated_at + AFTER UPDATE trigger to payments, cars, people, settlements, settings.
+-- Existing rows get '1970-01-01 00:00:00' sentinel (historical value unknown).
+
+ALTER TABLE payments    ADD COLUMN updated_at TEXT NOT NULL DEFAULT '1970-01-01 00:00:00';
+ALTER TABLE cars        ADD COLUMN updated_at TEXT NOT NULL DEFAULT '1970-01-01 00:00:00';
+ALTER TABLE people      ADD COLUMN updated_at TEXT NOT NULL DEFAULT '1970-01-01 00:00:00';
+ALTER TABLE settlements ADD COLUMN updated_at TEXT NOT NULL DEFAULT '1970-01-01 00:00:00';
+ALTER TABLE settings    ADD COLUMN updated_at TEXT NOT NULL DEFAULT '1970-01-01 00:00:00';
+
+CREATE TRIGGER IF NOT EXISTS trg_payments_updated_at    AFTER UPDATE ON payments    FOR EACH ROW BEGIN UPDATE payments    SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id; END;
+CREATE TRIGGER IF NOT EXISTS trg_cars_updated_at        AFTER UPDATE ON cars        FOR EACH ROW BEGIN UPDATE cars        SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id; END;
+CREATE TRIGGER IF NOT EXISTS trg_people_updated_at      AFTER UPDATE ON people      FOR EACH ROW BEGIN UPDATE people      SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id; END;
+CREATE TRIGGER IF NOT EXISTS trg_settlements_updated_at AFTER UPDATE ON settlements FOR EACH ROW BEGIN UPDATE settlements SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id; END;
+CREATE TRIGGER IF NOT EXISTS trg_settings_updated_at    AFTER UPDATE ON settings    FOR EACH ROW BEGIN UPDATE settings    SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id; END;

--- a/types/index.ts
+++ b/types/index.ts
@@ -7,6 +7,7 @@ export interface Person {
   username: string | null;
   password_hash: string | null;
   is_admin: 0 | 1;
+  updated_at: string;
 }
 
 export interface Car {
@@ -22,6 +23,7 @@ export interface Car {
   long_threshold: number;
   active: 0 | 1;
   expected_km: number | null;
+  updated_at: string;
 }
 
 export type ExpenseCategory = "onderhoud" | "keuring" | "belasting" | "verzekering" | "diversen";
@@ -115,6 +117,7 @@ export interface Payment {
   amount: number;
   note: string | null;
   year: number; // date.year − 1 (payment settles previous year)
+  updated_at: string;
   // joined
   person_name?: string;
 }


### PR DESCRIPTION
Closes #108

## Summary
- Migration `0009` adds `updated_at TEXT NOT NULL DEFAULT '1970-01-01 00:00:00'` to `payments`, `cars`, `people`, `settlements`, and `settings` tables
- `AFTER UPDATE` triggers keep the column current on every row update
- TypeScript `Person`, `Car`, and `Payment` interfaces updated with `updated_at: string`
- `insertPerson`/`updatePerson` signatures use `Omit<Person, "id" | "updated_at">` (DB-managed field excluded)
- Migration test for 0004 updated to skip 0009 on its partial schema

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `npx vitest run` — 329 tests pass
- [ ] After deploy: verify `SELECT updated_at FROM payments LIMIT 1` returns a timestamp