### PR TITLE
fix(dashboard): exclude settled_outside=1 fuel and expense from top-level aggregates

### DIFF
--- a/lib/__tests__/queries.test.ts
+++ b/lib/__tests__/queries.test.ts
@@ -400,4 +400,108 @@ describe("getDashboard", () => {
     expect(crossBd.fuel_settled_count).toBe(1);
     expect(crossBd.fuel_settled_liters).toBeCloseTo(30);
   });
+
+  it("excludes settled_outside=1 fuel from fuel_amount and balance", () => {
+    const db = makeDb();
+    const pid = insertPerson(db, { ...basePerson, first_name: "Alice" });
+    const cid = insertCar(db, {
+      short: "JF",
+      name: "Car JF",
+      price_per_km: 0.25,
+      brand: null,
+      color: null,
+    });
+    insertTrip(db, {
+      person_id: pid,
+      car_id: cid,
+      date: "2026-01-10",
+      start_odometer: 0,
+      end_odometer: 100,
+      location: null,
+    });
+    // settled_outside=1: should be excluded
+    insertFuelFillup(db, {
+      person_id: pid,
+      car_id: cid,
+      date: "2026-01-10",
+      amount: 50,
+      liters: 30,
+      price_per_liter: null,
+      full_tank: 0,
+      odometer: null,
+      receipt: null,
+      location: null,
+      gps_coords: null,
+      settled_outside: 1,
+    });
+    // settled_outside=0: should be included
+    insertFuelFillup(db, {
+      person_id: pid,
+      car_id: cid,
+      date: "2026-01-10",
+      amount: 20,
+      liters: 12,
+      price_per_liter: null,
+      full_tank: 0,
+      odometer: null,
+      receipt: null,
+      location: null,
+      gps_coords: null,
+      settled_outside: 0,
+    });
+    // trip_amount = -25 (100km * 0.25), fuel_amount should = 20 (not 70)
+    // total_amount = -25 + 20 = -5, balance = -5
+    const rows = getDashboard(db, 2026);
+    expect(rows[0].fuel_amount).toBeCloseTo(20);
+    expect(rows[0].fuel_count).toBe(1);
+    expect(rows[0].total_amount).toBeCloseTo(-5);
+    expect(rows[0].balance).toBeCloseTo(-5);
+  });
+
+  it("excludes settled_outside=1 expenses from expense_amount and balance", () => {
+    const db = makeDb();
+    const pid = insertPerson(db, { ...basePerson, first_name: "Bob" });
+    const cid = insertCar(db, {
+      short: "LW",
+      name: "Car LW",
+      price_per_km: 0.25,
+      brand: null,
+      color: null,
+    });
+    insertTrip(db, {
+      person_id: pid,
+      car_id: cid,
+      date: "2026-02-01",
+      start_odometer: 0,
+      end_odometer: 100,
+      location: null,
+    });
+    // settled_outside=1: should be excluded
+    insertExpense(db, {
+      person_id: pid,
+      car_id: cid,
+      date: "2026-02-01",
+      amount: 80,
+      description: "big repair",
+      category: null,
+      settled_outside: 1,
+    });
+    // settled_outside=0: should be included
+    insertExpense(db, {
+      person_id: pid,
+      car_id: cid,
+      date: "2026-02-01",
+      amount: 30,
+      description: "oil",
+      category: null,
+      settled_outside: 0,
+    });
+    // trip_amount = -25, expense_amount should = 30 (not 110)
+    // total_amount = -25 + 30 = 5, balance = 5
+    const rows = getDashboard(db, 2026);
+    expect(rows[0].expense_amount).toBeCloseTo(30);
+    expect(rows[0].expense_count).toBe(1);
+    expect(rows[0].total_amount).toBeCloseTo(5);
+    expect(rows[0].balance).toBeCloseTo(5);
+  });
 });

--- a/lib/queries/dashboard.ts
+++ b/lib/queries/dashboard.ts
@@ -116,6 +116,7 @@ export function getDashboard(db: Database.Database, year: number): DashboardRow[
              COALESCE(SUM(amount),0) AS fuel_amount
       FROM fuel_fillups
       WHERE strftime('%Y', date) = ?
+        AND settled_outside = 0
       GROUP BY person_id
     `
     )
@@ -129,6 +130,7 @@ export function getDashboard(db: Database.Database, year: number): DashboardRow[
              COALESCE(SUM(amount),0) AS expense_amount
       FROM expenses
       WHERE strftime('%Y', date) = ?
+        AND settled_outside = 0
       GROUP BY person_id
     `
     )


### PR DESCRIPTION
## Summary
- Adds `AND settled_outside = 0` to the `fuelRows` query in `getDashboard()` so the top-level `fuel_amount` matches the settlement algorithm
- Adds `AND settled_outside = 0` to the `expenseRows` query so `expense_amount` and `expense_count` also exclude externally-settled records
- Adds two regression tests covering both fixes

## Test Plan
- [x] `npm test` passes (368 tests)
- [x] Dashboard `fuel_amount` / `expense_amount` / `balance` now match S1 value from settlement for members with `settled_outside=1` records

Closes #149