### PR TITLE
feat(calendar): two-way Google Calendar sync with RSVP-based confirmation (#115)

### DIFF
--- a/app/admin/cars/page.tsx
+++ b/app/admin/cars/page.tsx
@@ -217,7 +217,7 @@ function CarRow({
               <option value="">—</option>
               {people.map((p) => (
                 <option key={p.id} value={p.name}>
-                  {p.name}
+                  {displayName(p)}
                 </option>
               ))}
             </select>
@@ -235,7 +235,7 @@ function CarRow({
               <option value="">— geen —</option>
               {people.map((p) => (
                 <option key={p.id} value={p.id}>
-                  {p.name}
+                  {displayName(p)}
                 </option>
               ))}
             </select>
@@ -574,7 +574,7 @@ function OwnerCarTile({
               <option value="">— geen —</option>
               {people.map((p) => (
                 <option key={p.id} value={p.id}>
-                  {p.name}
+                  {displayName(p)}
                 </option>
               ))}
             </select>
@@ -1137,6 +1137,10 @@ function OwnerFleet({ myName }: { myName: string | null }) {
 }
 
 // ── Page ──────────────────────────────────────────────────────
+function displayName(p: { name: string; username?: string | null }): string {
+  return p.name?.split(" ")[0] || p.username || "?";
+}
+
 export default function AdminWagensPage() {
   const { data: me, isLoading } = useMe();
   const router = useRouter();

--- a/app/admin/cars/page.tsx
+++ b/app/admin/cars/page.tsx
@@ -343,9 +343,11 @@ function OwnerCarTile({
   const t = useT();
   const updateCar = useUpdateCar();
   const deleteCar = useDeleteCar();
+  const { data: people = [] } = usePeople();
   const [name, setName] = useState(car.name);
   const [price, setPrice] = useState(car.price_per_km);
   const [activeLocal, setActiveLocal] = useState(car.active !== 0);
+  const [ownerPersonId, setOwnerPersonId] = useState<number | null>(car.owner_person_id ?? null);
   const [deleteConfirm, setDeleteConfirm] = useState(false);
 
   const [prevId, setPrevId] = useState(car.id);
@@ -354,11 +356,15 @@ function OwnerCarTile({
     setName(car.name);
     setPrice(car.price_per_km);
     setActiveLocal(car.active !== 0);
+    setOwnerPersonId(car.owner_person_id ?? null);
     setDeleteConfirm(false);
   }
 
   const dirty =
-    name !== car.name || price !== car.price_per_km || activeLocal !== (car.active !== 0);
+    name !== car.name ||
+    price !== car.price_per_km ||
+    activeLocal !== (car.active !== 0) ||
+    ownerPersonId !== (car.owner_person_id ?? null);
   const isActive = car.active !== 0;
 
   const inputStyle: React.CSSProperties = {
@@ -386,12 +392,19 @@ function OwnerCarTile({
     setName(car.name);
     setPrice(car.price_per_km);
     setActiveLocal(car.active !== 0);
+    setOwnerPersonId(car.owner_person_id ?? null);
     setDeleteConfirm(false);
   }
 
   function handleSave() {
     updateCar.mutate(
-      { ...car, name, price_per_km: price, active: activeLocal ? 1 : 0 },
+      {
+        ...car,
+        name,
+        price_per_km: price,
+        active: activeLocal ? 1 : 0,
+        owner_person_id: ownerPersonId,
+      },
       {
         onSuccess: () => {
           onToggle();
@@ -550,6 +563,21 @@ function OwnerCarTile({
                 }}
               />
             </div>
+          </div>
+          <div style={{ marginBottom: 12 }}>
+            <label style={labelStyle}>Eigenaar (persoon)</label>
+            <select
+              value={ownerPersonId ?? ""}
+              onChange={(e) => setOwnerPersonId(e.target.value ? Number(e.target.value) : null)}
+              style={{ ...inputStyle, background: paper.paperDeep }}
+            >
+              <option value="">— geen —</option>
+              {people.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
           </div>
           <div style={{ display: "flex", gap: 8, marginBottom: 12 }}>
             <button

--- a/app/admin/cars/page.tsx
+++ b/app/admin/cars/page.tsx
@@ -16,9 +16,7 @@ import { CostCoverageScreen } from "@/components/cost-coverage-screen";
 import { Fab } from "@/components/fab";
 
 // ── Owner screen state ────────────────────────────────────────
-type OwnerScreen =
-  | { view: "fleet" }
-  | { view: "detail"; carId: number };
+type OwnerScreen = { view: "fleet" } | { view: "detail"; carId: number };
 
 const overlayStyle: React.CSSProperties = {
   position: "fixed",
@@ -59,6 +57,7 @@ function CarRow({
   const [name, setName] = useState(car.name);
   const [price, setPrice] = useState(car.price_per_km);
   const [owner, setOwner] = useState(car.owner_name ?? "");
+  const [ownerPersonId, setOwnerPersonId] = useState<number | null>(car.owner_person_id ?? null);
   const isActive = car.active !== 0;
 
   const [prevId, setPrevId] = useState(car.id);
@@ -67,14 +66,20 @@ function CarRow({
     setName(car.name);
     setPrice(car.price_per_km);
     setOwner(car.owner_name ?? "");
+    setOwnerPersonId(car.owner_person_id ?? null);
   }
 
-  const dirty = name !== car.name || price !== car.price_per_km || owner !== (car.owner_name ?? "");
+  const dirty =
+    name !== car.name ||
+    price !== car.price_per_km ||
+    owner !== (car.owner_name ?? "") ||
+    ownerPersonId !== (car.owner_person_id ?? null);
 
   const reset = () => {
     setName(car.name);
     setPrice(car.price_per_km);
     setOwner(car.owner_name ?? "");
+    setOwnerPersonId(car.owner_person_id ?? null);
   };
 
   const inputStyle: React.CSSProperties = {
@@ -206,7 +211,7 @@ function CarRow({
               style={inputStyle}
             />
           </div>
-          <div style={{ marginBottom: 14 }}>
+          <div style={{ marginBottom: 8 }}>
             <label style={labelStyle}>{t("form.owner")}</label>
             <select value={owner} onChange={(e) => setOwner(e.target.value)} style={inputStyle}>
               <option value="">—</option>
@@ -217,11 +222,35 @@ function CarRow({
               ))}
             </select>
           </div>
+          <div style={{ marginBottom: 14 }}>
+            <label style={labelStyle}>Eigenaar (persoon)</label>
+            <select
+              value={ownerPersonId ?? ""}
+              onChange={(e) => setOwnerPersonId(e.target.value ? Number(e.target.value) : null)}
+              style={{
+                ...inputStyle,
+                background: paper.paperDeep,
+              }}
+            >
+              <option value="">— geen —</option>
+              {people.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          </div>
           <div style={{ marginBottom: 12 }}>
             <button
               disabled={isSaving}
               onClick={() =>
-                onSave({ name, price_per_km: price, owner_name: owner || null, active: 0 })
+                onSave({
+                  name,
+                  price_per_km: price,
+                  owner_name: owner || null,
+                  owner_person_id: ownerPersonId,
+                  active: 0,
+                })
               }
               style={{
                 width: "100%",
@@ -266,7 +295,13 @@ function CarRow({
             <button
               disabled={!dirty || isSaving}
               onClick={() =>
-                onSave({ name, price_per_km: price, owner_name: owner || null, active: car.active })
+                onSave({
+                  name,
+                  price_per_km: price,
+                  owner_name: owner || null,
+                  owner_person_id: ownerPersonId,
+                  active: car.active,
+                })
               }
               style={{
                 flex: 2,
@@ -322,7 +357,8 @@ function OwnerCarTile({
     setDeleteConfirm(false);
   }
 
-  const dirty = name !== car.name || price !== car.price_per_km || activeLocal !== (car.active !== 0);
+  const dirty =
+    name !== car.name || price !== car.price_per_km || activeLocal !== (car.active !== 0);
   const isActive = car.active !== 0;
 
   const inputStyle: React.CSSProperties = {
@@ -373,7 +409,9 @@ function OwnerCarTile({
     deleteCar.mutate(car.id, {
       onError: (err: unknown) => {
         const apiErr = err as { status?: number; message?: string };
-        toast.error(apiErr.status === 409 ? t("owner.car_has_history") : (apiErr.message ?? "Error"));
+        toast.error(
+          apiErr.status === 409 ? t("owner.car_has_history") : (apiErr.message ?? "Error")
+        );
         setDeleteConfirm(false);
       },
     });
@@ -405,10 +443,29 @@ function OwnerCarTile({
         }}
       >
         <CarBadge short={car.short} active={isActive} />
-        <div style={{ flex: 1, fontFamily: fontSerif, fontSize: 14, fontWeight: 600, color: paper.ink, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        <div
+          style={{
+            flex: 1,
+            fontFamily: fontSerif,
+            fontSize: 14,
+            fontWeight: 600,
+            color: paper.ink,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
           {car.owner_name ?? <span style={{ color: paper.inkMute, fontStyle: "italic" }}>—</span>}
         </div>
-        <div style={{ fontFamily: fontMono, fontSize: 11, fontWeight: 700, color: paper.ink, flexShrink: 0 }}>
+        <div
+          style={{
+            fontFamily: fontMono,
+            fontSize: 11,
+            fontWeight: 700,
+            color: paper.ink,
+            flexShrink: 0,
+          }}
+        >
           €{car.price_per_km.toFixed(2)}/km
         </div>
       </div>
@@ -423,51 +480,158 @@ function OwnerCarTile({
           <div style={{ marginBottom: 12 }}>
             <label style={labelStyle}>{t("form.price_per_km")}</label>
             <div style={{ display: "flex", gap: 6 }}>
-              <input type="number" step="0.005" value={price} onChange={(e) => setPrice(parseFloat(e.target.value) || 0)} style={{ ...inputStyle, flex: 1 }} />
+              <input
+                type="number"
+                step="0.005"
+                value={price}
+                onChange={(e) => setPrice(parseFloat(e.target.value) || 0)}
+                style={{ ...inputStyle, flex: 1 }}
+              />
               {pnlData && (
                 <button
                   onClick={onDetail}
                   title={t("coverage.open_hint")}
-                  style={{ fontFamily: fontMono, fontSize: 10, fontWeight: 700, padding: "0 10px", background: paper.blue, color: paper.paper, border: "none", cursor: "pointer", flexShrink: 0 }}
+                  style={{
+                    fontFamily: fontMono,
+                    fontSize: 10,
+                    fontWeight: 700,
+                    padding: "0 10px",
+                    background: paper.blue,
+                    color: paper.paper,
+                    border: "none",
+                    cursor: "pointer",
+                    flexShrink: 0,
+                  }}
                 >
                   ✦
                 </button>
               )}
             </div>
           </div>
-          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 16 }}>
-            <span style={labelStyle}>{activeLocal ? t("admin.car_active") : t("admin.car_inactive")}</span>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              marginBottom: 16,
+            }}
+          >
+            <span style={labelStyle}>
+              {activeLocal ? t("admin.car_active") : t("admin.car_inactive")}
+            </span>
             <div
               role="switch"
               aria-checked={activeLocal}
               tabIndex={0}
               onClick={() => setActiveLocal((v) => !v)}
               onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && setActiveLocal((v) => !v)}
-              style={{ width: 44, height: 24, borderRadius: 12, background: activeLocal ? paper.green : paper.paperDark, position: "relative", cursor: "pointer", flexShrink: 0, transition: "background 0.2s" }}
+              style={{
+                width: 44,
+                height: 24,
+                borderRadius: 12,
+                background: activeLocal ? paper.green : paper.paperDark,
+                position: "relative",
+                cursor: "pointer",
+                flexShrink: 0,
+                transition: "background 0.2s",
+              }}
             >
-              <div style={{ position: "absolute", top: 2, left: activeLocal ? 22 : 2, width: 20, height: 20, borderRadius: "50%", background: paper.paper, boxShadow: "0 1px 3px rgba(0,0,0,0.25)", transition: "left 0.18s" }} />
+              <div
+                style={{
+                  position: "absolute",
+                  top: 2,
+                  left: activeLocal ? 22 : 2,
+                  width: 20,
+                  height: 20,
+                  borderRadius: "50%",
+                  background: paper.paper,
+                  boxShadow: "0 1px 3px rgba(0,0,0,0.25)",
+                  transition: "left 0.18s",
+                }}
+              />
             </div>
           </div>
           <div style={{ display: "flex", gap: 8, marginBottom: 12 }}>
             <button
-              onClick={() => { resetForm(); onToggle(); }}
-              style={{ flex: 1, padding: "9px", background: "transparent", color: paper.inkDim, border: `1px solid ${paper.paperDark}`, cursor: "pointer", fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 1.5, textTransform: "uppercase" }}
+              onClick={() => {
+                resetForm();
+                onToggle();
+              }}
+              style={{
+                flex: 1,
+                padding: "9px",
+                background: "transparent",
+                color: paper.inkDim,
+                border: `1px solid ${paper.paperDark}`,
+                cursor: "pointer",
+                fontFamily: fontMono,
+                fontSize: 9,
+                fontWeight: 700,
+                letterSpacing: 1.5,
+                textTransform: "uppercase",
+              }}
             >
               {t("action.cancel")}
             </button>
             <button
               disabled={!dirty || updateCar.isPending}
               onClick={handleSave}
-              style={{ flex: 2, padding: "9px", background: dirty && !updateCar.isPending ? paper.ink : paper.paperDark, color: dirty && !updateCar.isPending ? paper.paper : paper.inkMute, border: "none", cursor: dirty && !updateCar.isPending ? "pointer" : "default", fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 2, textTransform: "uppercase" }}
+              style={{
+                flex: 2,
+                padding: "9px",
+                background: dirty && !updateCar.isPending ? paper.ink : paper.paperDark,
+                color: dirty && !updateCar.isPending ? paper.paper : paper.inkMute,
+                border: "none",
+                cursor: dirty && !updateCar.isPending ? "pointer" : "default",
+                fontFamily: fontMono,
+                fontSize: 9,
+                fontWeight: 700,
+                letterSpacing: 2,
+                textTransform: "uppercase",
+              }}
             >
               {updateCar.isPending ? "…" : t("action.save")}
             </button>
           </div>
-          <button onClick={handleDelete} disabled={deleteCar.isPending} style={{ width: "100%", padding: "9px", background: deleteConfirm ? paper.accent : "transparent", color: deleteConfirm ? paper.paper : paper.accent, border: `1px solid ${paper.accent}`, cursor: "pointer", fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 1.5, textTransform: "uppercase" }}>
-            {deleteCar.isPending ? "…" : deleteConfirm ? t("owner.delete_confirm") : t("action.delete")}
+          <button
+            onClick={handleDelete}
+            disabled={deleteCar.isPending}
+            style={{
+              width: "100%",
+              padding: "9px",
+              background: deleteConfirm ? paper.accent : "transparent",
+              color: deleteConfirm ? paper.paper : paper.accent,
+              border: `1px solid ${paper.accent}`,
+              cursor: "pointer",
+              fontFamily: fontMono,
+              fontSize: 9,
+              fontWeight: 700,
+              letterSpacing: 1.5,
+              textTransform: "uppercase",
+            }}
+          >
+            {deleteCar.isPending
+              ? "…"
+              : deleteConfirm
+                ? t("owner.delete_confirm")
+                : t("action.delete")}
           </button>
           {deleteConfirm && (
-            <button onClick={() => setDeleteConfirm(false)} style={{ width: "100%", marginTop: 4, padding: "6px", background: "transparent", color: paper.inkDim, border: `1px solid ${paper.paperDark}`, cursor: "pointer", fontFamily: fontMono, fontSize: 8, letterSpacing: 1 }}>
+            <button
+              onClick={() => setDeleteConfirm(false)}
+              style={{
+                width: "100%",
+                marginTop: 4,
+                padding: "6px",
+                background: "transparent",
+                color: paper.inkDim,
+                border: `1px solid ${paper.paperDark}`,
+                cursor: "pointer",
+                fontFamily: fontMono,
+                fontSize: 8,
+                letterSpacing: 1,
+              }}
+            >
               {t("action.cancel")}
             </button>
           )}
@@ -485,7 +649,8 @@ function OwnerCreateForm({ onBack }: { onBack: () => void }) {
   const [short, setShort] = useState("");
   const [price, setPrice] = useState(0.2);
 
-  const valid = name.trim().length > 0 && short.trim().length > 0 && short.length <= 10 && price > 0;
+  const valid =
+    name.trim().length > 0 && short.trim().length > 0 && short.length <= 10 && price > 0;
 
   const inputStyle: React.CSSProperties = {
     width: "100%",
@@ -510,32 +675,75 @@ function OwnerCreateForm({ onBack }: { onBack: () => void }) {
 
   function handleSubmit() {
     if (!valid || createCar.isPending) return;
-    createCar.mutate(
-      { short: short.toUpperCase(), name, price_per_km: price } as Omit<Car, "id">,
-      { onSuccess: onBack }
-    );
+    createCar.mutate({ short: short.toUpperCase(), name, price_per_km: price } as Omit<Car, "id">, {
+      onSuccess: onBack,
+    });
   }
 
   return (
     <div style={{ background: paper.paperDeep }}>
       {/* Sheet header: × / goal / Add */}
-      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "0 16px", height: 52, borderBottom: `1.5px solid ${paper.paperDark}`, background: paper.paper, position: "sticky", top: 0, zIndex: 10, borderRadius: "14px 14px 0 0" }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "0 16px",
+          height: 52,
+          borderBottom: `1.5px solid ${paper.paperDark}`,
+          background: paper.paper,
+          position: "sticky",
+          top: 0,
+          zIndex: 10,
+          borderRadius: "14px 14px 0 0",
+        }}
+      >
         <button
           type="button"
           onClick={onBack}
           aria-label={t("action.close")}
-          style={{ fontFamily: fontMono, fontSize: 18, fontWeight: 700, background: "transparent", border: "none", cursor: "pointer", color: paper.ink, padding: "0 4px", lineHeight: 1 }}
+          style={{
+            fontFamily: fontMono,
+            fontSize: 18,
+            fontWeight: 700,
+            background: "transparent",
+            border: "none",
+            cursor: "pointer",
+            color: paper.ink,
+            padding: "0 4px",
+            lineHeight: 1,
+          }}
         >
           ×
         </button>
-        <div style={{ fontFamily: fontMono, fontSize: 10, fontWeight: 700, letterSpacing: 3, color: paper.inkDim, textTransform: "uppercase" }}>
+        <div
+          style={{
+            fontFamily: fontMono,
+            fontSize: 10,
+            fontWeight: 700,
+            letterSpacing: 3,
+            color: paper.inkDim,
+            textTransform: "uppercase",
+          }}
+        >
           {t("owner.add_car")}
         </div>
         <button
           type="button"
           disabled={!valid || createCar.isPending}
           onClick={handleSubmit}
-          style={{ fontFamily: fontMono, fontSize: 9, fontWeight: 700, letterSpacing: 2, textTransform: "uppercase", background: valid && !createCar.isPending ? paper.accent : paper.paperDark, color: valid && !createCar.isPending ? "#fff" : paper.inkMute, border: "none", padding: "8px 14px", cursor: valid && !createCar.isPending ? "pointer" : "default" }}
+          style={{
+            fontFamily: fontMono,
+            fontSize: 9,
+            fontWeight: 700,
+            letterSpacing: 2,
+            textTransform: "uppercase",
+            background: valid && !createCar.isPending ? paper.accent : paper.paperDark,
+            color: valid && !createCar.isPending ? "#fff" : paper.inkMute,
+            border: "none",
+            padding: "8px 14px",
+            cursor: valid && !createCar.isPending ? "pointer" : "default",
+          }}
         >
           {createCar.isPending ? "…" : t("action.add")}
         </button>
@@ -547,11 +755,24 @@ function OwnerCreateForm({ onBack }: { onBack: () => void }) {
         </div>
         <div style={{ marginBottom: 8 }}>
           <label style={labelStyle}>{t("form.short")}</label>
-          <input value={short} onChange={(e) => setShort(e.target.value.toUpperCase())} maxLength={10} placeholder="ETH" style={inputStyle} />
+          <input
+            value={short}
+            onChange={(e) => setShort(e.target.value.toUpperCase())}
+            maxLength={10}
+            placeholder="ETH"
+            style={inputStyle}
+          />
         </div>
         <div style={{ marginBottom: 16 }}>
           <label style={labelStyle}>{t("form.price_per_km")}</label>
-          <input type="number" step="0.005" min="0.01" value={price} onChange={(e) => setPrice(parseFloat(e.target.value) || 0)} style={inputStyle} />
+          <input
+            type="number"
+            step="0.005"
+            min="0.01"
+            value={price}
+            onChange={(e) => setPrice(parseFloat(e.target.value) || 0)}
+            style={inputStyle}
+          />
         </div>
       </div>
     </div>
@@ -572,17 +793,29 @@ function generateCarDetailMd(car: import("@/lib/queries/admin").CarPnL, year: nu
 
   lines.push(`\n## Ritten`);
   lines.push(`${car.trip_count} ritten · ${car.trip_km.toLocaleString("nl-BE")} km`);
-  lines.push(`- Anderen: ${car.trip_count - car.owner_trip_count} rit. · ${(car.trip_km - car.owner_trip_km).toLocaleString("nl-BE")} km · € ${fmt(othersRevenue)}`);
-  lines.push(`- Eigen:   ${car.owner_trip_count} rit. · ${car.owner_trip_km.toLocaleString("nl-BE")} km · € ${fmt(car.owner_trip_amount)}`);
+  lines.push(
+    `- Anderen: ${car.trip_count - car.owner_trip_count} rit. · ${(car.trip_km - car.owner_trip_km).toLocaleString("nl-BE")} km · € ${fmt(othersRevenue)}`
+  );
+  lines.push(
+    `- Eigen:   ${car.owner_trip_count} rit. · ${car.owner_trip_km.toLocaleString("nl-BE")} km · € ${fmt(car.owner_trip_amount)}`
+  );
 
   lines.push(`\n## Tankbeurten`);
-  lines.push(`${car.fuel_count} tankbeurten · ${fmtL(car.fuel_liters)} L · € ${fmt(car.fuel_amount)}`);
-  lines.push(`- Anderen: ${car.fuel_count - car.owner_fuel_count} tk. · ${fmtL(car.fuel_liters - car.owner_fuel_liters)} L · € ${fmt(car.fuel_amount - car.owner_fuel_amount)}`);
-  lines.push(`- Eigen:   ${car.owner_fuel_count} tk. · ${fmtL(car.owner_fuel_liters)} L · € ${fmt(car.owner_fuel_amount)}`);
+  lines.push(
+    `${car.fuel_count} tankbeurten · ${fmtL(car.fuel_liters)} L · € ${fmt(car.fuel_amount)}`
+  );
+  lines.push(
+    `- Anderen: ${car.fuel_count - car.owner_fuel_count} tk. · ${fmtL(car.fuel_liters - car.owner_fuel_liters)} L · € ${fmt(car.fuel_amount - car.owner_fuel_amount)}`
+  );
+  lines.push(
+    `- Eigen:   ${car.owner_fuel_count} tk. · ${fmtL(car.owner_fuel_liters)} L · € ${fmt(car.owner_fuel_amount)}`
+  );
 
   lines.push(`\n## Kosten`);
   lines.push(`${car.expense_count} kosten · € ${fmt(car.expense_amount)}`);
-  lines.push(`- Anderen: ${car.expense_count - car.owner_expense_count} kst. · € ${fmt(car.expense_amount - car.owner_expense_amount)}`);
+  lines.push(
+    `- Anderen: ${car.expense_count - car.owner_expense_count} kst. · € ${fmt(car.expense_amount - car.owner_expense_amount)}`
+  );
   lines.push(`- Eigen:   ${car.owner_expense_count} kst. · € ${fmt(car.owner_expense_amount)}`);
 
   lines.push(`\n## Resultaat`);
@@ -592,7 +825,8 @@ function generateCarDetailMd(car: import("@/lib/queries/admin").CarPnL, year: nu
 
   // Projection (same formula as CostCoverageScreen)
   const fuelPerKm = car.trip_km > 0 ? car.fuel_amount / car.trip_km : 0;
-  const pctOthers = car.trip_km > 0 ? Math.round(((car.trip_km - car.owner_trip_km) / car.trip_km) * 100) / 100 : 0;
+  const pctOthers =
+    car.trip_km > 0 ? Math.round(((car.trip_km - car.owner_trip_km) / car.trip_km) * 100) / 100 : 0;
   const nonOwnerKm = car.trip_km * pctOthers;
   const ownerKm = car.trip_km * (1 - pctOthers);
   const markupPerKm = car.car_price_per_km - fuelPerKm;
@@ -633,12 +867,14 @@ function OwnerFleet({ myName }: { myName: string | null }) {
   const year = yearParam ? parseInt(yearParam, 10) : currentYear;
 
   const screen: OwnerScreen =
-    viewParam === "detail" && screenCarId ? { view: "detail", carId: screenCarId } :
-    { view: "fleet" };
+    viewParam === "detail" && screenCarId
+      ? { view: "detail", carId: screenCarId }
+      : { view: "fleet" };
 
   const setYear = (newYear: number) => {
     const p = new URLSearchParams(searchParams.toString());
-    if (newYear === currentYear) p.delete("year"); else p.set("year", String(newYear));
+    if (newYear === currentYear) p.delete("year");
+    else p.set("year", String(newYear));
     router.replace(`${pathname}?${p.toString()}`, { scroll: false });
   };
 
@@ -672,14 +908,57 @@ function OwnerFleet({ myName }: { myName: string | null }) {
   const [expandedId, setExpandedId] = useState<number | null>(null);
 
   const yearSelector = (
-    <div style={{ display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 16 }}>
-      <button onClick={() => setYear(year - 1)} disabled={year <= earliestYear} style={{ padding: "6px 14px", background: "transparent", border: `1.5px solid ${paper.ink}`, borderRight: "none", fontFamily: fontMono, fontSize: 10, fontWeight: 700, color: year <= earliestYear ? paper.inkMute : paper.ink, cursor: year <= earliestYear ? "default" : "pointer", letterSpacing: 1 }}>
+    <div
+      style={{ display: "flex", alignItems: "center", justifyContent: "center", marginBottom: 16 }}
+    >
+      <button
+        onClick={() => setYear(year - 1)}
+        disabled={year <= earliestYear}
+        style={{
+          padding: "6px 14px",
+          background: "transparent",
+          border: `1.5px solid ${paper.ink}`,
+          borderRight: "none",
+          fontFamily: fontMono,
+          fontSize: 10,
+          fontWeight: 700,
+          color: year <= earliestYear ? paper.inkMute : paper.ink,
+          cursor: year <= earliestYear ? "default" : "pointer",
+          letterSpacing: 1,
+        }}
+      >
         ← {year - 1}
       </button>
-      <div style={{ padding: "6px 18px", background: paper.ink, color: paper.paper, fontFamily: fontMono, fontSize: 10, fontWeight: 700, letterSpacing: 2, border: `1.5px solid ${paper.ink}` }}>
+      <div
+        style={{
+          padding: "6px 18px",
+          background: paper.ink,
+          color: paper.paper,
+          fontFamily: fontMono,
+          fontSize: 10,
+          fontWeight: 700,
+          letterSpacing: 2,
+          border: `1.5px solid ${paper.ink}`,
+        }}
+      >
         {year}
       </div>
-      <button onClick={() => setYear(year + 1)} disabled={year >= currentYear} style={{ padding: "6px 14px", background: "transparent", border: `1.5px solid ${paper.ink}`, borderLeft: "none", fontFamily: fontMono, fontSize: 10, fontWeight: 700, color: year >= currentYear ? paper.inkMute : paper.ink, cursor: year >= currentYear ? "default" : "pointer", letterSpacing: 1 }}>
+      <button
+        onClick={() => setYear(year + 1)}
+        disabled={year >= currentYear}
+        style={{
+          padding: "6px 14px",
+          background: "transparent",
+          border: `1.5px solid ${paper.ink}`,
+          borderLeft: "none",
+          fontFamily: fontMono,
+          fontSize: 10,
+          fontWeight: 700,
+          color: year >= currentYear ? paper.inkMute : paper.ink,
+          cursor: year >= currentYear ? "default" : "pointer",
+          letterSpacing: 1,
+        }}
+      >
         {year + 1} →
       </button>
     </div>
@@ -707,7 +986,19 @@ function OwnerFleet({ myName }: { myName: string | null }) {
           <button
             onClick={handleDownload}
             title="Download als .md"
-            style={{ position: "absolute", right: 0, top: 0, padding: "6px 10px", background: "transparent", border: `1.5px solid ${paper.ink}`, color: paper.ink, cursor: "pointer", fontFamily: fontMono, fontSize: 12, lineHeight: 1 }}
+            style={{
+              position: "absolute",
+              right: 0,
+              top: 0,
+              padding: "6px 10px",
+              background: "transparent",
+              border: `1.5px solid ${paper.ink}`,
+              color: paper.ink,
+              cursor: "pointer",
+              fontFamily: fontMono,
+              fontSize: 12,
+              lineHeight: 1,
+            }}
           >
             ↓
           </button>
@@ -753,7 +1044,15 @@ function OwnerFleet({ myName }: { myName: string | null }) {
       <Fab onClick={openAdd} label={t("owner.add_car")} />
 
       {myCars.length === 0 ? (
-        <div style={{ fontFamily: fontMono, fontSize: 11, color: paper.inkMute, textAlign: "center", padding: "32px 0" }}>
+        <div
+          style={{
+            fontFamily: fontMono,
+            fontSize: 11,
+            color: paper.inkMute,
+            textAlign: "center",
+            padding: "32px 0",
+          }}
+        >
           {t("owner.no_cars")}
         </div>
       ) : (
@@ -761,7 +1060,18 @@ function OwnerFleet({ myName }: { myName: string | null }) {
           {activeCars.map(renderTile)}
           {inactiveCars.length > 0 && (
             <>
-              <div style={{ fontFamily: fontMono, fontSize: 9, color: paper.inkDim, letterSpacing: 2, textTransform: "uppercase", padding: "14px 0 8px", borderTop: `1.5px dashed ${paper.inkMute}`, marginTop: 4 }}>
+              <div
+                style={{
+                  fontFamily: fontMono,
+                  fontSize: 9,
+                  color: paper.inkDim,
+                  letterSpacing: 2,
+                  textTransform: "uppercase",
+                  padding: "14px 0 8px",
+                  borderTop: `1.5px dashed ${paper.inkMute}`,
+                  marginTop: 4,
+                }}
+              >
                 {t("admin.car_deactivated_section")}
               </div>
               {inactiveCars.map(renderTile)}
@@ -770,11 +1080,24 @@ function OwnerFleet({ myName }: { myName: string | null }) {
         </>
       )}
 
-      <Dialog.Root open={adding} onOpenChange={(open) => { if (!open) closeAdd(); }}>
+      <Dialog.Root
+        open={adding}
+        onOpenChange={(open) => {
+          if (!open) closeAdd();
+        }}
+      >
         <Dialog.Portal>
           <Dialog.Overlay style={overlayStyle} />
           <Dialog.Content style={sheetStyle} aria-describedby={undefined}>
-            <Dialog.Title style={{ position: "absolute", width: 1, height: 1, overflow: "hidden", clip: "rect(0,0,0,0)" }}>
+            <Dialog.Title
+              style={{
+                position: "absolute",
+                width: 1,
+                height: 1,
+                overflow: "hidden",
+                clip: "rect(0,0,0,0)",
+              }}
+            >
               {t("owner.add_car")}
             </Dialog.Title>
             <OwnerCreateForm onBack={closeAdd} />

--- a/app/admin/members/page.tsx
+++ b/app/admin/members/page.tsx
@@ -2,6 +2,8 @@
 import { useState, useEffect } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Pencil } from "lucide-react";
 import { useMe } from "@/hooks/use-me";
 import { paper, fontMono, fontSerif } from "@/lib/paper-theme";
 import { useT } from "@/components/locale-provider";
@@ -33,6 +35,7 @@ function PersonRow({
   const [isAdmin, setIsAdmin] = useState(person.is_admin === 1);
   const [inviteBanner, setInviteBanner] = useState<string | null>(null);
 
+  const [hovered, setHovered] = useState(false);
   const [prevId, setPrevId] = useState(person.id);
   if (person.id !== prevId) {
     setPrevId(person.id);
@@ -145,15 +148,34 @@ function PersonRow({
         {/* Name + ← view as + username */}
         <div style={{ flex: 1, display: "flex", alignItems: "baseline", gap: 8, minWidth: 0 }}>
           <span
-            style={{
-              fontFamily: fontSerif,
-              fontSize: 15,
-              fontWeight: 700,
-              color: paper.ink,
-              whiteSpace: "nowrap",
-            }}
+            style={{ display: "inline-flex", alignItems: "center", gap: 4 }}
+            onMouseEnter={() => setHovered(true)}
+            onMouseLeave={() => setHovered(false)}
           >
-            {person.name}
+            <span
+              style={{
+                fontFamily: fontSerif,
+                fontSize: 15,
+                fontWeight: 700,
+                color: paper.ink,
+                whiteSpace: "nowrap",
+              }}
+            >
+              {person.name}
+            </span>
+            <Link
+              href={`/user/${person.id}/edit`}
+              onClick={(e) => e.stopPropagation()}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                color: paper.inkDim,
+                opacity: hovered ? 1 : 0,
+                transition: "opacity 0.15s",
+              }}
+            >
+              <Pencil size={11} />
+            </Link>
           </span>
           {onCloak && (
             <button

--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -18,6 +18,10 @@ export default function AdminSettingsPage() {
   const [showToken, setShowToken] = useState(false);
   const [testStatus, setTestStatus] = useState<{ ok: boolean; message: string } | null>(null);
   const [testing, setTesting] = useState(false);
+  const [backfillStatus, setBackfillStatus] = useState<{ ok: boolean; message: string } | null>(
+    null
+  );
+  const [backfilling, setBackfilling] = useState(false);
 
   useEffect(() => {
     if (data) {
@@ -342,6 +346,66 @@ export default function AdminSettingsPage() {
                   }}
                 >
                   {testStatus.message}
+                </div>
+              )}
+              <button
+                type="button"
+                disabled={backfilling}
+                onClick={async () => {
+                  setBackfilling(true);
+                  setBackfillStatus(null);
+                  try {
+                    const csrfToken = document.cookie.match(/csrf-token=([^;]+)/)?.[1] ?? "";
+                    const res = await fetch("/api/admin/calendar-backfill", {
+                      method: "POST",
+                      headers: { "x-csrf-token": csrfToken },
+                    });
+                    const body = (await res.json()) as
+                      | { ok: true; synced: number; failed: number; total: number }
+                      | { ok: false; error: string };
+                    if (body.ok) {
+                      setBackfillStatus({
+                        ok: true,
+                        message: `${body.synced}/${body.total} reserveringen gesynchroniseerd${body.failed > 0 ? ` (${body.failed} mislukt)` : ""}`,
+                      });
+                    } else {
+                      setBackfillStatus({ ok: false, message: `Fout: ${body.error}` });
+                    }
+                  } catch {
+                    setBackfillStatus({ ok: false, message: "Netwerkfout" });
+                  } finally {
+                    setBackfilling(false);
+                  }
+                }}
+                style={{
+                  marginTop: 8,
+                  width: "100%",
+                  padding: "8px",
+                  fontFamily: fontMono,
+                  fontSize: 9,
+                  fontWeight: 700,
+                  letterSpacing: 2,
+                  textTransform: "uppercase",
+                  background: "none",
+                  color: backfilling ? paper.inkMute : paper.inkDim,
+                  border: `1px solid ${paper.paperDark}`,
+                  cursor: backfilling ? "not-allowed" : "pointer",
+                }}
+              >
+                {backfilling ? "…" : t("settings.backfill")}
+              </button>
+              {backfillStatus && (
+                <div
+                  style={{
+                    marginTop: 8,
+                    fontFamily: fontMono,
+                    fontSize: 10,
+                    color: backfillStatus.ok ? "#2d7a2d" : paper.accent,
+                    letterSpacing: 0.5,
+                    lineHeight: 1.5,
+                  }}
+                >
+                  {backfillStatus.message}
                 </div>
               )}
             </>

--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -165,6 +165,23 @@ export default function AdminSettingsPage() {
             {t("settings.calendar_hint")}
           </div>
 
+          {!isLoading && data && !data.env_credentials_ok && (
+            <div
+              style={{
+                fontFamily: fontMono,
+                fontSize: 10,
+                color: "#b45309",
+                background: "#fffbeb",
+                border: "1px solid #fde68a",
+                padding: "8px 10px",
+                marginBottom: 12,
+                lineHeight: 1.5,
+              }}
+            >
+              {t("settings.env_warning")}
+            </div>
+          )}
+
           {isLoading ? (
             <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkMute }}>…</div>
           ) : (

--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -10,13 +10,42 @@ export default function AdminSettingsPage() {
   const { data, isLoading } = useAdminSettings();
   const save = useSaveAdminSettings();
   const [bankAccount, setBankAccount] = useState("");
+  const [calendarId, setCalendarId] = useState("");
+  const [refreshToken, setRefreshToken] = useState("");
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    if (data) setBankAccount(data.coop_bank_account);
+    if (data) {
+      setBankAccount(data.coop_bank_account);
+      setCalendarId(data.google_calendar_id ?? "");
+      setRefreshToken(data.google_oauth_refresh_token ?? "");
+    }
   }, [data]);
 
   const dirty = data ? bankAccount !== data.coop_bank_account : false;
+  const calendarDirty = data
+    ? calendarId !== (data.google_calendar_id ?? "") ||
+      refreshToken !== (data.google_oauth_refresh_token ?? "")
+    : false;
+
+  const inputStyle = {
+    width: "100%",
+    padding: "8px 10px",
+    fontFamily: fontMono,
+    fontSize: 12,
+    background: paper.paperDark,
+    color: paper.ink,
+    outline: "none",
+    boxSizing: "border-box" as const,
+    letterSpacing: 1,
+  };
+
+  const labelStyle = {
+    fontFamily: fontMono,
+    fontSize: 9,
+    color: paper.inkMute,
+    letterSpacing: 1,
+    marginBottom: 4,
+  };
 
   return (
     <div style={{ padding: 16, maxWidth: 480 }}>
@@ -69,16 +98,8 @@ export default function AdminSettingsPage() {
               onChange={(e) => setBankAccount(e.target.value)}
               placeholder="BE12 3456 7890 1234"
               style={{
-                width: "100%",
-                padding: "8px 10px",
-                fontFamily: fontMono,
-                fontSize: 12,
-                background: paper.paperDark,
-                color: paper.ink,
+                ...inputStyle,
                 border: `1.5px solid ${dirty ? paper.ink : paper.paperDark}`,
-                outline: "none",
-                boxSizing: "border-box",
-                letterSpacing: 1,
               }}
             />
             <button
@@ -99,11 +120,104 @@ export default function AdminSettingsPage() {
                 cursor: dirty ? "pointer" : "default",
               }}
             >
-              {save.isPending ? t("action.saving") : save.isSuccess && !dirty ? t("action.saved") : t("action.save")}
+              {save.isPending
+                ? t("action.saving")
+                : save.isSuccess && !dirty
+                  ? t("action.saved")
+                  : t("action.save")}
             </button>
           </>
         )}
       </Card>
+
+      <div style={{ marginTop: 16 }}>
+        <Card>
+          <div
+            style={{
+              fontFamily: fontSerif,
+              fontSize: 14,
+              fontWeight: 700,
+              color: paper.ink,
+              marginBottom: 12,
+            }}
+          >
+            Google Calendar
+          </div>
+          <div
+            style={{
+              fontFamily: fontMono,
+              fontSize: 9,
+              color: paper.inkMute,
+              letterSpacing: 1,
+              marginBottom: 8,
+            }}
+          >
+            Laat leeg om de integratie uit te schakelen.
+          </div>
+
+          {isLoading ? (
+            <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkMute }}>…</div>
+          ) : (
+            <>
+              <div style={{ marginBottom: 12 }}>
+                <div style={labelStyle}>Google Calendar ID</div>
+                <input
+                  type="text"
+                  value={calendarId}
+                  onChange={(e) => setCalendarId(e.target.value)}
+                  placeholder="abc123@group.calendar.google.com"
+                  style={{
+                    ...inputStyle,
+                    border: `1.5px solid ${calendarDirty ? paper.ink : paper.paperDark}`,
+                  }}
+                />
+              </div>
+              <div style={{ marginBottom: 12 }}>
+                <div style={labelStyle}>OAuth Refresh Token</div>
+                <input
+                  type="password"
+                  value={refreshToken}
+                  onChange={(e) => setRefreshToken(e.target.value)}
+                  placeholder="••••••••"
+                  style={{
+                    ...inputStyle,
+                    border: `1.5px solid ${calendarDirty ? paper.ink : paper.paperDark}`,
+                  }}
+                />
+              </div>
+              <button
+                onClick={() =>
+                  save.mutate({
+                    google_calendar_id: calendarId,
+                    google_oauth_refresh_token: refreshToken,
+                  })
+                }
+                disabled={!calendarDirty || save.isPending}
+                style={{
+                  marginTop: 10,
+                  width: "100%",
+                  padding: "8px",
+                  fontFamily: fontMono,
+                  fontSize: 9,
+                  fontWeight: 700,
+                  letterSpacing: 2,
+                  textTransform: "uppercase",
+                  background: calendarDirty ? paper.ink : paper.paperDark,
+                  color: calendarDirty ? paper.paper : paper.inkMute,
+                  border: "none",
+                  cursor: calendarDirty ? "pointer" : "default",
+                }}
+              >
+                {save.isPending
+                  ? t("action.saving")
+                  : save.isSuccess && !calendarDirty
+                    ? t("action.saved")
+                    : t("action.save")}
+              </button>
+            </>
+          )}
+        </Card>
+      </div>
     </div>
   );
 }

--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -274,12 +274,17 @@ export default function AdminSettingsPage() {
                         message: t("settings.test_ok").replace("{name}", body.summary),
                       });
                     } else {
+                      const errorMap: Record<string, string> = {
+                        no_calendar_id: t("settings.test_no_id"),
+                        no_token: t("settings.test_no_token"),
+                        no_env_credentials: t("settings.test_no_env"),
+                        invalid_client: t("settings.test_invalid_client"),
+                        invalid_grant: t("settings.test_invalid_grant"),
+                        calendar_not_found: t("settings.test_not_found"),
+                      };
                       const msg =
-                        body.error === "no_calendar_id"
-                          ? t("settings.test_no_id")
-                          : body.error === "no_token"
-                            ? t("settings.test_no_token")
-                            : t("settings.test_fail").replace("{error}", body.error);
+                        errorMap[body.error] ??
+                        t("settings.test_fail").replace("{error}", body.error);
                       setTestStatus({ ok: false, message: msg });
                     }
                   } catch {
@@ -316,6 +321,7 @@ export default function AdminSettingsPage() {
                     fontSize: 10,
                     color: testStatus.ok ? "#2d7a2d" : paper.accent,
                     letterSpacing: 0.5,
+                    lineHeight: 1.5,
                   }}
                 >
                   {testStatus.message}

--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 import { useState, useEffect } from "react";
+import { Eye, EyeOff } from "lucide-react";
+import { toast } from "sonner";
 import { paper, fontMono, fontSerif } from "@/lib/paper-theme";
 import { useAdminSettings, useSaveAdminSettings } from "@/hooks/use-admin-settings";
 import { Card, Perf } from "../_shared";
@@ -13,19 +15,19 @@ export default function AdminSettingsPage() {
   const [bankAccount, setBankAccount] = useState("");
   const [calendarId, setCalendarId] = useState("");
   const [refreshToken, setRefreshToken] = useState("");
+  const [showToken, setShowToken] = useState(false);
 
   useEffect(() => {
     if (data) {
       setBankAccount(data.coop_bank_account);
       setCalendarId(data.google_calendar_id ?? "");
-      setRefreshToken(data.google_oauth_refresh_token ?? "");
+      // Never pre-fill the token — user must re-enter to change it
     }
   }, [data]);
 
   const dirty = data ? bankAccount !== data.coop_bank_account : false;
   const calendarDirty = data
-    ? calendarId !== (data.google_calendar_id ?? "") ||
-      refreshToken !== (data.google_oauth_refresh_token ?? "")
+    ? calendarId !== (data.google_calendar_id ?? "") || refreshToken !== ""
     : false;
 
   const inputStyle = {
@@ -60,7 +62,7 @@ export default function AdminSettingsPage() {
           marginBottom: 12,
         }}
       >
-        Instellingen
+        {t("settings.title")}
       </div>
 
       <Card>
@@ -73,7 +75,7 @@ export default function AdminSettingsPage() {
             marginBottom: 12,
           }}
         >
-          Coöperatie bankrekening
+          {t("settings.bank_title")}
         </div>
         <div
           style={{
@@ -84,7 +86,7 @@ export default function AdminSettingsPage() {
             marginBottom: 8,
           }}
         >
-          Wordt vermeld in het betalingsbericht voor leden.
+          {t("settings.bank_hint")}
         </div>
 
         <Perf margin="0 0 12px" />
@@ -104,7 +106,12 @@ export default function AdminSettingsPage() {
               }}
             />
             <button
-              onClick={() => saveBankAccount.mutate({ coop_bank_account: bankAccount })}
+              onClick={() =>
+                saveBankAccount.mutate(
+                  { coop_bank_account: bankAccount },
+                  { onSuccess: () => toast.success(t("action.saved")) }
+                )
+              }
               disabled={!dirty || saveBankAccount.isPending}
               style={{
                 marginTop: 10,
@@ -142,7 +149,7 @@ export default function AdminSettingsPage() {
               marginBottom: 12,
             }}
           >
-            Google Calendar
+            {t("settings.calendar_title")}
           </div>
           <div
             style={{
@@ -153,7 +160,7 @@ export default function AdminSettingsPage() {
               marginBottom: 8,
             }}
           >
-            Laat leeg om de integratie uit te schakelen.
+            {t("settings.calendar_hint")}
           </div>
 
           {isLoading ? (
@@ -161,7 +168,7 @@ export default function AdminSettingsPage() {
           ) : (
             <>
               <div style={{ marginBottom: 12 }}>
-                <div style={labelStyle}>Google Calendar ID</div>
+                <div style={labelStyle}>{t("settings.calendar_id_label")}</div>
                 <input
                   type="text"
                   value={calendarId}
@@ -174,24 +181,57 @@ export default function AdminSettingsPage() {
                 />
               </div>
               <div style={{ marginBottom: 12 }}>
-                <div style={labelStyle}>OAuth Refresh Token</div>
-                <input
-                  type="password"
-                  value={refreshToken}
-                  onChange={(e) => setRefreshToken(e.target.value)}
-                  placeholder="••••••••"
-                  style={{
-                    ...inputStyle,
-                    border: `1.5px solid ${calendarDirty ? paper.ink : paper.paperDark}`,
-                  }}
-                />
+                <div style={labelStyle}>{t("settings.token_label")}</div>
+                <div style={{ position: "relative" }}>
+                  <input
+                    type={showToken ? "text" : "password"}
+                    value={refreshToken}
+                    onChange={(e) => setRefreshToken(e.target.value)}
+                    placeholder={
+                      data?.google_oauth_refresh_token
+                        ? t("settings.token_stored")
+                        : t("settings.token_empty")
+                    }
+                    style={{
+                      ...inputStyle,
+                      paddingRight: 32,
+                      border: `1.5px solid ${calendarDirty ? paper.ink : paper.paperDark}`,
+                    }}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowToken((v) => !v)}
+                    style={{
+                      position: "absolute",
+                      right: 8,
+                      top: "50%",
+                      transform: "translateY(-50%)",
+                      background: "none",
+                      border: "none",
+                      cursor: "pointer",
+                      padding: 0,
+                      color: paper.inkMute,
+                      display: "flex",
+                    }}
+                  >
+                    {showToken ? <EyeOff size={14} /> : <Eye size={14} />}
+                  </button>
+                </div>
               </div>
               <button
                 onClick={() =>
-                  saveCalendar.mutate({
-                    google_calendar_id: calendarId,
-                    google_oauth_refresh_token: refreshToken,
-                  })
+                  saveCalendar.mutate(
+                    {
+                      google_calendar_id: calendarId,
+                      ...(refreshToken !== "" && { google_oauth_refresh_token: refreshToken }),
+                    },
+                    {
+                      onSuccess: () => {
+                        setRefreshToken("");
+                        toast.success(t("action.saved"));
+                      },
+                    }
+                  )
                 }
                 disabled={!calendarDirty || saveCalendar.isPending}
                 style={{

--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -16,6 +16,8 @@ export default function AdminSettingsPage() {
   const [calendarId, setCalendarId] = useState("");
   const [refreshToken, setRefreshToken] = useState("");
   const [showToken, setShowToken] = useState(false);
+  const [testStatus, setTestStatus] = useState<{ ok: boolean; message: string } | null>(null);
+  const [testing, setTesting] = useState(false);
 
   useEffect(() => {
     if (data) {
@@ -255,6 +257,70 @@ export default function AdminSettingsPage() {
                     ? t("action.saved")
                     : t("action.save")}
               </button>
+              <button
+                type="button"
+                disabled={testing}
+                onClick={async () => {
+                  setTesting(true);
+                  setTestStatus(null);
+                  try {
+                    const res = await fetch("/api/admin/calendar-test");
+                    const body = (await res.json()) as
+                      | { ok: true; summary: string }
+                      | { ok: false; error: string };
+                    if (body.ok) {
+                      setTestStatus({
+                        ok: true,
+                        message: t("settings.test_ok").replace("{name}", body.summary),
+                      });
+                    } else {
+                      const msg =
+                        body.error === "no_calendar_id"
+                          ? t("settings.test_no_id")
+                          : body.error === "no_token"
+                            ? t("settings.test_no_token")
+                            : t("settings.test_fail").replace("{error}", body.error);
+                      setTestStatus({ ok: false, message: msg });
+                    }
+                  } catch {
+                    setTestStatus({
+                      ok: false,
+                      message: t("settings.test_fail").replace("{error}", "network error"),
+                    });
+                  } finally {
+                    setTesting(false);
+                  }
+                }}
+                style={{
+                  marginTop: 8,
+                  width: "100%",
+                  padding: "8px",
+                  fontFamily: fontMono,
+                  fontSize: 9,
+                  fontWeight: 700,
+                  letterSpacing: 2,
+                  textTransform: "uppercase",
+                  background: "none",
+                  color: testing ? paper.inkMute : paper.inkDim,
+                  border: `1px solid ${paper.paperDark}`,
+                  cursor: testing ? "not-allowed" : "pointer",
+                }}
+              >
+                {testing ? "…" : t("settings.test")}
+              </button>
+              {testStatus && (
+                <div
+                  style={{
+                    marginTop: 8,
+                    fontFamily: fontMono,
+                    fontSize: 10,
+                    color: testStatus.ok ? "#2d7a2d" : paper.accent,
+                    letterSpacing: 0.5,
+                  }}
+                >
+                  {testStatus.message}
+                </div>
+              )}
             </>
           )}
         </Card>

--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -8,7 +8,8 @@ import { useT } from "@/components/locale-provider";
 export default function AdminSettingsPage() {
   const t = useT();
   const { data, isLoading } = useAdminSettings();
-  const save = useSaveAdminSettings();
+  const saveBankAccount = useSaveAdminSettings();
+  const saveCalendar = useSaveAdminSettings();
   const [bankAccount, setBankAccount] = useState("");
   const [calendarId, setCalendarId] = useState("");
   const [refreshToken, setRefreshToken] = useState("");
@@ -103,8 +104,8 @@ export default function AdminSettingsPage() {
               }}
             />
             <button
-              onClick={() => save.mutate({ coop_bank_account: bankAccount })}
-              disabled={!dirty || save.isPending}
+              onClick={() => saveBankAccount.mutate({ coop_bank_account: bankAccount })}
+              disabled={!dirty || saveBankAccount.isPending}
               style={{
                 marginTop: 10,
                 width: "100%",
@@ -120,9 +121,9 @@ export default function AdminSettingsPage() {
                 cursor: dirty ? "pointer" : "default",
               }}
             >
-              {save.isPending
+              {saveBankAccount.isPending
                 ? t("action.saving")
-                : save.isSuccess && !dirty
+                : saveBankAccount.isSuccess && !dirty
                   ? t("action.saved")
                   : t("action.save")}
             </button>
@@ -187,12 +188,12 @@ export default function AdminSettingsPage() {
               </div>
               <button
                 onClick={() =>
-                  save.mutate({
+                  saveCalendar.mutate({
                     google_calendar_id: calendarId,
                     google_oauth_refresh_token: refreshToken,
                   })
                 }
-                disabled={!calendarDirty || save.isPending}
+                disabled={!calendarDirty || saveCalendar.isPending}
                 style={{
                   marginTop: 10,
                   width: "100%",
@@ -208,9 +209,9 @@ export default function AdminSettingsPage() {
                   cursor: calendarDirty ? "pointer" : "default",
                 }}
               >
-                {save.isPending
+                {saveCalendar.isPending
                   ? t("action.saving")
-                  : save.isSuccess && !calendarDirty
+                  : saveCalendar.isSuccess && !calendarDirty
                     ? t("action.saved")
                     : t("action.save")}
               </button>

--- a/app/api/admin/calendar-backfill/route.ts
+++ b/app/api/admin/calendar-backfill/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import { json, requireAdmin } from "@/lib/api";
+import { getSetting } from "@/lib/queries/settings";
+import { env } from "@/lib/env";
+import { syncReservationCreate } from "@/lib/reservation-sync";
+
+export const POST = json(async (req) => {
+  await requireAdmin(req);
+  const db = getDb();
+
+  if (!env.GOOGLE_CLIENT_ID || !env.GOOGLE_CLIENT_SECRET)
+    return NextResponse.json({ ok: false, error: "no_env_credentials" });
+
+  if (!getSetting(db, "google_calendar_id"))
+    return NextResponse.json({ ok: false, error: "no_calendar_id" });
+
+  if (!getSetting(db, "google_oauth_refresh_token"))
+    return NextResponse.json({ ok: false, error: "no_token" });
+
+  const today = new Date().toISOString().slice(0, 10);
+
+  // Upcoming reservations not yet synced
+  const rows = db
+    .prepare(
+      `SELECT id FROM reservations
+       WHERE end_date >= ? AND google_event_id IS NULL AND status != 'rejected'
+       ORDER BY start_date`
+    )
+    .all(today) as { id: number }[];
+
+  let synced = 0;
+  let failed = 0;
+  for (const row of rows) {
+    try {
+      await syncReservationCreate(db, row.id);
+      synced++;
+    } catch {
+      failed++;
+    }
+  }
+
+  return NextResponse.json({ ok: true, synced, failed, total: rows.length });
+});

--- a/app/api/admin/calendar-renew/route.ts
+++ b/app/api/admin/calendar-renew/route.ts
@@ -1,0 +1,16 @@
+// app/api/admin/calendar-renew/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import { env } from "@/lib/env";
+import { handleCalendarRenew } from "@/lib/calendar-renew";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const cronSecret = env.CRON_SECRET;
+  if (!cronSecret || req.headers.get("authorization") !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const baseUrl = env.NEXT_PUBLIC_BASE_URL ?? new URL(req.url).origin;
+  const result = await handleCalendarRenew(getDb(), baseUrl);
+  return NextResponse.json(result);
+}

--- a/app/api/admin/calendar-renew/route.ts
+++ b/app/api/admin/calendar-renew/route.ts
@@ -11,6 +11,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   }
 
   const baseUrl = env.NEXT_PUBLIC_BASE_URL ?? new URL(req.url).origin;
-  const result = await handleCalendarRenew(getDb(), baseUrl);
-  return NextResponse.json(result);
+  try {
+    const result = await handleCalendarRenew(getDb(), baseUrl);
+    return NextResponse.json(result);
+  } catch (e) {
+    console.error("[calendar-renew] unhandled error", e);
+    return NextResponse.json({ ok: false, error: String(e) }, { status: 500 });
+  }
 }

--- a/app/api/admin/calendar-test/route.ts
+++ b/app/api/admin/calendar-test/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { google } from "googleapis";
+import { getDb } from "@/lib/db";
+import { json, requireAdmin } from "@/lib/api";
+import { getSetting } from "@/lib/queries/settings";
+import { getOAuthClient } from "@/lib/google-calendar";
+
+export const GET = json(async (req) => {
+  await requireAdmin(req);
+  const db = getDb();
+
+  const calendarId = getSetting(db, "google_calendar_id");
+  const refreshToken = getSetting(db, "google_oauth_refresh_token");
+
+  if (!calendarId) return NextResponse.json({ ok: false, error: "no_calendar_id" });
+  if (!refreshToken) return NextResponse.json({ ok: false, error: "no_token" });
+
+  const client = getOAuthClient(refreshToken);
+  const cal = google.calendar({ version: "v3", auth: client });
+
+  const res = await cal.calendars.get({ calendarId });
+  return NextResponse.json({ ok: true, summary: res.data.summary ?? calendarId });
+});

--- a/app/api/admin/calendar-test/route.ts
+++ b/app/api/admin/calendar-test/route.ts
@@ -1,13 +1,30 @@
 import { NextResponse } from "next/server";
 import { google } from "googleapis";
 import { getDb } from "@/lib/db";
+import { env } from "@/lib/env";
 import { json, requireAdmin } from "@/lib/api";
 import { getSetting } from "@/lib/queries/settings";
 import { getOAuthClient } from "@/lib/google-calendar";
 
+function googleErrorCode(e: unknown): string {
+  if (e && typeof e === "object") {
+    const err = e as Record<string, unknown>;
+    const data = (err.response as Record<string, unknown> | undefined)?.data;
+    if (data && typeof data === "object" && "error" in data) {
+      return String((data as Record<string, unknown>).error);
+    }
+    const status = (err.response as Record<string, unknown> | undefined)?.status;
+    if (status === 404) return "calendar_not_found";
+  }
+  return "unknown";
+}
+
 export const GET = json(async (req) => {
   await requireAdmin(req);
   const db = getDb();
+
+  if (!env.GOOGLE_CLIENT_ID || !env.GOOGLE_CLIENT_SECRET)
+    return NextResponse.json({ ok: false, error: "no_env_credentials" });
 
   const calendarId = getSetting(db, "google_calendar_id");
   const refreshToken = getSetting(db, "google_oauth_refresh_token");
@@ -15,9 +32,12 @@ export const GET = json(async (req) => {
   if (!calendarId) return NextResponse.json({ ok: false, error: "no_calendar_id" });
   if (!refreshToken) return NextResponse.json({ ok: false, error: "no_token" });
 
-  const client = getOAuthClient(refreshToken);
-  const cal = google.calendar({ version: "v3", auth: client });
-
-  const res = await cal.calendars.get({ calendarId });
-  return NextResponse.json({ ok: true, summary: res.data.summary ?? calendarId });
+  try {
+    const client = getOAuthClient(refreshToken);
+    const cal = google.calendar({ version: "v3", auth: client });
+    const res = await cal.calendars.get({ calendarId });
+    return NextResponse.json({ ok: true, summary: res.data.summary ?? calendarId });
+  } catch (e) {
+    return NextResponse.json({ ok: false, error: googleErrorCode(e) });
+  }
 });

--- a/app/api/admin/settings/route.ts
+++ b/app/api/admin/settings/route.ts
@@ -5,7 +5,9 @@ import { json, readBody, requireAdmin, requireAdminOrOwner } from "@/lib/api";
 import { getSetting, setSetting } from "@/lib/queries/settings";
 
 const settingsSchema = z.object({
-  coop_bank_account: z.string().max(200),
+  coop_bank_account: z.string().max(200).optional(),
+  google_calendar_id: z.string().max(200).optional(),
+  google_oauth_refresh_token: z.string().max(500).optional(),
 });
 
 export const GET = json(async (req) => {
@@ -13,12 +15,20 @@ export const GET = json(async (req) => {
   const db = getDb();
   return NextResponse.json({
     coop_bank_account: getSetting(db, "coop_bank_account"),
+    google_calendar_id: getSetting(db, "google_calendar_id"),
+    google_oauth_refresh_token: getSetting(db, "google_oauth_refresh_token"),
   });
 });
 
 export const PUT = json(async (req) => {
   await requireAdmin(req);
-  const { coop_bank_account } = await readBody(req, settingsSchema);
-  setSetting(getDb(), "coop_bank_account", coop_bank_account);
+  const data = await readBody(req, settingsSchema);
+  const db = getDb();
+  if (data.coop_bank_account !== undefined)
+    setSetting(db, "coop_bank_account", data.coop_bank_account);
+  if (data.google_calendar_id !== undefined)
+    setSetting(db, "google_calendar_id", data.google_calendar_id);
+  if (data.google_oauth_refresh_token !== undefined)
+    setSetting(db, "google_oauth_refresh_token", data.google_oauth_refresh_token);
   return NextResponse.json({ ok: true });
 });

--- a/app/api/admin/settings/route.ts
+++ b/app/api/admin/settings/route.ts
@@ -1,13 +1,14 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { getDb } from "@/lib/db";
+import { env } from "@/lib/env";
 import { json, readBody, requireAdmin, requireAdminOrOwner } from "@/lib/api";
 import { getSetting, setSetting } from "@/lib/queries/settings";
 
 const settingsSchema = z.object({
   coop_bank_account: z.string().max(200).optional(),
   google_calendar_id: z.string().max(200).optional(),
-  google_oauth_refresh_token: z.string().max(500).optional(),
+  google_oauth_refresh_token: z.string().max(2000).optional(),
 });
 
 export const GET = json(async (req) => {
@@ -17,6 +18,7 @@ export const GET = json(async (req) => {
     coop_bank_account: getSetting(db, "coop_bank_account"),
     google_calendar_id: getSetting(db, "google_calendar_id"),
     google_oauth_refresh_token: getSetting(db, "google_oauth_refresh_token"),
+    env_credentials_ok: !!(env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET),
   });
 });
 

--- a/app/api/calendar-webhook/route.ts
+++ b/app/api/calendar-webhook/route.ts
@@ -32,8 +32,12 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   } catch (e: unknown) {
     const code = (e as { code?: number })?.code;
     if (code === 410) {
-      // syncToken invalidated — full re-sync
-      ({ items, nextSyncToken } = await listEventsDelta(client, calendarId));
+      try {
+        ({ items, nextSyncToken } = await listEventsDelta(client, calendarId));
+      } catch (e2) {
+        console.error("[calendar-webhook] full re-sync also failed", e2);
+        return NextResponse.json({ ok: true });
+      }
     } else {
       console.error("[calendar-webhook] listEventsDelta failed", e);
       return NextResponse.json({ ok: true });

--- a/app/api/calendar-webhook/route.ts
+++ b/app/api/calendar-webhook/route.ts
@@ -1,0 +1,52 @@
+// app/api/calendar-webhook/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import { getSetting } from "@/lib/queries/settings";
+import { getOAuthClient, listEventsDelta } from "@/lib/google-calendar";
+import { processCalendarDelta } from "@/lib/process-calendar-delta";
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  // Initial handshake from Google
+  const resourceState = req.headers.get("x-goog-resource-state");
+  if (resourceState === "sync") return NextResponse.json({ ok: true });
+
+  const db = getDb();
+  const calendarId = getSetting(db, "google_calendar_id");
+  const refreshToken = getSetting(db, "google_oauth_refresh_token");
+  if (!calendarId || !refreshToken) return NextResponse.json({ ok: true });
+
+  const client = getOAuthClient(refreshToken);
+  const stateRow = db.prepare("SELECT sync_token FROM calendar_sync_state WHERE id = 1").get() as
+    | { sync_token: string }
+    | undefined;
+
+  let items: Awaited<ReturnType<typeof listEventsDelta>>["items"];
+  let nextSyncToken: string;
+
+  try {
+    ({ items, nextSyncToken } = await listEventsDelta(
+      client,
+      calendarId,
+      stateRow?.sync_token || undefined
+    ));
+  } catch (e: unknown) {
+    const code = (e as { code?: number })?.code;
+    if (code === 410) {
+      // syncToken invalidated — full re-sync
+      ({ items, nextSyncToken } = await listEventsDelta(client, calendarId));
+    } else {
+      console.error("[calendar-webhook] listEventsDelta failed", e);
+      return NextResponse.json({ ok: true });
+    }
+  }
+
+  // Upsert sync_token (INSERT sets defaults for other columns if row doesn't exist yet)
+  db.prepare(
+    `INSERT INTO calendar_sync_state (id, sync_token) VALUES (1, ?)
+     ON CONFLICT(id) DO UPDATE SET sync_token = excluded.sync_token`
+  ).run(nextSyncToken);
+
+  await processCalendarDelta(db, client, calendarId, items);
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/calendar-webhook/route.ts
+++ b/app/api/calendar-webhook/route.ts
@@ -16,9 +16,15 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   if (!calendarId || !refreshToken) return NextResponse.json({ ok: true });
 
   const client = getOAuthClient(refreshToken);
-  const stateRow = db.prepare("SELECT sync_token FROM calendar_sync_state WHERE id = 1").get() as
-    | { sync_token: string }
-    | undefined;
+  const stateRow = db
+    .prepare("SELECT sync_token, channel_id FROM calendar_sync_state WHERE id = 1")
+    .get() as { sync_token: string; channel_id: string } | undefined;
+
+  // Validate channel ID to reject spoofed webhook calls
+  const incomingChannelId = req.headers.get("x-goog-channel-id");
+  if (stateRow && incomingChannelId !== stateRow.channel_id) {
+    return NextResponse.json({ ok: true });
+  }
 
   let items: Awaited<ReturnType<typeof listEventsDelta>>["items"];
   let nextSyncToken: string;
@@ -44,13 +50,13 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     }
   }
 
-  // Upsert sync_token (INSERT sets defaults for other columns if row doesn't exist yet)
+  await processCalendarDelta(db, client, calendarId, items);
+
+  // Upsert sync_token after processing so a crash mid-processing triggers a retry
   db.prepare(
     `INSERT INTO calendar_sync_state (id, sync_token) VALUES (1, ?)
      ON CONFLICT(id) DO UPDATE SET sync_token = excluded.sync_token`
   ).run(nextSyncToken);
-
-  await processCalendarDelta(db, client, calendarId, items);
 
   return NextResponse.json({ ok: true });
 }

--- a/app/api/cars/[id]/route.ts
+++ b/app/api/cars/[id]/route.ts
@@ -1,7 +1,15 @@
 import { getCarById, updateCar, deleteCar, carHasHistory } from "@/lib/queries/cars";
 import { carSchema, ownerCarPatchSchema } from "@/lib/schemas/car";
 import { getDb } from "@/lib/db";
-import { json, readBody, readId, notFound, forbidden, conflict, requireAdminOrOwner } from "@/lib/api";
+import {
+  json,
+  readBody,
+  readId,
+  notFound,
+  forbidden,
+  conflict,
+  requireAdminOrOwner,
+} from "@/lib/api";
 
 export const GET = json(async (_req, ctx) => {
   const car = getCarById(getDb(), await readId(ctx));
@@ -25,6 +33,7 @@ export const PUT = json(async (req, ctx) => {
       brand: current.brand,
       color: current.color,
       owner_name: current.owner_name,
+      owner_person_id: current.owner_person_id,
       long_threshold: current.long_threshold,
       active: patch.active ?? current.active,
       expected_km: current.expected_km,

--- a/app/api/people/[id]/profile/route.ts
+++ b/app/api/people/[id]/profile/route.ts
@@ -9,6 +9,12 @@ import { z } from "zod";
 const profileSchema = z.object({
   name: z.string().min(1),
   bank_account: z.string().default(""),
+  email: z
+    .string()
+    .email()
+    .nullable()
+    .optional()
+    .transform((v) => v ?? null),
 });
 
 export const PATCH = json(async (req, ctx) => {
@@ -20,6 +26,6 @@ export const PATCH = json(async (req, ctx) => {
   const data = await readBody(req, profileSchema);
   const existing = getPersonById(getDb(), id);
   if (!existing) notFound();
-  updatePerson(getDb(), id, { ...existing, ...data });
+  updatePerson(getDb(), id, { ...existing, ...data, email: data.email ?? null });
   return { ok: true };
 });

--- a/app/api/reservations/[id]/route.ts
+++ b/app/api/reservations/[id]/route.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/queries/reservations";
 import { json, readBody, readId, notFound } from "@/lib/api";
 import { reservationSchema } from "@/lib/schemas/reservation";
+import { syncReservationUpdate, syncReservationDelete } from "@/lib/reservation-sync";
 
 export const GET = json(async (_req, ctx) => {
   const id = await readId(ctx);
@@ -20,8 +21,10 @@ export const PUT = json(async (req, ctx) => {
   const id = await readId(ctx);
   const body = await readBody(req, reservationSchema);
   const expectedUpdatedAt = req.headers.get("X-Expected-Updated-At") ?? undefined;
+  const db = getDb();
   try {
-    updateReservation(getDb(), id, body, { expectedUpdatedAt });
+    updateReservation(db, id, body, { expectedUpdatedAt });
+    syncReservationUpdate(db, id).catch(() => {});
     return NextResponse.json({ ok: true });
   } catch (e) {
     if (e instanceof ConflictError) {
@@ -33,6 +36,8 @@ export const PUT = json(async (req, ctx) => {
 
 export const DELETE = json(async (_req, ctx) => {
   const id = await readId(ctx);
-  const result = getDb().prepare("DELETE FROM reservations WHERE id = ?").run(id);
+  const db = getDb();
+  await syncReservationDelete(db, id).catch(() => {});
+  const result = db.prepare("DELETE FROM reservations WHERE id = ?").run(id);
   return NextResponse.json({ deleted: result.changes > 0 });
 });

--- a/app/api/reservations/[id]/route.ts
+++ b/app/api/reservations/[id]/route.ts
@@ -38,6 +38,6 @@ export const DELETE = json(async (_req, ctx) => {
   const id = await readId(ctx);
   const db = getDb();
   await syncReservationDelete(db, id).catch(() => {});
-  const result = db.prepare("DELETE FROM reservations WHERE id = ?").run(id);
-  return NextResponse.json({ deleted: result.changes > 0 });
+  deleteReservation(db, id);
+  return NextResponse.json({ deleted: true });
 });

--- a/app/api/reservations/[id]/status/route.ts
+++ b/app/api/reservations/[id]/status/route.ts
@@ -2,10 +2,13 @@ import { getDb } from "@/lib/db";
 import { updateReservationStatus } from "@/lib/queries/reservations";
 import { json, readBody, readId } from "@/lib/api";
 import { reservationStatusSchema } from "@/lib/schemas/reservation";
+import { syncReservationUpdate } from "@/lib/reservation-sync";
 
 export const PATCH = json(async (req, ctx) => {
   const id = await readId(ctx);
   const body = await readBody(req, reservationStatusSchema);
-  updateReservationStatus(getDb(), id, body.status);
+  const db = getDb();
+  updateReservationStatus(db, id, body.status);
+  syncReservationUpdate(db, id).catch(() => {});
   return { ok: true };
 });

--- a/app/api/reservations/route.ts
+++ b/app/api/reservations/route.ts
@@ -3,6 +3,7 @@ import { getDb } from "@/lib/db";
 import { getReservations, insertReservation } from "@/lib/queries/reservations";
 import { json, readBody } from "@/lib/api";
 import { reservationSchema } from "@/lib/schemas/reservation";
+import { syncReservationCreate } from "@/lib/reservation-sync";
 
 export const GET = json(async () => getReservations(getDb()));
 
@@ -10,6 +11,8 @@ export const POST = json(async (req) => {
   const raw = await req.json();
   const body = reservationSchema.parse(raw);
   const client_id = typeof raw.client_id === "string" ? raw.client_id : null;
-  const id = insertReservation(getDb(), { ...body, client_id });
+  const db = getDb();
+  const id = insertReservation(db, { ...body, client_id });
+  syncReservationCreate(db, id).catch(() => {});
   return NextResponse.json({ id }, { status: 201 });
 });

--- a/app/api/reservations/route.ts
+++ b/app/api/reservations/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
-import { getReservations, insertReservation } from "@/lib/queries/reservations";
+import { getReservations, getReservationById, insertReservation } from "@/lib/queries/reservations";
 import { json, readBody } from "@/lib/api";
 import { reservationSchema } from "@/lib/schemas/reservation";
 import { syncReservationCreate } from "@/lib/reservation-sync";
@@ -14,5 +14,6 @@ export const POST = json(async (req) => {
   const db = getDb();
   const id = insertReservation(db, { ...body, client_id });
   syncReservationCreate(db, id).catch(() => {});
-  return NextResponse.json({ id }, { status: 201 });
+  const reservation = getReservationById(db, id);
+  return NextResponse.json(reservation, { status: 201 });
 });

--- a/app/user/[id]/edit/page.tsx
+++ b/app/user/[id]/edit/page.tsx
@@ -17,6 +17,7 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
   const [loading, setLoading] = useState(true);
   const [name, setName] = useState("");
   const [bankAccount, setBankAccount] = useState("");
+  const [email, setEmail] = useState("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
@@ -39,6 +40,7 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
         setPerson(p);
         setName(p.name);
         setBankAccount(p.bank_account ?? "");
+        setEmail(p.email ?? "");
         setLoading(false);
       })
       .catch(() => setLoading(false));
@@ -65,7 +67,10 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
     );
   }
 
-  const dirty = name !== person.name || bankAccount !== (person.bank_account ?? "");
+  const dirty =
+    name !== person.name ||
+    bankAccount !== (person.bank_account ?? "") ||
+    email !== (person.email ?? "");
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -75,7 +80,7 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
       await apiFetch(`/api/people/${id}/profile`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name, bank_account: bankAccount }),
+        body: JSON.stringify({ name, bank_account: bankAccount, email: email || null }),
       });
       setSaved(true);
       setTimeout(() => router.push("/"), 800);
@@ -91,163 +96,198 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
       <PageHeader title={t("page.profile_edit")} />
 
       <div style={{ padding: 16 }}>
-      <div
-        style={{
-          background: paper.paper,
-          boxShadow: "0 1px 4px rgba(0,0,0,0.07)",
-          padding: "14px 16px",
-        }}
-      >
         <div
           style={{
-            fontFamily: fontSerif,
-            fontSize: 14,
-            fontWeight: 700,
-            color: paper.ink,
-            marginBottom: 16,
+            background: paper.paper,
+            boxShadow: "0 1px 4px rgba(0,0,0,0.07)",
+            padding: "14px 16px",
           }}
         >
-          {person.name}
-        </div>
-
-        <form onSubmit={handleSubmit}>
-          <div style={{ marginBottom: 12 }}>
-            <label
-              htmlFor="edit-username"
-              style={{
-                display: "block",
-                fontFamily: fontMono,
-                fontSize: 9,
-                color: paper.inkMute,
-                letterSpacing: 1,
-                marginBottom: 4,
-              }}
-            >
-              {t("form.username")}
-            </label>
-            <input
-              id="edit-username"
-              type="text"
-              value={person.username ?? ""}
-              readOnly
-              style={{
-                width: "100%",
-                padding: "8px 10px",
-                fontFamily: fontMono,
-                fontSize: 12,
-                background: paper.paperDeep,
-                color: paper.inkMute,
-                border: `1.5px solid ${paper.paperDeep}`,
-                outline: "none",
-                boxSizing: "border-box",
-                cursor: "default",
-              }}
-            />
-          </div>
-
-          <div style={{ marginBottom: 12 }}>
-            <label
-              htmlFor="edit-name"
-              style={{
-                display: "block",
-                fontFamily: fontMono,
-                fontSize: 9,
-                color: paper.inkMute,
-                letterSpacing: 1,
-                marginBottom: 4,
-              }}
-            >
-              {t("form.full_name")}
-            </label>
-            <input
-              id="edit-name"
-              type="text"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              required
-              style={{
-                width: "100%",
-                padding: "8px 10px",
-                fontFamily: fontMono,
-                fontSize: 12,
-                background: paper.paperDark,
-                color: paper.ink,
-                border: `1.5px solid ${name !== person.name ? paper.ink : paper.paperDark}`,
-                outline: "none",
-                boxSizing: "border-box",
-              }}
-            />
-          </div>
-
-          <div style={{ marginBottom: 16 }}>
-            <label
-              htmlFor="edit-bank"
-              style={{
-                display: "block",
-                fontFamily: fontMono,
-                fontSize: 9,
-                color: paper.inkMute,
-                letterSpacing: 1,
-                marginBottom: 4,
-              }}
-            >
-              {t("form.bank_account")}
-            </label>
-            <input
-              id="edit-bank"
-              type="text"
-              value={bankAccount}
-              onChange={(e) => setBankAccount(e.target.value)}
-              placeholder="BE00 0000 0000 0000"
-              style={{
-                width: "100%",
-                padding: "8px 10px",
-                fontFamily: fontMono,
-                fontSize: 12,
-                background: paper.paperDark,
-                color: paper.ink,
-                border: `1.5px solid ${bankAccount !== (person.bank_account ?? "") ? paper.ink : paper.paperDark}`,
-                outline: "none",
-                boxSizing: "border-box",
-                letterSpacing: 1,
-              }}
-            />
-          </div>
-
-          {error && (
-            <div
-              style={{
-                fontFamily: fontMono,
-                fontSize: 10,
-                color: paper.accent,
-                marginBottom: 10,
-              }}
-            >
-              {error}
-            </div>
-          )}
-
-          <button
-            type="submit"
-            disabled={!dirty || saving}
+          <div
             style={{
-              width: "100%",
-              padding: "8px",
-              fontFamily: fontMono,
-              fontSize: 9,
+              fontFamily: fontSerif,
+              fontSize: 14,
               fontWeight: 700,
-              letterSpacing: 2,
-              textTransform: "uppercase",
-              background: saved ? paper.green : dirty ? paper.ink : paper.paperDark,
-              color: dirty || saved ? paper.paper : paper.inkMute,
-              border: "none",
-              cursor: dirty && !saving ? "pointer" : "default",
+              color: paper.ink,
+              marginBottom: 16,
             }}
           >
-            {saved ? t("action.saved") : saving ? t("action.saving") : t("action.save")}
-          </button>
-        </form>
-      </div>
+            {person.name}
+          </div>
+
+          <form onSubmit={handleSubmit}>
+            <div style={{ marginBottom: 12 }}>
+              <label
+                htmlFor="edit-username"
+                style={{
+                  display: "block",
+                  fontFamily: fontMono,
+                  fontSize: 9,
+                  color: paper.inkMute,
+                  letterSpacing: 1,
+                  marginBottom: 4,
+                }}
+              >
+                {t("form.username")}
+              </label>
+              <input
+                id="edit-username"
+                type="text"
+                value={person.username ?? ""}
+                readOnly
+                style={{
+                  width: "100%",
+                  padding: "8px 10px",
+                  fontFamily: fontMono,
+                  fontSize: 12,
+                  background: paper.paperDeep,
+                  color: paper.inkMute,
+                  border: `1.5px solid ${paper.paperDeep}`,
+                  outline: "none",
+                  boxSizing: "border-box",
+                  cursor: "default",
+                }}
+              />
+            </div>
+
+            <div style={{ marginBottom: 12 }}>
+              <label
+                htmlFor="edit-name"
+                style={{
+                  display: "block",
+                  fontFamily: fontMono,
+                  fontSize: 9,
+                  color: paper.inkMute,
+                  letterSpacing: 1,
+                  marginBottom: 4,
+                }}
+              >
+                {t("form.full_name")}
+              </label>
+              <input
+                id="edit-name"
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                required
+                style={{
+                  width: "100%",
+                  padding: "8px 10px",
+                  fontFamily: fontMono,
+                  fontSize: 12,
+                  background: paper.paperDark,
+                  color: paper.ink,
+                  border: `1.5px solid ${name !== person.name ? paper.ink : paper.paperDark}`,
+                  outline: "none",
+                  boxSizing: "border-box",
+                }}
+              />
+            </div>
+
+            <div style={{ marginBottom: 12 }}>
+              <label
+                htmlFor="edit-bank"
+                style={{
+                  display: "block",
+                  fontFamily: fontMono,
+                  fontSize: 9,
+                  color: paper.inkMute,
+                  letterSpacing: 1,
+                  marginBottom: 4,
+                }}
+              >
+                {t("form.bank_account")}
+              </label>
+              <input
+                id="edit-bank"
+                type="text"
+                value={bankAccount}
+                onChange={(e) => setBankAccount(e.target.value)}
+                placeholder="BE00 0000 0000 0000"
+                style={{
+                  width: "100%",
+                  padding: "8px 10px",
+                  fontFamily: fontMono,
+                  fontSize: 12,
+                  background: paper.paperDark,
+                  color: paper.ink,
+                  border: `1.5px solid ${bankAccount !== (person.bank_account ?? "") ? paper.ink : paper.paperDark}`,
+                  outline: "none",
+                  boxSizing: "border-box",
+                  letterSpacing: 1,
+                }}
+              />
+            </div>
+
+            <div style={{ marginBottom: 16 }}>
+              <label
+                htmlFor="edit-email"
+                style={{
+                  display: "block",
+                  fontFamily: fontMono,
+                  fontSize: 9,
+                  color: paper.inkMute,
+                  letterSpacing: 1,
+                  marginBottom: 4,
+                }}
+              >
+                {t("form.email")}
+              </label>
+              <input
+                id="edit-email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="naam@voorbeeld.be"
+                style={{
+                  width: "100%",
+                  padding: "8px 10px",
+                  fontFamily: fontMono,
+                  fontSize: 12,
+                  background: paper.paperDark,
+                  color: paper.ink,
+                  border: `1.5px solid ${email !== (person.email ?? "") ? paper.ink : paper.paperDark}`,
+                  outline: "none",
+                  boxSizing: "border-box",
+                  letterSpacing: 1,
+                }}
+              />
+            </div>
+
+            {error && (
+              <div
+                style={{
+                  fontFamily: fontMono,
+                  fontSize: 10,
+                  color: paper.accent,
+                  marginBottom: 10,
+                }}
+              >
+                {error}
+              </div>
+            )}
+
+            <button
+              type="submit"
+              disabled={!dirty || saving}
+              style={{
+                width: "100%",
+                padding: "8px",
+                fontFamily: fontMono,
+                fontSize: 9,
+                fontWeight: 700,
+                letterSpacing: 2,
+                textTransform: "uppercase",
+                background: saved ? paper.green : dirty ? paper.ink : paper.paperDark,
+                color: dirty || saved ? paper.paper : paper.inkMute,
+                border: "none",
+                cursor: dirty && !saving ? "pointer" : "default",
+              }}
+            >
+              {saved ? t("action.saved") : saving ? t("action.saving") : t("action.save")}
+            </button>
+          </form>
+        </div>
       </div>
     </div>
   );

--- a/hooks/use-admin-settings.ts
+++ b/hooks/use-admin-settings.ts
@@ -3,6 +3,8 @@ import { apiFetch } from "@/lib/api/client";
 
 interface AdminSettings {
   coop_bank_account: string;
+  google_calendar_id: string;
+  google_oauth_refresh_token: string;
 }
 
 export function useAdminSettings() {
@@ -15,7 +17,7 @@ export function useAdminSettings() {
 export function useSaveAdminSettings() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (data: AdminSettings) =>
+    mutationFn: (data: Partial<AdminSettings>) =>
       apiFetch("/api/admin/settings", { method: "PUT", body: JSON.stringify(data) }),
     onSuccess: () => qc.invalidateQueries({ queryKey: ["admin-settings"] }),
   });

--- a/hooks/use-admin-settings.ts
+++ b/hooks/use-admin-settings.ts
@@ -5,6 +5,7 @@ interface AdminSettings {
   coop_bank_account: string;
   google_calendar_id: string;
   google_oauth_refresh_token: string;
+  env_credentials_ok: boolean;
 }
 
 export function useAdminSettings() {

--- a/lib/__tests__/calendar_renew.test.ts
+++ b/lib/__tests__/calendar_renew.test.ts
@@ -83,5 +83,24 @@ describe("handleCalendarRenew", () => {
     expect(calMock.stopChannel).not.toHaveBeenCalled();
     expect(calMock.watchEvents).toHaveBeenCalledOnce();
     expect(result).toMatchObject({ ok: true, renewed: true });
+    const row = db
+      .prepare("SELECT channel_id, sync_token FROM calendar_sync_state WHERE id = 1")
+      .get() as { channel_id: string; sync_token: string };
+    expect(row.channel_id).toBe("new-ch");
+    expect(row.sync_token).toBe("new-tok");
+  });
+
+  it("throws when listEventsDelta fails with non-410 error", async () => {
+    const db = makeDb();
+    setSetting(db, "google_calendar_id", "cal-id");
+    setSetting(db, "google_oauth_refresh_token", "rt");
+    vi.mocked(calMock.listEventsDelta).mockRejectedValueOnce(
+      Object.assign(new Error("network error"), { code: 500 })
+    );
+
+    await expect(handleCalendarRenew(db, "https://example.com")).rejects.toThrow("network error");
+
+    const row = db.prepare("SELECT channel_id FROM calendar_sync_state WHERE id = 1").get();
+    expect(row).toBeUndefined();
   });
 });

--- a/lib/__tests__/calendar_renew.test.ts
+++ b/lib/__tests__/calendar_renew.test.ts
@@ -1,0 +1,87 @@
+// lib/__tests__/calendar_renew.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../db/migrate";
+import { setSetting } from "../queries/settings";
+import { handleCalendarRenew } from "../calendar-renew";
+
+vi.mock("../google-calendar", () => ({
+  getOAuthClient: vi.fn(() => ({})),
+  stopChannel: vi.fn().mockResolvedValue(undefined),
+  watchEvents: vi.fn().mockResolvedValue({
+    channelId: "new-ch",
+    resourceId: "new-res",
+    expiration: "2026-05-16T04:00:00.000Z",
+  }),
+  listEventsDelta: vi.fn().mockResolvedValue({ items: [], nextSyncToken: "new-tok" }),
+}));
+
+import * as calMock from "../google-calendar";
+
+function makeDb() {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  runMigrations(db);
+  return db;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("handleCalendarRenew", () => {
+  it("returns skipped:disabled when settings are empty", async () => {
+    const db = makeDb();
+    const result = await handleCalendarRenew(db, "https://example.com");
+    expect(result).toEqual({ ok: true, skipped: "disabled" });
+    expect(calMock.watchEvents).not.toHaveBeenCalled();
+  });
+
+  it("returns skipped:not_due when channel expires in >5 days", async () => {
+    const db = makeDb();
+    setSetting(db, "google_calendar_id", "cal-id");
+    setSetting(db, "google_oauth_refresh_token", "rt");
+    const future = new Date(Date.now() + 6 * 24 * 60 * 60 * 1000).toISOString();
+    db.prepare(
+      "INSERT INTO calendar_sync_state (id, channel_id, resource_id, expiration_at, sync_token) VALUES (1, 'ch', 'res', ?, 'tok')"
+    ).run(future);
+
+    const result = await handleCalendarRenew(db, "https://example.com");
+    expect(result).toEqual({ ok: true, skipped: "not_due" });
+    expect(calMock.watchEvents).not.toHaveBeenCalled();
+  });
+
+  it("renews channel when it expires in <5 days", async () => {
+    const db = makeDb();
+    setSetting(db, "google_calendar_id", "cal-id");
+    setSetting(db, "google_oauth_refresh_token", "rt");
+    const soon = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString();
+    db.prepare(
+      "INSERT INTO calendar_sync_state (id, channel_id, resource_id, expiration_at, sync_token) VALUES (1, 'old-ch', 'old-res', ?, 'old-tok')"
+    ).run(soon);
+
+    const result = await handleCalendarRenew(db, "https://example.com");
+
+    expect(calMock.stopChannel).toHaveBeenCalledWith(expect.anything(), "old-ch", "old-res");
+    expect(calMock.watchEvents).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({ ok: true, renewed: true });
+
+    const row = db
+      .prepare("SELECT channel_id, sync_token FROM calendar_sync_state WHERE id = 1")
+      .get() as { channel_id: string; sync_token: string };
+    expect(row.channel_id).toBe("new-ch");
+    expect(row.sync_token).toBe("new-tok");
+  });
+
+  it("does initial setup when no state row exists", async () => {
+    const db = makeDb();
+    setSetting(db, "google_calendar_id", "cal-id");
+    setSetting(db, "google_oauth_refresh_token", "rt");
+
+    const result = await handleCalendarRenew(db, "https://example.com");
+
+    expect(calMock.stopChannel).not.toHaveBeenCalled();
+    expect(calMock.watchEvents).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({ ok: true, renewed: true });
+  });
+});

--- a/lib/__tests__/db.test.ts
+++ b/lib/__tests__/db.test.ts
@@ -3,7 +3,7 @@ import Database from "better-sqlite3";
 import { runMigrations } from "../db/migrate";
 
 describe("runMigrations", () => {
-  it("creates all 12 tables", () => {
+  it("creates all 13 tables", () => {
     const db = new Database(":memory:");
     runMigrations(db);
     const tables = db

--- a/lib/__tests__/db.test.ts
+++ b/lib/__tests__/db.test.ts
@@ -3,7 +3,7 @@ import Database from "better-sqlite3";
 import { runMigrations } from "../db/migrate";
 
 describe("runMigrations", () => {
-  it("creates all 11 tables", () => {
+  it("creates all 12 tables", () => {
     const db = new Database(":memory:");
     runMigrations(db);
     const tables = db
@@ -14,6 +14,7 @@ describe("runMigrations", () => {
       .map((r: any) => r.name);
     expect(tables).toEqual([
       "_migrations",
+      "calendar_sync_state",
       "car_price_history",
       "cars",
       "expenses",

--- a/lib/__tests__/google_calendar.test.ts
+++ b/lib/__tests__/google_calendar.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { addDays } from "../google-calendar";
+
+describe("addDays", () => {
+  it("adds 1 day to a date string", () => {
+    expect(addDays("2026-06-10", 1)).toBe("2026-06-11");
+  });
+
+  it("handles month boundary", () => {
+    expect(addDays("2026-06-30", 1)).toBe("2026-07-01");
+  });
+
+  it("handles year boundary", () => {
+    expect(addDays("2026-12-31", 1)).toBe("2027-01-01");
+  });
+
+  it("handles leap year", () => {
+    expect(addDays("2024-02-28", 1)).toBe("2024-02-29");
+  });
+});

--- a/lib/__tests__/migration_0004.test.ts
+++ b/lib/__tests__/migration_0004.test.ts
@@ -31,6 +31,10 @@ describe("migration 0004 — car owner era", () => {
       INSERT INTO _migrations (filename) VALUES ('0008_drop_fixed_costs_json.sql');
       INSERT INTO _migrations (filename) VALUES ('0009_updated_at_admin_tables.sql');
       INSERT INTO _migrations (filename) VALUES ('0010_people_bank_account.sql');
+      INSERT INTO _migrations (filename) VALUES ('0011_people_email.sql');
+      INSERT INTO _migrations (filename) VALUES ('0012_cars_owner_person_id.sql');
+      INSERT INTO _migrations (filename) VALUES ('0013_reservation_calendar_columns.sql');
+      INSERT INTO _migrations (filename) VALUES ('0014_calendar_sync_state.sql');
     `);
     runMigrations(db2);
     const car = db2.prepare("SELECT owner_from FROM cars WHERE short = 'XX'").get() as {

--- a/lib/__tests__/migration_0011_to_0014.test.ts
+++ b/lib/__tests__/migration_0011_to_0014.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../db/migrate";
+
+function makeDb() {
+  const db = new Database(":memory:");
+  runMigrations(db);
+  return db;
+}
+
+describe("migration 0011 — people email", () => {
+  it("adds email column to people", () => {
+    const db = makeDb();
+    const cols = db.prepare("PRAGMA table_info(people)").all() as { name: string }[];
+    expect(cols.map((c) => c.name)).toContain("email");
+  });
+
+  it("email is nullable", () => {
+    const db = makeDb();
+    db.prepare("INSERT INTO people (name, active) VALUES (?, 1)").run("Alice");
+    const row = db.prepare("SELECT email FROM people WHERE name = 'Alice'").get() as {
+      email: string | null;
+    };
+    expect(row.email).toBeNull();
+  });
+});
+
+describe("migration 0012 — cars owner_person_id", () => {
+  it("adds owner_person_id column to cars", () => {
+    const db = makeDb();
+    const cols = db.prepare("PRAGMA table_info(cars)").all() as { name: string }[];
+    expect(cols.map((c) => c.name)).toContain("owner_person_id");
+  });
+});
+
+describe("migration 0013 — reservation calendar columns", () => {
+  it("adds 4 calendar columns to reservations", () => {
+    const db = makeDb();
+    const cols = db.prepare("PRAGMA table_info(reservations)").all() as { name: string }[];
+    const names = cols.map((c) => c.name);
+    expect(names).toContain("google_event_id");
+    expect(names).toContain("last_synced_etag");
+    expect(names).toContain("last_app_write_nonce");
+    expect(names).toContain("last_known_response_status");
+  });
+});
+
+describe("migration 0014 — calendar_sync_state table", () => {
+  it("creates calendar_sync_state table", () => {
+    const db = makeDb();
+    const tables = db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as {
+      name: string;
+    }[];
+    expect(tables.map((t) => t.name)).toContain("calendar_sync_state");
+  });
+
+  it("id = 1 check constraint enforces singleton", () => {
+    const db = makeDb();
+    db.prepare(
+      "INSERT INTO calendar_sync_state (id, channel_id, resource_id, expiration_at, sync_token) VALUES (1, 'c', 'r', '2026-01-01', 't')"
+    ).run();
+    expect(() =>
+      db
+        .prepare(
+          "INSERT INTO calendar_sync_state (id, channel_id, resource_id, expiration_at, sync_token) VALUES (2, 'c', 'r', '2026-01-01', 't')"
+        )
+        .run()
+    ).toThrow();
+  });
+});

--- a/lib/__tests__/process_calendar_delta.test.ts
+++ b/lib/__tests__/process_calendar_delta.test.ts
@@ -105,6 +105,13 @@ describe("processCalendarDelta", () => {
     ];
     await processCalendarDelta(db, fakeClient, calendarId, events);
     expect(calMock.updateEvent).toHaveBeenCalledOnce();
+    const row = db
+      .prepare(
+        "SELECT last_synced_etag, last_app_write_nonce FROM reservations WHERE google_event_id = 'evt-123'"
+      )
+      .get() as { last_synced_etag: string; last_app_write_nonce: string };
+    expect(row.last_synced_etag).toBe('"new-etag"');
+    expect(row.last_app_write_nonce).toBeTruthy();
   });
 
   it("updates reservation to confirmed when owner accepts", async () => {

--- a/lib/__tests__/process_calendar_delta.test.ts
+++ b/lib/__tests__/process_calendar_delta.test.ts
@@ -77,13 +77,13 @@ describe("processCalendarDelta", () => {
     expect(calMock.updateEvent).not.toHaveBeenCalled();
   });
 
-  it("skips event if appWriteNonce matches last_app_write_nonce (echo)", async () => {
+  it("skips event if appWriteNonce matches last_app_write_nonce when etag absent (echo fallback)", async () => {
     const db = makeDb();
     seedWithEvent(db);
     const events: CalendarEvent[] = [
       {
         id: "evt-123",
-        etag: '"different-etag"',
+        etag: null, // no etag — nonce is the only echo guard
         extendedProperties: { private: { appWriteNonce: "nonce-abc" } },
       },
     ];

--- a/lib/__tests__/process_calendar_delta.test.ts
+++ b/lib/__tests__/process_calendar_delta.test.ts
@@ -1,0 +1,172 @@
+// lib/__tests__/process_calendar_delta.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../db/migrate";
+import { setSetting } from "../queries/settings";
+import { processCalendarDelta } from "../process-calendar-delta";
+import type { CalendarEvent } from "../google-calendar";
+
+vi.mock("../google-calendar", () => ({
+  getOAuthClient: vi.fn(() => ({})),
+  updateEvent: vi.fn().mockResolvedValue({ etag: '"new-etag"' }),
+  addDays: (d: string, n: number) => {
+    const dt = new Date(d + "T00:00:00Z");
+    dt.setUTCDate(dt.getUTCDate() + n);
+    return dt.toISOString().slice(0, 10);
+  },
+}));
+
+import * as calMock from "../google-calendar";
+
+function makeDb() {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  runMigrations(db);
+  return db;
+}
+
+function seedWithEvent(db: Database.Database, overrides: Record<string, unknown> = {}) {
+  db.prepare(
+    "INSERT INTO people (id, name, active, email) VALUES (1, 'Alice', 1, null), (2, 'Owner Bob', 1, 'bob@example.com') ON CONFLICT DO NOTHING"
+  ).run();
+  db.prepare(
+    "INSERT INTO cars (id, short, name, price_per_km, owner_person_id, active) VALUES (1, 'CA', 'Car A', 0.2, 2, 1) ON CONFLICT DO NOTHING"
+  ).run();
+  const defaults = {
+    google_event_id: "evt-123",
+    last_synced_etag: '"old-etag"',
+    last_app_write_nonce: "nonce-abc",
+    last_known_response_status: "needsAction",
+    status: "pending",
+  };
+  const merged = { ...defaults, ...overrides };
+  db.prepare(
+    `INSERT INTO reservations (person_id, car_id, start_date, end_date, status, updated_at,
+      google_event_id, last_synced_etag, last_app_write_nonce, last_known_response_status)
+     VALUES (1, 1, '2026-06-01', '2026-06-03', ?, datetime('now'), ?, ?, ?, ?)`
+  ).run(
+    merged.status,
+    merged.google_event_id,
+    merged.last_synced_etag,
+    merged.last_app_write_nonce,
+    merged.last_known_response_status
+  );
+}
+
+const fakeClient = {} as any;
+const calendarId = "cal-id";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("processCalendarDelta", () => {
+  it("skips events not found in reservations", async () => {
+    const db = makeDb();
+    seedWithEvent(db);
+    const events: CalendarEvent[] = [{ id: "unknown-evt", etag: '"new"' }];
+    await processCalendarDelta(db, fakeClient, calendarId, events);
+    expect(calMock.updateEvent).not.toHaveBeenCalled();
+  });
+
+  it("skips event if etag matches last_synced_etag (echo)", async () => {
+    const db = makeDb();
+    seedWithEvent(db, { last_synced_etag: '"same-etag"' });
+    const events: CalendarEvent[] = [{ id: "evt-123", etag: '"same-etag"' }];
+    await processCalendarDelta(db, fakeClient, calendarId, events);
+    expect(calMock.updateEvent).not.toHaveBeenCalled();
+  });
+
+  it("skips event if appWriteNonce matches last_app_write_nonce (echo)", async () => {
+    const db = makeDb();
+    seedWithEvent(db);
+    const events: CalendarEvent[] = [
+      {
+        id: "evt-123",
+        etag: '"different-etag"',
+        extendedProperties: { private: { appWriteNonce: "nonce-abc" } },
+      },
+    ];
+    await processCalendarDelta(db, fakeClient, calendarId, events);
+    expect(calMock.updateEvent).not.toHaveBeenCalled();
+  });
+
+  it("overwrites calendar when time is edited (app is authoritative)", async () => {
+    const db = makeDb();
+    seedWithEvent(db);
+    const events: CalendarEvent[] = [
+      {
+        id: "evt-123",
+        etag: '"different-etag"',
+        start: { date: "2026-07-01" }, // wrong date
+        end: { date: "2026-07-04" },
+        extendedProperties: { private: { appWriteNonce: "other-nonce" } },
+      },
+    ];
+    await processCalendarDelta(db, fakeClient, calendarId, events);
+    expect(calMock.updateEvent).toHaveBeenCalledOnce();
+  });
+
+  it("updates reservation to confirmed when owner accepts", async () => {
+    const db = makeDb();
+    seedWithEvent(db);
+    const events: CalendarEvent[] = [
+      {
+        id: "evt-123",
+        etag: '"different-etag"',
+        start: { date: "2026-06-01" },
+        end: { date: "2026-06-04" }, // end_date + 1 (exclusive)
+        attendees: [{ email: "bob@example.com", responseStatus: "accepted" }],
+        extendedProperties: { private: { appWriteNonce: "other-nonce" } },
+      },
+    ];
+    await processCalendarDelta(db, fakeClient, calendarId, events);
+    const row = db
+      .prepare(
+        "SELECT status, last_known_response_status FROM reservations WHERE google_event_id = 'evt-123'"
+      )
+      .get() as { status: string; last_known_response_status: string };
+    expect(row.status).toBe("confirmed");
+    expect(row.last_known_response_status).toBe("accepted");
+  });
+
+  it("updates reservation to rejected when owner declines", async () => {
+    const db = makeDb();
+    seedWithEvent(db);
+    const events: CalendarEvent[] = [
+      {
+        id: "evt-123",
+        etag: '"different-etag"',
+        start: { date: "2026-06-01" },
+        end: { date: "2026-06-04" },
+        attendees: [{ email: "bob@example.com", responseStatus: "declined" }],
+        extendedProperties: { private: { appWriteNonce: "other-nonce" } },
+      },
+    ];
+    await processCalendarDelta(db, fakeClient, calendarId, events);
+    const row = db
+      .prepare("SELECT status FROM reservations WHERE google_event_id = 'evt-123'")
+      .get() as { status: string };
+    expect(row.status).toBe("rejected");
+  });
+
+  it("treats cancelled event (owner deleted invite) as declined", async () => {
+    const db = makeDb();
+    seedWithEvent(db);
+    const events: CalendarEvent[] = [
+      {
+        id: "evt-123",
+        etag: '"different-etag"',
+        status: "cancelled",
+        start: { date: "2026-06-01" },
+        end: { date: "2026-06-04" },
+        extendedProperties: { private: { appWriteNonce: "other-nonce" } },
+      },
+    ];
+    await processCalendarDelta(db, fakeClient, calendarId, events);
+    const row = db
+      .prepare("SELECT status FROM reservations WHERE google_event_id = 'evt-123'")
+      .get() as { status: string };
+    expect(row.status).toBe("rejected");
+  });
+});

--- a/lib/__tests__/queries_people.test.ts
+++ b/lib/__tests__/queries_people.test.ts
@@ -31,6 +31,7 @@ const basePerson = {
   password_hash: null,
   is_admin: 0 as const,
   bank_account: "",
+  email: null,
 };
 
 describe("getPeople", () => {

--- a/lib/__tests__/reservation_sync.test.ts
+++ b/lib/__tests__/reservation_sync.test.ts
@@ -1,0 +1,140 @@
+// lib/__tests__/reservation_sync.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../db/migrate";
+import { setSetting } from "../queries/settings";
+import {
+  syncReservationCreate,
+  syncReservationUpdate,
+  syncReservationDelete,
+} from "../reservation-sync";
+
+// Mock the google-calendar module
+vi.mock("../google-calendar", () => ({
+  getOAuthClient: vi.fn(() => ({})),
+  createEvent: vi.fn().mockResolvedValue({ id: "evt-123", etag: '"etag-abc"' }),
+  updateEvent: vi.fn().mockResolvedValue({ etag: '"etag-xyz"' }),
+  deleteEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+import * as calMock from "../google-calendar";
+
+function makeDb() {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  runMigrations(db);
+  return db;
+}
+
+function seedReservation(db: Database.Database): number {
+  db.prepare("INSERT INTO people (id, name, active) VALUES (1, 'Alice', 1)").run();
+  db.prepare(
+    "INSERT INTO people (id, name, active, email) VALUES (2, 'Owner Bob', 1, 'bob@example.com')"
+  ).run();
+  db.prepare(
+    "INSERT INTO cars (id, short, name, price_per_km, owner_person_id, active) VALUES (1, 'CA', 'Car A', 0.2, 2, 1)"
+  ).run();
+  const result = db
+    .prepare(
+      "INSERT INTO reservations (person_id, car_id, start_date, end_date, status, updated_at) VALUES (1, 1, '2026-06-01', '2026-06-03', 'pending', datetime('now'))"
+    )
+    .run();
+  return result.lastInsertRowid as number;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("syncReservationCreate", () => {
+  it("does nothing when calendar settings are empty", async () => {
+    const db = makeDb();
+    seedReservation(db);
+    await syncReservationCreate(db, 1);
+    expect(calMock.createEvent).not.toHaveBeenCalled();
+  });
+
+  it("calls createEvent and saves event_id + etag", async () => {
+    const db = makeDb();
+    const id = seedReservation(db);
+    setSetting(db, "google_calendar_id", "cal-id");
+    setSetting(db, "google_oauth_refresh_token", "refresh-token");
+
+    await syncReservationCreate(db, id);
+
+    expect(calMock.createEvent).toHaveBeenCalledOnce();
+    const row = db
+      .prepare(
+        "SELECT google_event_id, last_synced_etag, last_app_write_nonce FROM reservations WHERE id = ?"
+      )
+      .get(id) as {
+      google_event_id: string;
+      last_synced_etag: string;
+      last_app_write_nonce: string;
+    };
+    expect(row.google_event_id).toBe("evt-123");
+    expect(row.last_synced_etag).toBe('"etag-abc"');
+    expect(row.last_app_write_nonce).toBeTruthy();
+  });
+
+  it("passes owner email to createEvent when owner has email", async () => {
+    const db = makeDb();
+    const id = seedReservation(db);
+    setSetting(db, "google_calendar_id", "cal-id");
+    setSetting(db, "google_oauth_refresh_token", "refresh-token");
+
+    await syncReservationCreate(db, id);
+
+    const callArgs = vi.mocked(calMock.createEvent).mock.calls[0];
+    expect(callArgs[4]).toBe("bob@example.com");
+  });
+});
+
+describe("syncReservationUpdate", () => {
+  it("does nothing if reservation has no google_event_id", async () => {
+    const db = makeDb();
+    const id = seedReservation(db);
+    setSetting(db, "google_calendar_id", "cal-id");
+    setSetting(db, "google_oauth_refresh_token", "refresh-token");
+
+    await syncReservationUpdate(db, id);
+    expect(calMock.updateEvent).not.toHaveBeenCalled();
+  });
+
+  it("calls updateEvent and updates etag", async () => {
+    const db = makeDb();
+    const id = seedReservation(db);
+    setSetting(db, "google_calendar_id", "cal-id");
+    setSetting(db, "google_oauth_refresh_token", "refresh-token");
+    db.prepare("UPDATE reservations SET google_event_id='evt-123' WHERE id=?").run(id);
+
+    await syncReservationUpdate(db, id);
+
+    expect(calMock.updateEvent).toHaveBeenCalledOnce();
+    const row = db.prepare("SELECT last_synced_etag FROM reservations WHERE id = ?").get(id) as {
+      last_synced_etag: string;
+    };
+    expect(row.last_synced_etag).toBe('"etag-xyz"');
+  });
+});
+
+describe("syncReservationDelete", () => {
+  it("calls deleteEvent and clears calendar columns", async () => {
+    const db = makeDb();
+    const id = seedReservation(db);
+    setSetting(db, "google_calendar_id", "cal-id");
+    setSetting(db, "google_oauth_refresh_token", "refresh-token");
+    db.prepare(
+      "UPDATE reservations SET google_event_id='evt-123', last_synced_etag='e', last_app_write_nonce='n' WHERE id=?"
+    ).run(id);
+
+    await syncReservationDelete(db, id);
+
+    expect(calMock.deleteEvent).toHaveBeenCalledWith(expect.anything(), "cal-id", "evt-123");
+    const row = db
+      .prepare("SELECT google_event_id, last_synced_etag FROM reservations WHERE id = ?")
+      .get(id) as { google_event_id: string | null; last_synced_etag: string | null };
+    expect(row.google_event_id).toBeNull();
+    expect(row.last_synced_etag).toBeNull();
+  });
+});

--- a/lib/__tests__/reservation_sync.test.ts
+++ b/lib/__tests__/reservation_sync.test.ts
@@ -111,10 +111,11 @@ describe("syncReservationUpdate", () => {
     await syncReservationUpdate(db, id);
 
     expect(calMock.updateEvent).toHaveBeenCalledOnce();
-    const row = db.prepare("SELECT last_synced_etag FROM reservations WHERE id = ?").get(id) as {
-      last_synced_etag: string;
-    };
+    const row = db
+      .prepare("SELECT last_synced_etag, last_app_write_nonce FROM reservations WHERE id = ?")
+      .get(id) as { last_synced_etag: string; last_app_write_nonce: string };
     expect(row.last_synced_etag).toBe('"etag-xyz"');
+    expect(row.last_app_write_nonce).toBeTruthy();
   });
 });
 
@@ -125,16 +126,25 @@ describe("syncReservationDelete", () => {
     setSetting(db, "google_calendar_id", "cal-id");
     setSetting(db, "google_oauth_refresh_token", "refresh-token");
     db.prepare(
-      "UPDATE reservations SET google_event_id='evt-123', last_synced_etag='e', last_app_write_nonce='n' WHERE id=?"
+      "UPDATE reservations SET google_event_id='evt-123', last_synced_etag='e', last_app_write_nonce='n', last_known_response_status='needsAction' WHERE id=?"
     ).run(id);
 
     await syncReservationDelete(db, id);
 
     expect(calMock.deleteEvent).toHaveBeenCalledWith(expect.anything(), "cal-id", "evt-123");
     const row = db
-      .prepare("SELECT google_event_id, last_synced_etag FROM reservations WHERE id = ?")
-      .get(id) as { google_event_id: string | null; last_synced_etag: string | null };
+      .prepare(
+        "SELECT google_event_id, last_synced_etag, last_app_write_nonce, last_known_response_status FROM reservations WHERE id = ?"
+      )
+      .get(id) as {
+      google_event_id: string | null;
+      last_synced_etag: string | null;
+      last_app_write_nonce: string | null;
+      last_known_response_status: string | null;
+    };
     expect(row.google_event_id).toBeNull();
     expect(row.last_synced_etag).toBeNull();
+    expect(row.last_app_write_nonce).toBeNull();
+    expect(row.last_known_response_status).toBeNull();
   });
 });

--- a/lib/calendar-renew.ts
+++ b/lib/calendar-renew.ts
@@ -34,7 +34,7 @@ export async function handleCalendarRenew(
   if (stateRow) {
     const expiresMs = new Date(stateRow.expiration_at).getTime();
     const fiveDaysMs = 5 * 24 * 60 * 60 * 1000;
-    if (expiresMs - Date.now() > fiveDaysMs) {
+    if (!isNaN(expiresMs) && expiresMs - Date.now() > fiveDaysMs) {
       return { ok: true, skipped: "not_due" };
     }
     try {
@@ -62,6 +62,7 @@ export async function handleCalendarRenew(
       await processCalendarDelta(db, client, calendarId, delta.items);
     } else {
       console.error("[calendar-renew] listEventsDelta failed", e);
+      throw e;
     }
   }
 

--- a/lib/calendar-renew.ts
+++ b/lib/calendar-renew.ts
@@ -1,0 +1,79 @@
+// lib/calendar-renew.ts
+import { randomUUID } from "crypto";
+import type Database from "better-sqlite3";
+import { getSetting } from "@/lib/queries/settings";
+import { getOAuthClient, watchEvents, stopChannel, listEventsDelta } from "@/lib/google-calendar";
+import { processCalendarDelta } from "@/lib/process-calendar-delta";
+
+export interface RenewResult {
+  ok: boolean;
+  skipped?: string;
+  renewed?: boolean;
+  expiresAt?: string;
+}
+
+export async function handleCalendarRenew(
+  db: Database.Database,
+  baseUrl: string
+): Promise<RenewResult> {
+  const calendarId = getSetting(db, "google_calendar_id");
+  const refreshToken = getSetting(db, "google_oauth_refresh_token");
+  if (!calendarId || !refreshToken) return { ok: true, skipped: "disabled" };
+
+  const client = getOAuthClient(refreshToken);
+
+  const stateRow = db.prepare("SELECT * FROM calendar_sync_state WHERE id = 1").get() as
+    | {
+        channel_id: string;
+        resource_id: string;
+        expiration_at: string;
+        sync_token: string;
+      }
+    | undefined;
+
+  if (stateRow) {
+    const expiresMs = new Date(stateRow.expiration_at).getTime();
+    const fiveDaysMs = 5 * 24 * 60 * 60 * 1000;
+    if (expiresMs - Date.now() > fiveDaysMs) {
+      return { ok: true, skipped: "not_due" };
+    }
+    try {
+      await stopChannel(client, stateRow.channel_id, stateRow.resource_id);
+    } catch (e) {
+      console.error("[calendar-renew] stopChannel failed (continuing)", e);
+    }
+  }
+
+  const channelId = randomUUID();
+  const webhookUrl = `${baseUrl}/api/calendar-webhook`;
+  const newChannel = await watchEvents(client, calendarId, webhookUrl, channelId);
+
+  // Catch up on missed events before persisting the new channel
+  let nextSyncToken = stateRow?.sync_token;
+  try {
+    const delta = await listEventsDelta(client, calendarId, stateRow?.sync_token);
+    nextSyncToken = delta.nextSyncToken;
+    await processCalendarDelta(db, client, calendarId, delta.items);
+  } catch (e: unknown) {
+    const code = (e as { code?: number })?.code;
+    if (code === 410) {
+      const delta = await listEventsDelta(client, calendarId);
+      nextSyncToken = delta.nextSyncToken;
+      await processCalendarDelta(db, client, calendarId, delta.items);
+    } else {
+      console.error("[calendar-renew] listEventsDelta failed", e);
+    }
+  }
+
+  db.prepare(
+    `INSERT INTO calendar_sync_state (id, channel_id, resource_id, expiration_at, sync_token)
+     VALUES (1, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       channel_id=excluded.channel_id,
+       resource_id=excluded.resource_id,
+       expiration_at=excluded.expiration_at,
+       sync_token=excluded.sync_token`
+  ).run(newChannel.channelId, newChannel.resourceId, newChannel.expiration, nextSyncToken ?? "");
+
+  return { ok: true, renewed: true, expiresAt: newChannel.expiration };
+}

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -14,6 +14,9 @@ const envSchema = z.object({
   NEXT_PUBLIC_BASE_URL: z.string().url().optional(),
   AUTH_USERNAME: z.string().optional(),
   AUTH_PASSWORD_HASH: z.string().optional(),
+  CRON_SECRET: z.string().optional(),
+  GOOGLE_CLIENT_ID: z.string().optional(),
+  GOOGLE_CLIENT_SECRET: z.string().optional(),
 });
 
 type Env = z.infer<typeof envSchema>;

--- a/lib/google-calendar.ts
+++ b/lib/google-calendar.ts
@@ -1,6 +1,7 @@
 // lib/google-calendar.ts
 import { google } from "googleapis";
 import type { OAuth2Client } from "google-auth-library";
+import { env } from "@/lib/env";
 
 export type { OAuth2Client };
 
@@ -21,10 +22,7 @@ export function addDays(dateStr: string, days: number): string {
 }
 
 export function getOAuthClient(refreshToken: string): OAuth2Client {
-  const client = new google.auth.OAuth2(
-    process.env.GOOGLE_CLIENT_ID,
-    process.env.GOOGLE_CLIENT_SECRET
-  );
+  const client = new google.auth.OAuth2(env.GOOGLE_CLIENT_ID, env.GOOGLE_CLIENT_SECRET);
   client.setCredentials({ refresh_token: refreshToken });
   return client;
 }

--- a/lib/google-calendar.ts
+++ b/lib/google-calendar.ts
@@ -107,7 +107,7 @@ export async function watchEvents(
   return {
     channelId: res.data.id!,
     resourceId: res.data.resourceId!,
-    expiration: new Date(Number(res.data.expiration)).toISOString(),
+    expiration: res.data.expiration ? new Date(Number(res.data.expiration)).toISOString() : "",
   };
 }
 
@@ -127,8 +127,12 @@ export async function listEventsDelta(
 ): Promise<{ items: CalendarEvent[]; nextSyncToken: string }> {
   const cal = google.calendar({ version: "v3", auth: client });
   const res = await cal.events.list({ calendarId, syncToken, showDeleted: true });
+  const nextSyncToken = res.data.nextSyncToken;
+  if (!nextSyncToken) {
+    throw new Error("listEventsDelta: result is paginated; full sync required");
+  }
   return {
     items: (res.data.items ?? []) as CalendarEvent[],
-    nextSyncToken: res.data.nextSyncToken!,
+    nextSyncToken,
   };
 }

--- a/lib/google-calendar.ts
+++ b/lib/google-calendar.ts
@@ -1,0 +1,134 @@
+// lib/google-calendar.ts
+import { google } from "googleapis";
+import type { OAuth2Client } from "google-auth-library";
+
+export type { OAuth2Client };
+
+export interface CalendarEvent {
+  id?: string | null;
+  etag?: string | null;
+  status?: string | null;
+  start?: { date?: string | null };
+  end?: { date?: string | null };
+  attendees?: Array<{ email?: string | null; responseStatus?: string | null }>;
+  extendedProperties?: { private?: { appWriteNonce?: string | null } };
+}
+
+export function addDays(dateStr: string, days: number): string {
+  const d = new Date(dateStr + "T00:00:00Z");
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+export function getOAuthClient(refreshToken: string): OAuth2Client {
+  const client = new google.auth.OAuth2(
+    process.env.GOOGLE_CLIENT_ID,
+    process.env.GOOGLE_CLIENT_SECRET
+  );
+  client.setCredentials({ refresh_token: refreshToken });
+  return client;
+}
+
+interface ReservationShape {
+  start_date: string;
+  end_date: string;
+  note?: string | null;
+  status?: string;
+  car_short?: string | null;
+  person_name?: string | null;
+}
+
+function buildEventBody(r: ReservationShape, nonce: string, ownerEmail?: string): object {
+  const calStatus =
+    r.status === "confirmed" ? "confirmed" : r.status === "rejected" ? "cancelled" : "tentative";
+  return {
+    summary: r.car_short ? `[${r.car_short}] ${r.person_name ?? ""}` : "Reservering",
+    description: r.note ?? undefined,
+    start: { date: r.start_date },
+    end: { date: addDays(r.end_date, 1) },
+    status: calStatus,
+    attendees: ownerEmail ? [{ email: ownerEmail }] : undefined,
+    extendedProperties: { private: { appWriteNonce: nonce } },
+  };
+}
+
+export async function createEvent(
+  client: OAuth2Client,
+  calendarId: string,
+  r: ReservationShape,
+  nonce: string,
+  ownerEmail?: string
+): Promise<{ id: string; etag: string }> {
+  const cal = google.calendar({ version: "v3", auth: client });
+  const res = await cal.events.insert({
+    calendarId,
+    requestBody: buildEventBody(r, nonce, ownerEmail),
+  });
+  return { id: res.data.id!, etag: res.data.etag! };
+}
+
+export async function updateEvent(
+  client: OAuth2Client,
+  calendarId: string,
+  eventId: string,
+  r: ReservationShape,
+  nonce: string,
+  ownerEmail?: string
+): Promise<{ etag: string }> {
+  const cal = google.calendar({ version: "v3", auth: client });
+  const res = await cal.events.update({
+    calendarId,
+    eventId,
+    requestBody: buildEventBody(r, nonce, ownerEmail),
+  });
+  return { etag: res.data.etag! };
+}
+
+export async function deleteEvent(
+  client: OAuth2Client,
+  calendarId: string,
+  eventId: string
+): Promise<void> {
+  const cal = google.calendar({ version: "v3", auth: client });
+  await cal.events.delete({ calendarId, eventId });
+}
+
+export async function watchEvents(
+  client: OAuth2Client,
+  calendarId: string,
+  webhookUrl: string,
+  channelId: string
+): Promise<{ channelId: string; resourceId: string; expiration: string }> {
+  const cal = google.calendar({ version: "v3", auth: client });
+  const res = await cal.events.watch({
+    calendarId,
+    requestBody: { id: channelId, type: "web_hook", address: webhookUrl },
+  });
+  return {
+    channelId: res.data.id!,
+    resourceId: res.data.resourceId!,
+    expiration: new Date(Number(res.data.expiration)).toISOString(),
+  };
+}
+
+export async function stopChannel(
+  client: OAuth2Client,
+  channelId: string,
+  resourceId: string
+): Promise<void> {
+  const cal = google.calendar({ version: "v3", auth: client });
+  await cal.channels.stop({ requestBody: { id: channelId, resourceId } });
+}
+
+export async function listEventsDelta(
+  client: OAuth2Client,
+  calendarId: string,
+  syncToken?: string
+): Promise<{ items: CalendarEvent[]; nextSyncToken: string }> {
+  const cal = google.calendar({ version: "v3", auth: client });
+  const res = await cal.events.list({ calendarId, syncToken, showDeleted: true });
+  return {
+    items: (res.data.items ?? []) as CalendarEvent[],
+    nextSyncToken: res.data.nextSyncToken!,
+  };
+}

--- a/lib/process-calendar-delta.ts
+++ b/lib/process-calendar-delta.ts
@@ -1,0 +1,111 @@
+// lib/process-calendar-delta.ts
+import type Database from "better-sqlite3";
+import type { OAuth2Client } from "google-auth-library";
+import { addDays, updateEvent } from "@/lib/google-calendar";
+import type { CalendarEvent } from "@/lib/google-calendar";
+
+interface ReservationRowForDelta {
+  id: number;
+  start_date: string;
+  end_date: string;
+  note: string | null;
+  status: string;
+  car_short: string;
+  person_name: string | null;
+  last_synced_etag: string | null;
+  last_app_write_nonce: string | null;
+  last_known_response_status: string | null;
+  owner_email: string | null;
+}
+
+export async function processCalendarDelta(
+  db: Database.Database,
+  client: OAuth2Client,
+  calendarId: string,
+  items: CalendarEvent[]
+): Promise<void> {
+  for (const event of items) {
+    if (!event.id) continue;
+
+    const row = db
+      .prepare(
+        `SELECT r.id, r.start_date, r.end_date, r.note, r.status, r.last_synced_etag,
+                r.last_app_write_nonce, r.last_known_response_status,
+                c.short AS car_short, rq.name AS person_name, own.email AS owner_email
+         FROM reservations r
+         JOIN cars c ON c.id = r.car_id
+         JOIN people rq ON rq.id = r.person_id
+         LEFT JOIN people own ON own.id = c.owner_person_id
+         WHERE r.google_event_id = ?`
+      )
+      .get(event.id) as ReservationRowForDelta | undefined;
+
+    if (!row) continue;
+
+    // Echo check — skip writes originating from the app itself
+    if (event.etag != null && event.etag === row.last_synced_etag) continue;
+    if (
+      event.extendedProperties?.private?.appWriteNonce != null &&
+      event.extendedProperties.private.appWriteNonce === row.last_app_write_nonce
+    )
+      continue;
+
+    // Time-edit guard — app is authoritative for event times
+    // Skip time check for cancelled events (start/end may be absent)
+    const expectedEnd = addDays(row.end_date, 1);
+    if (
+      event.status !== "cancelled" &&
+      (event.start?.date !== row.start_date || event.end?.date !== expectedEnd)
+    ) {
+      const nonce = crypto.randomUUID();
+      try {
+        const { etag } = await updateEvent(
+          client,
+          calendarId,
+          event.id,
+          {
+            start_date: row.start_date,
+            end_date: row.end_date,
+            note: row.note,
+            status: row.status,
+            car_short: row.car_short,
+            person_name: row.person_name,
+          },
+          nonce,
+          row.owner_email ?? undefined
+        );
+        db.prepare(
+          "UPDATE reservations SET last_synced_etag=?, last_app_write_nonce=? WHERE id=?"
+        ).run(etag, nonce, row.id);
+      } catch (e) {
+        console.error("[calendar-delta] overwrite time edit failed", e);
+      }
+      continue;
+    }
+
+    // RSVP check
+    let newResponseStatus: string;
+    if (event.status === "cancelled") {
+      newResponseStatus = "declined";
+    } else {
+      const ownerEmail = row.owner_email;
+      const attendee = ownerEmail
+        ? event.attendees?.find((a) => a.email === ownerEmail)
+        : undefined;
+      newResponseStatus = attendee?.responseStatus ?? "needsAction";
+    }
+
+    if (newResponseStatus !== row.last_known_response_status) {
+      let newStatus: string | null = null;
+      if (newResponseStatus === "accepted") newStatus = "confirmed";
+      else if (newResponseStatus === "declined") newStatus = "rejected";
+
+      if (newStatus) {
+        db.prepare("UPDATE reservations SET status=? WHERE id=?").run(newStatus, row.id);
+      }
+      db.prepare(
+        "UPDATE reservations SET last_known_response_status=?, last_synced_etag=? WHERE id=?"
+      ).run(newResponseStatus, event.etag ?? null, row.id);
+    }
+  }
+}

--- a/lib/process-calendar-delta.ts
+++ b/lib/process-calendar-delta.ts
@@ -42,9 +42,13 @@ export async function processCalendarDelta(
 
     if (!row) continue;
 
-    // Echo check — skip writes originating from the app itself
+    // Echo check — skip writes originating from the app itself.
+    // Etag is the primary guard. Nonce is a fallback for the rare case where Google
+    // returns a delta without an etag — using nonce as primary would suppress external
+    // RSVP changes because Google preserves extendedProperties through user edits.
     if (event.etag != null && event.etag === row.last_synced_etag) continue;
     if (
+      event.etag == null &&
       event.extendedProperties?.private?.appWriteNonce != null &&
       event.extendedProperties.private.appWriteNonce === row.last_app_write_nonce
     )

--- a/lib/process-calendar-delta.ts
+++ b/lib/process-calendar-delta.ts
@@ -100,12 +100,9 @@ export async function processCalendarDelta(
       if (newResponseStatus === "accepted") newStatus = "confirmed";
       else if (newResponseStatus === "declined") newStatus = "rejected";
 
-      if (newStatus) {
-        db.prepare("UPDATE reservations SET status=? WHERE id=?").run(newStatus, row.id);
-      }
       db.prepare(
-        "UPDATE reservations SET last_known_response_status=?, last_synced_etag=? WHERE id=?"
-      ).run(newResponseStatus, event.etag ?? null, row.id);
+        "UPDATE reservations SET status=COALESCE(?, status), last_known_response_status=?, last_synced_etag=? WHERE id=?"
+      ).run(newStatus, newResponseStatus, event.etag ?? null, row.id);
     }
   }
 }

--- a/lib/queries/cars.ts
+++ b/lib/queries/cars.ts
@@ -50,7 +50,7 @@ export function updateCar(db: Database.Database, id: number, data: CarInput): vo
       const person = db
         .prepare("SELECT name FROM people WHERE id = ?")
         .get(args.data.owner_person_id) as { name: string } | undefined;
-      if (person) ownerName = person.name;
+      if (person) ownerName = person.name.split(" ")[0];
     }
     db.prepare(
       "UPDATE cars SET short=?,name=?,price_per_km=?,brand=?,color=?,owner_name=?,long_threshold=?,active=?,expected_km=?,owner_person_id=? WHERE id=?"

--- a/lib/queries/cars.ts
+++ b/lib/queries/cars.ts
@@ -48,9 +48,9 @@ export function updateCar(db: Database.Database, id: number, data: CarInput): vo
     let ownerName = args.data.owner_name ?? null;
     if (args.data.owner_person_id) {
       const person = db
-        .prepare("SELECT name FROM people WHERE id = ?")
-        .get(args.data.owner_person_id) as { name: string } | undefined;
-      if (person) ownerName = person.name.split(" ")[0];
+        .prepare("SELECT name, username FROM people WHERE id = ?")
+        .get(args.data.owner_person_id) as { name: string; username: string | null } | undefined;
+      if (person) ownerName = person.name?.split(" ")[0] || person.username || null;
     }
     db.prepare(
       "UPDATE cars SET short=?,name=?,price_per_km=?,brand=?,color=?,owner_name=?,long_threshold=?,active=?,expected_km=?,owner_person_id=? WHERE id=?"

--- a/lib/queries/cars.ts
+++ b/lib/queries/cars.ts
@@ -44,6 +44,14 @@ export function updateCar(db: Database.Database, id: number, data: CarInput): vo
     if (current && Math.abs(args.data.price_per_km - current.price_per_km) >= 0.0001) {
       recordPriceHistory(db, args.id, args.data.price_per_km);
     }
+    // Sync owner_name from person table when owner_person_id is set
+    let ownerName = args.data.owner_name ?? null;
+    if (args.data.owner_person_id) {
+      const person = db
+        .prepare("SELECT name FROM people WHERE id = ?")
+        .get(args.data.owner_person_id) as { name: string } | undefined;
+      if (person) ownerName = person.name;
+    }
     db.prepare(
       "UPDATE cars SET short=?,name=?,price_per_km=?,brand=?,color=?,owner_name=?,long_threshold=?,active=?,expected_km=?,owner_person_id=? WHERE id=?"
     ).run(
@@ -52,7 +60,7 @@ export function updateCar(db: Database.Database, id: number, data: CarInput): vo
       args.data.price_per_km,
       args.data.brand ?? null,
       args.data.color ?? null,
-      args.data.owner_name ?? null,
+      ownerName,
       args.data.long_threshold ?? 500,
       args.data.active ?? 1,
       args.data.expected_km ?? null,

--- a/lib/queries/cars.ts
+++ b/lib/queries/cars.ts
@@ -20,7 +20,7 @@ export function insertCar(db: Database.Database, data: CarInput): number {
   return db.transaction((d: CarInput) => {
     const result = db
       .prepare(
-        "INSERT INTO cars (short,name,price_per_km,brand,color,owner_name,long_threshold) VALUES (?,?,?,?,?,?,?)"
+        "INSERT INTO cars (short,name,price_per_km,brand,color,owner_name,long_threshold,owner_person_id) VALUES (?,?,?,?,?,?,?,?)"
       )
       .run(
         d.short,
@@ -29,7 +29,8 @@ export function insertCar(db: Database.Database, data: CarInput): number {
         d.brand ?? null,
         d.color ?? null,
         d.owner_name ?? null,
-        d.long_threshold ?? 500
+        d.long_threshold ?? 500,
+        d.owner_person_id ?? null
       );
     const newId = result.lastInsertRowid as number;
     recordPriceHistory(db, newId, d.price_per_km);
@@ -44,7 +45,7 @@ export function updateCar(db: Database.Database, id: number, data: CarInput): vo
       recordPriceHistory(db, args.id, args.data.price_per_km);
     }
     db.prepare(
-      "UPDATE cars SET short=?,name=?,price_per_km=?,brand=?,color=?,owner_name=?,long_threshold=?,active=?,expected_km=? WHERE id=?"
+      "UPDATE cars SET short=?,name=?,price_per_km=?,brand=?,color=?,owner_name=?,long_threshold=?,active=?,expected_km=?,owner_person_id=? WHERE id=?"
     ).run(
       args.data.short,
       args.data.name,
@@ -55,6 +56,7 @@ export function updateCar(db: Database.Database, id: number, data: CarInput): vo
       args.data.long_threshold ?? 500,
       args.data.active ?? 1,
       args.data.expected_km ?? null,
+      args.data.owner_person_id ?? null,
       args.id
     );
   })({ id, data });

--- a/lib/queries/people.ts
+++ b/lib/queries/people.ts
@@ -32,7 +32,7 @@ export function insertPerson(
 ): number {
   const result = db
     .prepare(
-      "INSERT INTO people (name,discount,discount_long,active,username,is_admin,bank_account) VALUES (?,?,?,?,?,?,?)"
+      "INSERT INTO people (name,discount,discount_long,active,username,is_admin,bank_account,email) VALUES (?,?,?,?,?,?,?,?)"
     )
     .run(
       data.name,
@@ -41,7 +41,8 @@ export function insertPerson(
       data.active,
       data.username ?? null,
       data.is_admin ?? 0,
-      data.bank_account ?? ''
+      data.bank_account ?? "",
+      data.email ?? null
     );
   return result.lastInsertRowid as number;
 }
@@ -52,7 +53,7 @@ export function updatePerson(
   data: Omit<Person, "id" | "updated_at">
 ): void {
   db.prepare(
-    "UPDATE people SET name=?,discount=?,discount_long=?,active=?,username=?,is_admin=?,bank_account=? WHERE id=?"
+    "UPDATE people SET name=?,discount=?,discount_long=?,active=?,username=?,is_admin=?,bank_account=?,email=? WHERE id=?"
   ).run(
     data.name,
     data.discount,
@@ -60,7 +61,8 @@ export function updatePerson(
     data.active,
     data.username ?? null,
     data.is_admin ?? 0,
-    data.bank_account ?? '',
+    data.bank_account ?? "",
+    data.email ?? null,
     id
   );
 }

--- a/lib/reservation-sync.ts
+++ b/lib/reservation-sync.ts
@@ -1,0 +1,101 @@
+// lib/reservation-sync.ts
+import type Database from "better-sqlite3";
+import { getSetting } from "@/lib/queries/settings";
+import * as cal from "@/lib/google-calendar";
+
+interface ReservationRow {
+  id: number;
+  start_date: string;
+  end_date: string;
+  note: string | null;
+  status: string;
+  car_short: string;
+  person_name: string | null;
+  owner_email: string | null;
+  google_event_id: string | null;
+}
+
+function getCalendarCtx(
+  db: Database.Database
+): { client: cal.OAuth2Client; calendarId: string } | null {
+  const calendarId = getSetting(db, "google_calendar_id");
+  const refreshToken = getSetting(db, "google_oauth_refresh_token");
+  if (!calendarId || !refreshToken) return null;
+  return { client: cal.getOAuthClient(refreshToken), calendarId };
+}
+
+function getReservationForSync(db: Database.Database, id: number): ReservationRow | undefined {
+  return db
+    .prepare(
+      `SELECT r.id, r.start_date, r.end_date, r.note, r.status, r.google_event_id,
+              c.short AS car_short, rq.name AS person_name, own.email AS owner_email
+       FROM reservations r
+       JOIN cars c ON c.id = r.car_id
+       JOIN people rq ON rq.id = r.person_id
+       LEFT JOIN people own ON own.id = c.owner_person_id
+       WHERE r.id = ?`
+    )
+    .get(id) as ReservationRow | undefined;
+}
+
+export async function syncReservationCreate(db: Database.Database, id: number): Promise<void> {
+  const ctx = getCalendarCtx(db);
+  if (!ctx) return;
+  const r = getReservationForSync(db, id);
+  if (!r) return;
+  const nonce = crypto.randomUUID();
+  try {
+    const { id: eventId, etag } = await cal.createEvent(
+      ctx.client,
+      ctx.calendarId,
+      r,
+      nonce,
+      r.owner_email ?? undefined
+    );
+    db.prepare(
+      "UPDATE reservations SET google_event_id=?, last_synced_etag=?, last_app_write_nonce=? WHERE id=?"
+    ).run(eventId, etag, nonce, id);
+  } catch (e) {
+    console.error("[calendar-sync] createEvent failed", e);
+  }
+}
+
+export async function syncReservationUpdate(db: Database.Database, id: number): Promise<void> {
+  const ctx = getCalendarCtx(db);
+  if (!ctx) return;
+  const r = getReservationForSync(db, id);
+  if (!r || !r.google_event_id) return;
+  const nonce = crypto.randomUUID();
+  try {
+    const { etag } = await cal.updateEvent(
+      ctx.client,
+      ctx.calendarId,
+      r.google_event_id,
+      r,
+      nonce,
+      r.owner_email ?? undefined
+    );
+    db.prepare("UPDATE reservations SET last_synced_etag=?, last_app_write_nonce=? WHERE id=?").run(
+      etag,
+      nonce,
+      id
+    );
+  } catch (e) {
+    console.error("[calendar-sync] updateEvent failed", e);
+  }
+}
+
+export async function syncReservationDelete(db: Database.Database, id: number): Promise<void> {
+  const ctx = getCalendarCtx(db);
+  if (!ctx) return;
+  const r = getReservationForSync(db, id);
+  if (!r || !r.google_event_id) return;
+  try {
+    await cal.deleteEvent(ctx.client, ctx.calendarId, r.google_event_id);
+    db.prepare(
+      "UPDATE reservations SET google_event_id=NULL, last_synced_etag=NULL, last_app_write_nonce=NULL, last_known_response_status=NULL WHERE id=?"
+    ).run(id);
+  } catch (e) {
+    console.error("[calendar-sync] deleteEvent failed", e);
+  }
+}

--- a/lib/schemas/car.ts
+++ b/lib/schemas/car.ts
@@ -19,6 +19,13 @@ export const carSchema = z.object({
     .nullable()
     .optional()
     .transform((v) => v ?? null),
+  owner_person_id: z
+    .number()
+    .int()
+    .positive()
+    .nullable()
+    .optional()
+    .transform((v) => v ?? null),
   long_threshold: z.number().int().positive().optional().default(500),
   active: z.number().int().min(0).max(1).optional().default(1),
   expected_km: z

--- a/migrations/0011_people_email.sql
+++ b/migrations/0011_people_email.sql
@@ -1,0 +1,1 @@
+ALTER TABLE people ADD COLUMN email TEXT;

--- a/migrations/0012_cars_owner_person_id.sql
+++ b/migrations/0012_cars_owner_person_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cars ADD COLUMN owner_person_id INTEGER REFERENCES people(id);

--- a/migrations/0013_reservation_calendar_columns.sql
+++ b/migrations/0013_reservation_calendar_columns.sql
@@ -1,0 +1,4 @@
+ALTER TABLE reservations ADD COLUMN google_event_id TEXT;
+ALTER TABLE reservations ADD COLUMN last_synced_etag TEXT;
+ALTER TABLE reservations ADD COLUMN last_app_write_nonce TEXT;
+ALTER TABLE reservations ADD COLUMN last_known_response_status TEXT;

--- a/migrations/0014_calendar_sync_state.sql
+++ b/migrations/0014_calendar_sync_state.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS calendar_sync_state (
+  id            INTEGER PRIMARY KEY CHECK (id = 1),
+  channel_id    TEXT NOT NULL DEFAULT '',
+  resource_id   TEXT NOT NULL DEFAULT '',
+  expiration_at TEXT NOT NULL DEFAULT '',
+  sync_token    TEXT NOT NULL DEFAULT ''
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "better-sqlite3": "^12.9.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "googleapis": "^171.4.0",
         "idb": "^8.0.3",
         "iron-session": "^8.0.4",
         "leaflet": "^1.9.4",
@@ -6460,6 +6461,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
@@ -6963,6 +6973,15 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -7061,6 +7080,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -7395,6 +7420,15 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
@@ -7655,6 +7689,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ejs": {
@@ -8601,6 +8644,12 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fake-indexeddb": {
       "version": "6.2.5",
       "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
@@ -8669,6 +8718,29 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/file-entry-cache": {
@@ -8785,6 +8857,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -8862,6 +8946,34 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/generator-function": {
@@ -9052,6 +9164,61 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "171.4.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-171.4.0.tgz",
+      "integrity": "sha512-xybFL2SmmUgIifgsbsRQYRdNrSAYwxWZDmkZTGjUIaRnX5jPqR8el/cEvo6rCqh7iaZx6MfEPS/lrDgZ0bymkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.2.0",
+        "googleapis-common": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-8.0.1.tgz",
+      "integrity": "sha512-eCzNACUXPb1PW5l0ULTzMHaL/ltPRADoPgjBlT8jWsTbxkCp6siv+qKJ/1ldaybCthGwsYFYallF7u9AkU4L+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^7.0.0-rc.4",
+        "google-auth-library": "^10.1.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -9193,6 +9360,19 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/husky": {
       "version": "9.1.7",
@@ -10025,6 +10205,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -10092,6 +10281,27 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -10945,6 +11155,26 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -10972,6 +11202,24 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-releases": {
@@ -11512,6 +11760,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -13444,6 +13707,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
+    },
     "node_modules/use-callback-ref": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
@@ -13737,6 +14006,15 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "better-sqlite3": "^12.9.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "googleapis": "^171.4.0",
     "idb": "^8.0.3",
     "iron-session": "^8.0.4",
     "leaflet": "^1.9.4",

--- a/types/index.ts
+++ b/types/index.ts
@@ -8,6 +8,7 @@ export interface Person {
   password_hash: string | null;
   is_admin: 0 | 1;
   bank_account: string;
+  email: string | null;
   updated_at: string;
 }
 
@@ -21,6 +22,7 @@ export interface Car {
   owner_name: string | null;
   owner_from: string | null; // 'YYYY-MM-DD', inclusive
   owner_to: string | null; // 'YYYY-MM-DD', inclusive; NULL = ongoing
+  owner_person_id: number | null;
   long_threshold: number;
   active: 0 | 1;
   expected_km: number | null;
@@ -106,6 +108,10 @@ export interface Reservation {
   note: string | null;
   client_id: string | null;
   updated_at: string;
+  google_event_id: string | null;
+  last_synced_etag: string | null;
+  last_app_write_nonce: string | null;
+  last_known_response_status: string | null;
   // joined
   person_name?: string;
   car_short?: string;
@@ -174,6 +180,7 @@ export type PersonInput = Pick<Person, "name" | "discount" | "discount_long" | "
 };
 export type CarInput = Pick<Car, "short" | "name" | "price_per_km" | "brand" | "color"> & {
   owner_name?: string | null;
+  owner_person_id?: number | null;
   long_threshold?: number;
   fixed_costs_json?: string | null;
   active?: number;
@@ -310,4 +317,12 @@ export interface SettlementResult {
   payments_by_person: Record<number, number>;
   /** True when every transfer with a human payer has open === 0. */
   all_paid: boolean;
+}
+
+export interface CalendarSyncState {
+  id: 1;
+  channel_id: string;
+  resource_id: string;
+  expiration_at: string;
+  sync_token: string;
 }


### PR DESCRIPTION
## Summary

- Add Google Calendar two-way sync for reservations
- Webhook handler receives RSVP events from Google; confirms/rejects reservations automatically
- New DB migrations (0011–0014): `google_calendar_*` settings, `email` on people, `owner_person_id` FK on cars, `client_id` on reservations
- Admin settings: Google Calendar credential fields, connection test button, missing-env warning
- Backfill endpoint (`/api/admin/calendar-backfill`) to sync existing confirmed reservations retroactively
- Channel renewal cron route (`/api/admin/calendar-renew`)
- Reservation routes wired to sync on create/update/delete
- First-name display fix in owner dropdowns on cars admin
- Admin members list: hover pencil icon → `/user/:id/edit`
- POST `/api/reservations` now returns full reservation object (needed by sync)

Closes #115

## Test Plan
- [ ] Admin settings > Google Calendar section shows/saves credentials
- [ ] Test connection button confirms valid token
- [ ] Creating a confirmed reservation creates a Google Calendar event
- [ ] Updating dates/status updates the calendar event
- [ ] Deleting a reservation removes the calendar event
- [ ] RSVP accept on calendar → reservation status → confirmed
- [ ] RSVP decline on calendar → reservation status → rejected
- [ ] Backfill button syncs all confirmed reservations
- [ ] Channel renewal route refreshes expiring watch channels
- [ ] Owner dropdown in cars admin shows first name only

🤖 Generated with [Claude Code](https://claude.com/claude-code)