### PR TITLE
fix(auth): use owner_person_id FK for isOwner check (#131)

### DIFF
--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -27,7 +27,7 @@ export async function GET(req: Request) {
   if (cloaked) {
     // While cloaked, return the cloaked person's identity.
     // isOwner is computed from their name; isAdmin reflects their actual role.
-    const cloakedOwner = isOwner(getDb(), cloaked.personName);
+    const cloakedOwner = isOwner(getDb(), cloaked.personId);
     return withCsrfCookie(
       NextResponse.json({
         personId: cloaked.personId,
@@ -40,8 +40,8 @@ export async function GET(req: Request) {
   }
 
   let owner = false;
-  if (session.personName) {
-    owner = isOwner(getDb(), session.personName);
+  if (session.personId) {
+    owner = isOwner(getDb(), session.personId);
   }
 
   return withCsrfCookie(

--- a/lib/__tests__/queries_people.test.ts
+++ b/lib/__tests__/queries_people.test.ts
@@ -188,26 +188,26 @@ describe("setPasswordHash", () => {
 describe("isOwner", () => {
   it("returns false when person owns no active cars", () => {
     const db = makeDb();
-    insertPerson(db, { ...basePerson, name: "Alice" });
-    expect(isOwner(db, "Alice")).toBe(false);
+    const aliceId = insertPerson(db, { ...basePerson, name: "Alice" });
+    expect(isOwner(db, aliceId)).toBe(false);
   });
 
   it("returns true when person owns an active car", () => {
     const db = makeDb();
-    insertPerson(db, { ...basePerson, name: "Alice" });
-    db.exec(
-      `INSERT INTO cars (short,name,price_per_km,owner_name,owner_from,active) VALUES ('CA','Car A',0.2,'Alice','2020-01-01',1)`
-    );
-    expect(isOwner(db, "Alice")).toBe(true);
+    const aliceId = insertPerson(db, { ...basePerson, name: "Alice" });
+    db.prepare(
+      `INSERT INTO cars (short,name,price_per_km,owner_name,owner_person_id,owner_from,active) VALUES ('CA','Car A',0.2,'Alice',?,'2020-01-01',1)`
+    ).run(aliceId);
+    expect(isOwner(db, aliceId)).toBe(true);
   });
 
   it("returns true when person only owns inactive cars (owner retains API access after deactivation)", () => {
     const db = makeDb();
-    insertPerson(db, { ...basePerson, name: "Alice" });
-    db.exec(
-      `INSERT INTO cars (short,name,price_per_km,owner_name,owner_from,active) VALUES ('CA','Car A',0.2,'Alice','2020-01-01',0)`
-    );
-    expect(isOwner(db, "Alice")).toBe(true);
+    const aliceId = insertPerson(db, { ...basePerson, name: "Alice" });
+    db.prepare(
+      `INSERT INTO cars (short,name,price_per_km,owner_name,owner_person_id,owner_from,active) VALUES ('CA','Car A',0.2,'Alice',?,'2020-01-01',0)`
+    ).run(aliceId);
+    expect(isOwner(db, aliceId)).toBe(true);
   });
 });
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -48,12 +48,12 @@ export async function requireAdminOrOwner(req: Request) {
   const { sessionOptions } = await import("./session");
   const session = await getIronSession<SessionData>(req, NextResponse.next(), sessionOptions);
   if (session.isAdmin) return session;
-  const name = session.personName;
-  if (!name) forbidden();
+  const personId = session.personId;
+  if (!personId) forbidden();
   // isOwner is not stored in the session — check DB at runtime
   const { getDb } = await import("./db");
   const { isOwner } = await import("./queries/people");
-  if (!isOwner(getDb(), name)) forbidden();
+  if (!isOwner(getDb(), personId)) forbidden();
   return session;
 }
 

--- a/lib/queries/people.ts
+++ b/lib/queries/people.ts
@@ -71,8 +71,10 @@ export function setPasswordHash(db: Database.Database, id: number, passwordHash:
   db.prepare("UPDATE people SET password_hash=? WHERE id=?").run(passwordHash, id);
 }
 
-export function isOwner(db: Database.Database, personName: string): boolean {
-  const row = db.prepare("SELECT COUNT(*) as n FROM cars WHERE owner_name=?").get(personName) as {
+export function isOwner(db: Database.Database, personId: number): boolean {
+  const row = db
+    .prepare("SELECT COUNT(*) as n FROM cars WHERE owner_person_id=?")
+    .get(personId) as {
     n: number;
   };
   return row.n > 0;


### PR DESCRIPTION
## Summary

- `isOwner()` in `lib/queries/people.ts` was checking `WHERE owner_name = ?` using the person's full name string from the session
- `updateCar()` stores only the first name in `owner_name` (splits on space), so full name "Alice De Smedt" in session != "Alice" in `cars.owner_name`
- This caused `isOwner` to return false when an admin cloaked as an owner, redirecting away from `/admin/cars`

## Fix

Changed `isOwner()` to use `personId` + `owner_person_id` FK instead of the fragile name string comparison. Updated all three call sites (`app/api/me/route.ts` cloaked path, non-cloaked path, and `lib/api.ts` `requireAdminOrOwner`) plus the unit tests.

Closes #131