### PR TITLE
feat(profile): user self-service name + bank account edit

### DIFF
--- a/app/admin/settlement/page.tsx
+++ b/app/admin/settlement/page.tsx
@@ -8,6 +8,7 @@ import { useEarliestDashboardYear } from "@/hooks/use-dashboard";
 import { useSettlement } from "@/hooks/use-settlement";
 import { useMe } from "@/hooks/use-me";
 import { useAdminSettings } from "@/hooks/use-admin-settings";
+import { usePeople } from "@/hooks/use-people";
 import { apiFetch } from "@/lib/api/client";
 import { Card, Row, Perf } from "../_shared";
 import type { MemberStatement, AnnotatedTransfer } from "@/types";
@@ -428,6 +429,7 @@ function MemberCard({
   m,
   year,
   bankAccount,
+  personBankAccount,
   crossRows,
   settlementTransfer,
   showAll,
@@ -435,6 +437,7 @@ function MemberCard({
   m: MemberStatement;
   year: number;
   bankAccount: string;
+  personBankAccount: string;
   crossRows: { car_short: string; row: import("@/types").CarParticipantRow }[];
   settlementTransfer: AnnotatedTransfer | undefined;
   showAll: boolean;
@@ -561,7 +564,11 @@ function MemberCard({
       row(`Saldo`, net >= 0 ? "+" : "−", Math.abs(net)),
       ``,
       ...(net > 0
-        ? [`Coöp (${iban}) schrijft ${e(Math.abs(net))} over naar jou.`]
+        ? [
+            personBankAccount
+              ? `Coöp schrijft ${e(Math.abs(net))} over naar ${personBankAccount}.`
+              : `Coöp schrijft ${e(Math.abs(net))} over naar jou.`,
+          ]
         : net < 0
           ? [`Gelieve ${e(Math.abs(net))} over te schrijven naar ${iban}.`]
           : []),
@@ -978,6 +985,7 @@ function AdminSettlementPageContent() {
   const t = useT();
   const { data: me } = useMe();
   const { data: settings } = useAdminSettings();
+  const { data: people } = usePeople();
   const currentYear = new Date().getFullYear();
   const router = useRouter();
   const pathname = usePathname();
@@ -1157,6 +1165,7 @@ function AdminSettlementPageContent() {
                     m={m}
                     year={year}
                     bankAccount={settings?.coop_bank_account ?? ""}
+                    personBankAccount={people?.find((p) => p.name === m.person_name)?.bank_account ?? ""}
                     crossRows={
                       m.is_owner
                         ? data.car_settlements.flatMap((cs) =>

--- a/app/api/invite/[token]/route.ts
+++ b/app/api/invite/[token]/route.ts
@@ -48,7 +48,7 @@ export async function POST(req: Request, ctx: { params: Promise<{ token: string 
   const person = getPersonById(db, record.person_id);
   if (!person) return NextResponse.json({ error: "not_found" }, { status: 404 });
 
-  const res = NextResponse.json({ ok: true });
+  const res = NextResponse.json({ ok: true, person_id: person.id });
   const session = await getIronSession<SessionData>(req, res, sessionOptions);
   session.authenticated = true;
   session.personId = person.id;

--- a/app/api/people/[id]/profile/route.ts
+++ b/app/api/people/[id]/profile/route.ts
@@ -1,0 +1,25 @@
+import { getDb } from "@/lib/db";
+import { getPersonById, updatePerson } from "@/lib/queries/people";
+import { json, readBody, readId, notFound, forbidden } from "@/lib/api";
+import { getIronSession } from "iron-session";
+import { sessionOptions, type SessionData } from "@/lib/session";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+const profileSchema = z.object({
+  name: z.string().min(1),
+  bank_account: z.string().default(""),
+});
+
+export const PATCH = json(async (req, ctx) => {
+  const res = NextResponse.next();
+  const session = await getIronSession<SessionData>(req, res, sessionOptions);
+  const id = await readId(ctx);
+  if (!session.authenticated) forbidden("Unauthorized");
+  if (session.personId !== id && !session.isAdmin) forbidden("Forbidden");
+  const data = await readBody(req, profileSchema);
+  const existing = getPersonById(getDb(), id);
+  if (!existing) notFound();
+  updatePerson(getDb(), id, { ...existing, ...data });
+  return { ok: true };
+});

--- a/app/invite/[token]/page.tsx
+++ b/app/invite/[token]/page.tsx
@@ -44,7 +44,8 @@ export default function InvitePage() {
         body: JSON.stringify({ password }),
       });
       if (res.ok) {
-        router.replace("/");
+        const data = await res.json() as { ok: boolean; person_id: number };
+        router.replace(`/user/${data.person_id}/edit`);
       } else {
         setError(t("invite.invalid"));
       }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -52,6 +52,31 @@ import { CarBadge } from "@/components/car-badge";
 import { ErrorBoundary } from "@/components/error-boundary";
 
 // ── Primitives ────────────────────────────────────────────────────
+function NameEditLink({ name, personId }: { name: string; personId: number }) {
+  const [hover, setHover] = useState(false);
+  return (
+    <Link
+      href={`/user/${personId}/edit`}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      style={{ color: "inherit", textDecoration: "none", display: "inline-flex", alignItems: "baseline", gap: 6 }}
+    >
+      {" "}{name}
+      <span
+        style={{
+          fontSize: 16,
+          opacity: hover ? 0.6 : 0,
+          transition: "opacity 0.15s",
+          lineHeight: 1,
+          alignSelf: "center",
+        }}
+      >
+        ✏️
+      </span>
+    </Link>
+  );
+}
+
 function Perf({ margin = "12px 0" }: { margin?: string }) {
   return <div style={{ height: 0, borderTop: `1.5px dashed ${paper.ink}`, margin }} />;
 }
@@ -975,7 +1000,14 @@ function DashboardContent() {
   return (
     <div style={{ background: paper.paperDeep, minHeight: "100dvh", paddingBottom: 80 }}>
       <PageHeader
-        title={`${t("dashboard.hello")}${me?.personName ? ` ${me.personName.split(" ")[0]}` : ""}`}
+        title={
+          <>
+            {t("dashboard.hello")}
+            {me?.personName && me?.personId ? (
+              <NameEditLink name={me.personName.split(" ")[0]} personId={me.personId} />
+            ) : null}
+          </>
+        }
         subtitle={`${t("dashboard.today")} · ${todayFmt}`}
         titleSize={32}
       />

--- a/app/user/[id]/edit/page.tsx
+++ b/app/user/[id]/edit/page.tsx
@@ -1,0 +1,254 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useMe } from "@/hooks/use-me";
+import { useT } from "@/components/locale-provider";
+import { PageHeader } from "@/components/page-header";
+import { paper, fontMono, fontSerif } from "@/lib/paper-theme";
+import { apiFetch } from "@/lib/api/client";
+import type { Person } from "@/types";
+
+export default function EditProfilePage({ params }: { params: Promise<{ id: string }> }) {
+  const router = useRouter();
+  const t = useT();
+  const { data: me, isLoading: meLoading } = useMe();
+  const [id, setId] = useState<number | null>(null);
+  const [person, setPerson] = useState<Person | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [name, setName] = useState("");
+  const [bankAccount, setBankAccount] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    params.then(({ id: rawId }) => {
+      const n = Number(rawId);
+      setId(n);
+    });
+  }, [params]);
+
+  useEffect(() => {
+    if (id === null) return;
+    fetch(`/api/people/${id}`)
+      .then((r) => {
+        if (!r.ok) throw new Error("Niet gevonden");
+        return r.json() as Promise<Person>;
+      })
+      .then((p) => {
+        setPerson(p);
+        setName(p.name);
+        setBankAccount(p.bank_account ?? "");
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, [id]);
+
+  const canEdit = me != null && id != null && (me.personId === id || me.isAdmin);
+
+  if (meLoading || loading) {
+    return (
+      <div style={{ background: paper.paperDeep, minHeight: "100dvh" }}>
+        <PageHeader title={t("page.profile_edit")} />
+      </div>
+    );
+  }
+
+  if (!canEdit || !person) {
+    return (
+      <div style={{ background: paper.paperDeep, minHeight: "100dvh" }}>
+        <PageHeader title={t("page.profile_edit")} />
+        <div style={{ padding: 24, fontFamily: fontMono, fontSize: 12, color: paper.accent }}>
+          {!canEdit ? t("error.no_access") : t("error.not_found")}
+        </div>
+      </div>
+    );
+  }
+
+  const dirty = name !== person.name || bankAccount !== (person.bank_account ?? "");
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    try {
+      await apiFetch(`/api/people/${id}/profile`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, bank_account: bankAccount }),
+      });
+      setSaved(true);
+      setTimeout(() => router.push("/"), 800);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Fout bij opslaan");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div style={{ background: paper.paperDeep, minHeight: "100dvh" }}>
+      <PageHeader title={t("page.profile_edit")} />
+
+      <div style={{ padding: 16 }}>
+      <div
+        style={{
+          background: paper.paper,
+          boxShadow: "0 1px 4px rgba(0,0,0,0.07)",
+          padding: "14px 16px",
+        }}
+      >
+        <div
+          style={{
+            fontFamily: fontSerif,
+            fontSize: 14,
+            fontWeight: 700,
+            color: paper.ink,
+            marginBottom: 16,
+          }}
+        >
+          {person.name}
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <div style={{ marginBottom: 12 }}>
+            <label
+              htmlFor="edit-username"
+              style={{
+                display: "block",
+                fontFamily: fontMono,
+                fontSize: 9,
+                color: paper.inkMute,
+                letterSpacing: 1,
+                marginBottom: 4,
+              }}
+            >
+              {t("form.username")}
+            </label>
+            <input
+              id="edit-username"
+              type="text"
+              value={person.username ?? ""}
+              readOnly
+              style={{
+                width: "100%",
+                padding: "8px 10px",
+                fontFamily: fontMono,
+                fontSize: 12,
+                background: paper.paperDeep,
+                color: paper.inkMute,
+                border: `1.5px solid ${paper.paperDeep}`,
+                outline: "none",
+                boxSizing: "border-box",
+                cursor: "default",
+              }}
+            />
+          </div>
+
+          <div style={{ marginBottom: 12 }}>
+            <label
+              htmlFor="edit-name"
+              style={{
+                display: "block",
+                fontFamily: fontMono,
+                fontSize: 9,
+                color: paper.inkMute,
+                letterSpacing: 1,
+                marginBottom: 4,
+              }}
+            >
+              {t("form.full_name")}
+            </label>
+            <input
+              id="edit-name"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              style={{
+                width: "100%",
+                padding: "8px 10px",
+                fontFamily: fontMono,
+                fontSize: 12,
+                background: paper.paperDark,
+                color: paper.ink,
+                border: `1.5px solid ${name !== person.name ? paper.ink : paper.paperDark}`,
+                outline: "none",
+                boxSizing: "border-box",
+              }}
+            />
+          </div>
+
+          <div style={{ marginBottom: 16 }}>
+            <label
+              htmlFor="edit-bank"
+              style={{
+                display: "block",
+                fontFamily: fontMono,
+                fontSize: 9,
+                color: paper.inkMute,
+                letterSpacing: 1,
+                marginBottom: 4,
+              }}
+            >
+              {t("form.bank_account")}
+            </label>
+            <input
+              id="edit-bank"
+              type="text"
+              value={bankAccount}
+              onChange={(e) => setBankAccount(e.target.value)}
+              placeholder="BE00 0000 0000 0000"
+              style={{
+                width: "100%",
+                padding: "8px 10px",
+                fontFamily: fontMono,
+                fontSize: 12,
+                background: paper.paperDark,
+                color: paper.ink,
+                border: `1.5px solid ${bankAccount !== (person.bank_account ?? "") ? paper.ink : paper.paperDark}`,
+                outline: "none",
+                boxSizing: "border-box",
+                letterSpacing: 1,
+              }}
+            />
+          </div>
+
+          {error && (
+            <div
+              style={{
+                fontFamily: fontMono,
+                fontSize: 10,
+                color: paper.accent,
+                marginBottom: 10,
+              }}
+            >
+              {error}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={!dirty || saving}
+            style={{
+              width: "100%",
+              padding: "8px",
+              fontFamily: fontMono,
+              fontSize: 9,
+              fontWeight: 700,
+              letterSpacing: 2,
+              textTransform: "uppercase",
+              background: saved ? paper.green : dirty ? paper.ink : paper.paperDark,
+              color: dirty || saved ? paper.paper : paper.inkMute,
+              border: "none",
+              cursor: dirty && !saving ? "pointer" : "default",
+            }}
+          >
+            {saved ? t("action.saved") : saving ? t("action.saving") : t("action.save")}
+          </button>
+        </form>
+      </div>
+      </div>
+    </div>
+  );
+}

--- a/components/page-header.tsx
+++ b/components/page-header.tsx
@@ -13,7 +13,7 @@ const version = pkg.version;
 export const TITLE_BAR_HEIGHT = 47;
 
 interface Props {
-  title: string;
+  title: React.ReactNode;
   subtitle?: string;
   right?: React.ReactNode;
   titleSize?: number;

--- a/lib/__tests__/migration_0004.test.ts
+++ b/lib/__tests__/migration_0004.test.ts
@@ -30,6 +30,7 @@ describe("migration 0004 — car owner era", () => {
       INSERT INTO _migrations (filename) VALUES ('0007_settled_outside.sql');
       INSERT INTO _migrations (filename) VALUES ('0008_drop_fixed_costs_json.sql');
       INSERT INTO _migrations (filename) VALUES ('0009_updated_at_admin_tables.sql');
+      INSERT INTO _migrations (filename) VALUES ('0010_people_bank_account.sql');
     `);
     runMigrations(db2);
     const car = db2.prepare("SELECT owner_from FROM cars WHERE short = 'XX'").get() as {

--- a/lib/__tests__/queries.test.ts
+++ b/lib/__tests__/queries.test.ts
@@ -24,6 +24,7 @@ const basePerson = {
   username: null,
   password_hash: null,
   is_admin: 0 as const,
+  bank_account: "",
 };
 
 describe("people queries", () => {

--- a/lib/__tests__/queries_admin.test.ts
+++ b/lib/__tests__/queries_admin.test.ts
@@ -34,6 +34,7 @@ const basePerson = {
   username: null,
   password_hash: null,
   is_admin: 0 as const,
+  bank_account: "",
 };
 
 describe("getCarPnL", () => {

--- a/lib/__tests__/queries_people.test.ts
+++ b/lib/__tests__/queries_people.test.ts
@@ -30,6 +30,7 @@ const basePerson = {
   username: null,
   password_hash: null,
   is_admin: 0 as const,
+  bank_account: "",
 };
 
 describe("getPeople", () => {

--- a/lib/__tests__/queries_trips.test.ts
+++ b/lib/__tests__/queries_trips.test.ts
@@ -27,6 +27,7 @@ const basePerson = {
   username: null,
   password_hash: null,
   is_admin: 0 as const,
+  bank_account: "",
 };
 
 describe("getTripById", () => {

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -53,6 +53,7 @@ export const en: Messages = {
   "page.reservation_add": "Add reservation",
   "page.reservation_edit": "Edit reservation",
   "page.reservation_request": "Request reservation",
+  "page.profile_edit": "Edit profile",
 
   // Actions
   "action.add": "Add",
@@ -76,6 +77,9 @@ export const en: Messages = {
 
   // Form labels
   "form.name": "Name *",
+  "form.full_name": "First Last Name",
+  "form.bank_account": "Bank account (IBAN)",
+  "form.username": "Username",
   "form.password": "Password",
   "form.discount": "Discount (0–1)",
   "form.discount_long": "Long-trip discount (0–1)",
@@ -190,6 +194,8 @@ export const en: Messages = {
   // Errors
   "error.gps_unavailable": "GPS not available",
   "error.invalid_credentials": "Invalid username or password",
+  "error.no_access": "Access denied.",
+  "error.not_found": "Not found.",
 
   // Dashboard balance
   "balance.settled": "settled",

--- a/lib/i18n/messages/nl.ts
+++ b/lib/i18n/messages/nl.ts
@@ -51,6 +51,7 @@ export const nl = {
   "page.reservation_add": "Reservering toevoegen",
   "page.reservation_edit": "Reservering bewerken",
   "page.reservation_request": "Reservering aanvragen",
+  "page.profile_edit": "Profiel bewerken",
 
   // Actions
   "action.add": "Toevoegen",
@@ -74,6 +75,9 @@ export const nl = {
 
   // Form labels
   "form.name": "Naam *",
+  "form.full_name": "Voornaam Achternaam",
+  "form.bank_account": "Bankrekeningnummer (IBAN)",
+  "form.username": "Gebruikersnaam",
   "form.password": "Wachtwoord",
   "form.discount": "Korting (0–1)",
   "form.discount_long": "Korting lang (0–1)",
@@ -188,6 +192,8 @@ export const nl = {
   // Errors
   "error.gps_unavailable": "GPS niet beschikbaar",
   "error.invalid_credentials": "Ongeldige gebruikersnaam of wachtwoord",
+  "error.no_access": "Geen toegang.",
+  "error.not_found": "Niet gevonden.",
 
   // Dashboard balance (take {amount} placeholder)
   "balance.settled": "vereffend",

--- a/lib/queries/people.ts
+++ b/lib/queries/people.ts
@@ -32,7 +32,7 @@ export function insertPerson(
 ): number {
   const result = db
     .prepare(
-      "INSERT INTO people (name,discount,discount_long,active,username,is_admin) VALUES (?,?,?,?,?,?)"
+      "INSERT INTO people (name,discount,discount_long,active,username,is_admin,bank_account) VALUES (?,?,?,?,?,?,?)"
     )
     .run(
       data.name,
@@ -40,7 +40,8 @@ export function insertPerson(
       data.discount_long,
       data.active,
       data.username ?? null,
-      data.is_admin ?? 0
+      data.is_admin ?? 0,
+      data.bank_account ?? ''
     );
   return result.lastInsertRowid as number;
 }
@@ -51,7 +52,7 @@ export function updatePerson(
   data: Omit<Person, "id" | "updated_at">
 ): void {
   db.prepare(
-    "UPDATE people SET name=?,discount=?,discount_long=?,active=?,username=?,is_admin=? WHERE id=?"
+    "UPDATE people SET name=?,discount=?,discount_long=?,active=?,username=?,is_admin=?,bank_account=? WHERE id=?"
   ).run(
     data.name,
     data.discount,
@@ -59,6 +60,7 @@ export function updatePerson(
     data.active,
     data.username ?? null,
     data.is_admin ?? 0,
+    data.bank_account ?? '',
     id
   );
 }

--- a/lib/schemas/person.ts
+++ b/lib/schemas/person.ts
@@ -7,4 +7,5 @@ export const personSchema = z.object({
   active: z.union([z.literal(0), z.literal(1)]).default(1),
   username: z.string().min(1).nullable().optional(),
   is_admin: z.union([z.literal(0), z.literal(1)]).default(0),
+  bank_account: z.string().default(''),
 });

--- a/migrations/0010_people_bank_account.sql
+++ b/migrations/0010_people_bank_account.sql
@@ -1,0 +1,2 @@
+-- migrations/0010_people_bank_account.sql
+ALTER TABLE people ADD COLUMN bank_account TEXT NOT NULL DEFAULT '';

--- a/types/index.ts
+++ b/types/index.ts
@@ -7,6 +7,7 @@ export interface Person {
   username: string | null;
   password_hash: string | null;
   is_admin: 0 | 1;
+  bank_account: string;
   updated_at: string;
 }
 


### PR DESCRIPTION
Closes #117

## Summary
- Migration `0010`: adds `bank_account TEXT NOT NULL DEFAULT ''` to `people` table
- `PATCH /api/people/[id]/profile` — self or admin only (server-side ACL)
- New page `app/user/[id]/edit` — username (readonly), full name, IBAN form
- Pencil icon on hover over first name in homepage header → links to edit page
- Invite flow redirects to `/user/[id]/edit` after password set
- Settlement copy message uses owner's personal IBAN for payout line when set
- i18n: `page.profile_edit`, `form.full_name`, `form.bank_account`, `form.username`, `error.no_access`, `error.not_found`

## Test plan
- [ ] Visit invite link → set password → lands on profile edit page
- [ ] Edit name + IBAN → save → redirects to homepage
- [ ] Navigate to `/user/<other-id>/edit` as non-admin → "Geen toegang"
- [ ] Admin can edit any user's profile
- [ ] Settlement copy message for owner includes their IBAN when set
- [ ] Hover over first name on homepage → pencil appears