### PR TITLE
feat(fuel): rearrange FuelCard layout

### DIFF
--- a/components/fuel-card.tsx
+++ b/components/fuel-card.tsx
@@ -48,7 +48,8 @@ export function FuelCard({ fuel, onClick }: FuelCardProps) {
             textOverflow: "ellipsis",
           }}
         >
-          ⛽ {fuel.location ?? t("dashboard.fillup_label")}
+          {fuel.liters.toFixed(1)}L {t("fuel.card_refueled")}
+          {fuel.location ? ` · ${fuel.location}` : ""}
           {fuel.id < 0 && <PendingBadge />}
         </div>
         <div
@@ -60,7 +61,7 @@ export function FuelCard({ fuel, onClick }: FuelCardProps) {
             marginTop: 2,
           }}
         >
-          {fuel.person_name} · {fmtDate(fuel.date, locale)} · {fuel.liters.toFixed(1)}L
+          {fuel.person_name} · {fmtDate(fuel.date, locale)}
         </div>
       </div>
       <div style={{ textAlign: "right", flexShrink: 0 }}>

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -239,6 +239,7 @@ export const en: Messages = {
   "dashboard.noun_trips": "trips",
   "dashboard.noun_fillup": "fill-up",
   "dashboard.noun_fillups": "fill-ups",
+  "fuel.card_refueled": "refueled",
   "dashboard.noun_expense": "expense",
   "dashboard.noun_expenses": "expenses",
   "dashboard.total_label": "Total",

--- a/lib/i18n/messages/nl.ts
+++ b/lib/i18n/messages/nl.ts
@@ -237,6 +237,7 @@ export const nl = {
   "dashboard.noun_trips": "ritten",
   "dashboard.noun_fillup": "tankbeurt",
   "dashboard.noun_fillups": "tankbeurten",
+  "fuel.card_refueled": "getankt",
   "dashboard.noun_expense": "uitgave",
   "dashboard.noun_expenses": "uitgaven",
   "dashboard.total_label": "Totaal",


### PR DESCRIPTION
## Summary
- Line 1: `{liters}L getankt · {location}` (no icon, location optional)
- Line 2: `{person_name} · {date}` (liters removed)
- Added `fuel.card_refueled` i18n key (NL: "getankt", EN: "refueled")

Closes #146

## Test plan
- [ ] Card shows `31.0L getankt` as primary line
- [ ] Location appended as `· Shell Berchem` when set, absent when null
- [ ] Name and date on second line without liters
- [ ] EN locale shows "refueled" instead of "getankt"

🤖 Generated with [Claude Code](https://claude.com/claude-code)