### PR TITLE
feat(settlement+dashboard): settled-outside asterisk indicators, car ordering, Own Car label

### DIFF
--- a/app/admin/settlement/page.tsx
+++ b/app/admin/settlement/page.tsx
@@ -687,47 +687,6 @@ function MemberCard({
 
       {open && (
         <div style={{ borderTop: `1px dashed ${paper.paperDark}`, padding: "10px 14px 14px" }}>
-          {/* Cross-car sections — owners who drove other cars */}
-          {m.is_owner &&
-            crossRows.map((item, i) => {
-              const crossSaldo = -item.row.balance;
-              return (
-                <div key={i} style={{ marginTop: i === 0 ? 0 : 14 }}>
-                  <CarSectionHeader label={item.car_short} saldo={crossSaldo} />
-                  {item.row.trip_km > 0 && (
-                    <BreakdownCarRow
-                      car={`ritten (${item.row.trip_km} km)`}
-                      detail={null}
-                      amount={`− ${fmtMoney(item.row.trip_amount)}`}
-                      amountColor={paper.accent}
-                    />
-                  )}
-                  {item.row.fuel_liters > 0 && (
-                    <BreakdownCarRow
-                      car={`brandstof (${fmtL(item.row.fuel_liters)} L)${item.row.fuel_settled_liters > 0.05 ? " (*)" : ""}`}
-                      detail={null}
-                      amount={`+ ${fmtMoney(item.row.fuel_amount)}`}
-                      amountColor={paper.green}
-                    />
-                  )}
-                  {item.row.expense_amount > 0 && (
-                    <BreakdownCarRow
-                      car={`kosten${item.row.expense_settled_amount > 0.005 ? (item.row.fuel_settled_liters > 0.05 ? " (**)" : " (*)") : ""}`}
-                      detail={null}
-                      amount={`+ ${fmtMoney(item.row.expense_amount)}`}
-                      amountColor={paper.green}
-                    />
-                  )}
-                  <SettledNote
-                    fuelCount={item.row.fuel_settled_count}
-                    fuelLiters={item.row.fuel_settled_liters}
-                    expCount={item.row.expense_settled_count}
-                    expAmt={item.row.expense_settled_amount}
-                  />
-                </div>
-              );
-            })}
-
           {/* Non-owner: per-car breakdown */}
           {!m.is_owner &&
             m.car_eras.map((era, i) => (
@@ -766,7 +725,7 @@ function MemberCard({
               </div>
             ))}
 
-          {/* EIGEN WAGEN section — owners only */}
+          {/* EIGEN WAGEN section — owners only, shown first */}
           {m.is_owner &&
             m.car_eras.map((era, i) => {
               const nStar = era.n_c_star ?? 0;
@@ -776,10 +735,9 @@ function MemberCard({
                 <div
                   key={i}
                   style={{
-                    marginTop: crossRows.length > 0 || i > 0 ? 14 : 0,
-                    borderTop:
-                      crossRows.length > 0 || i > 0 ? `1px dashed ${paper.paperDark}` : undefined,
-                    paddingTop: crossRows.length > 0 || i > 0 ? 10 : 0,
+                    marginTop: i > 0 ? 14 : 0,
+                    borderTop: i > 0 ? `1px dashed ${paper.paperDark}` : undefined,
+                    paddingTop: i > 0 ? 10 : 0,
                   }}
                 >
                   <CarSectionHeader
@@ -834,6 +792,56 @@ function MemberCard({
                 </div>
               );
             })}
+
+          {/* Cross-car sections — owners who drove other owners' cars */}
+          {m.is_owner && crossRows.length > 0 && (
+            <div
+              style={{
+                marginTop: 14,
+                borderTop: `1px dashed ${paper.paperDark}`,
+                paddingTop: 10,
+              }}
+            >
+              {crossRows.map((item, i) => {
+                const crossSaldo = -item.row.balance;
+                return (
+                  <div key={i} style={{ marginTop: i === 0 ? 0 : 14 }}>
+                    <CarSectionHeader label={item.car_short} saldo={crossSaldo} />
+                    {item.row.trip_km > 0 && (
+                      <BreakdownCarRow
+                        car={`ritten (${item.row.trip_km} km)`}
+                        detail={null}
+                        amount={`− ${fmtMoney(item.row.trip_amount)}`}
+                        amountColor={paper.accent}
+                      />
+                    )}
+                    {item.row.fuel_liters > 0 && (
+                      <BreakdownCarRow
+                        car={`brandstof (${fmtL(item.row.fuel_liters)} L)${item.row.fuel_settled_liters > 0.05 ? " (*)" : ""}`}
+                        detail={null}
+                        amount={`+ ${fmtMoney(item.row.fuel_amount)}`}
+                        amountColor={paper.green}
+                      />
+                    )}
+                    {item.row.expense_amount > 0 && (
+                      <BreakdownCarRow
+                        car={`kosten${item.row.expense_settled_amount > 0.005 ? (item.row.fuel_settled_liters > 0.05 ? " (**)" : " (*)") : ""}`}
+                        detail={null}
+                        amount={`+ ${fmtMoney(item.row.expense_amount)}`}
+                        amountColor={paper.green}
+                      />
+                    )}
+                    <SettledNote
+                      fuelCount={item.row.fuel_settled_count}
+                      fuelLiters={item.row.fuel_settled_liters}
+                      expCount={item.row.expense_settled_count}
+                      expAmt={item.row.expense_settled_amount}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          )}
 
           {/* SALDO */}
           <div

--- a/app/admin/settlement/page.tsx
+++ b/app/admin/settlement/page.tsx
@@ -550,17 +550,25 @@ function MemberCard({
         const sec = [row(era.car_short, era.balance >= 0 ? "+" : "−", Math.abs(era.balance))];
         if (era.trip_km > 0)
           sec.push(row(`  ${t("page.trips")} (${era.trip_km} km)`, "−", era.trip_amount, WC));
+        const hasFuelStar = (era.fuel_settled_liters ?? 0) > 0.05;
+        const hasExpStar = (era.expense_settled_amount ?? 0) > 0.005;
         if (era.fuel_liters > 0)
           sec.push(
             row(
-              `  ${t("settlement.breakdown_fuel")} (${fmtL(era.fuel_liters)} L)`,
+              `  ${t("settlement.breakdown_fuel")} (${fmtL(era.fuel_liters)} L)${hasFuelStar ? " (*)" : ""}`,
               "+",
               era.fuel_amount,
               WC
             )
           );
         if (era.expense_amount > 0)
-          sec.push(row(`  ${t("settlement.breakdown_costs")}`, "+", era.expense_amount, WC));
+          sec.push(row(`  ${t("settlement.breakdown_costs")}${hasExpStar ? (hasFuelStar ? " (**)" : " (*)") : ""}`, "+", era.expense_amount, WC));
+        if (hasFuelStar)
+          sec.push(`  (*) ${era.fuel_settled_count} tankbeurt${(era.fuel_settled_count ?? 0) !== 1 ? "en" : ""} (${fmtL(era.fuel_settled_liters ?? 0)} L) buiten afrekening`);
+        if (hasExpStar) {
+          const prefix = hasFuelStar ? "(**)" : "(*)";
+          sec.push(`  ${prefix} ${era.expense_settled_count} kost${(era.expense_settled_count ?? 0) !== 1 ? "en" : ""} buiten afrekening`);
+        }
         sections.push(sec.join("\n"));
       }
     }
@@ -936,12 +944,21 @@ function generateSettlementMd(data: import("@/types").SettlementResult, year: nu
   for (const m of [...nonOwners].sort((a, b) => a.person_name.localeCompare(b.person_name, "nl"))) {
     lines.push(`### ${m.person_name}  ${sign(m.s1 ?? 0)}`);
     for (const e of m.car_eras) {
+      const hasFuelStar = (e.fuel_settled_liters ?? 0) > 0.05;
+      const hasExpStar = (e.expense_settled_amount ?? 0) > 0.005;
       lines.push(`- **${e.car_name}** (${e.owner_name})`);
       lines.push(`  - Ritten: ${e.trip_km} km · € ${fmt(e.trip_amount)}`);
       if (e.fuel_amount)
-        lines.push(`  - Brandstof: ${fmtL(e.fuel_liters)} L · € ${fmt(e.fuel_amount)}`);
-      if (e.expense_amount) lines.push(`  - Kosten: € ${fmt(e.expense_amount)}`);
+        lines.push(`  - Brandstof: ${fmtL(e.fuel_liters)} L · € ${fmt(e.fuel_amount)}${hasFuelStar ? " (*)" : ""}`);
+      if (e.expense_amount)
+        lines.push(`  - Kosten: € ${fmt(e.expense_amount)}${hasExpStar ? (hasFuelStar ? " (**)" : " (*)") : ""}`);
       lines.push(`  - Saldo: ${sign(e.balance)}`);
+      if (hasFuelStar)
+        lines.push(`  - _(*) ${e.fuel_settled_count} tankbeurt${(e.fuel_settled_count ?? 0) !== 1 ? "en" : ""} (${fmtL(e.fuel_settled_liters ?? 0)} L) buiten afrekening_`);
+      if (hasExpStar) {
+        const prefix = hasFuelStar ? "(**)" : "(*)";
+        lines.push(`  - _(${prefix}) ${e.expense_settled_count} kost${(e.expense_settled_count ?? 0) !== 1 ? "en" : ""} (€ ${fmt(e.expense_settled_amount ?? 0)}) buiten afrekening_`);
+      }
     }
   }
 
@@ -980,13 +997,22 @@ function generateSettlementMd(data: import("@/types").SettlementResult, year: nu
           (r) => r.row_type === "cross_owner" && r.person_name === m.person_name
         );
         if (!row) continue;
+        const rHasFuelStar = row.fuel_settled_liters > 0.05;
+        const rHasExpStar = row.expense_settled_amount > 0.005;
         lines.push(`- **${cs.car_name}** (${cs.owner_name})`);
         if (row.trip_km > 0)
           lines.push(`  - Ritten: ${row.trip_km} km · € ${fmt(row.trip_amount)}`);
         if (row.fuel_liters > 0.05)
-          lines.push(`  - Brandstof: ${fmtL(row.fuel_liters)} L · € ${fmt(row.fuel_amount)}`);
-        if (row.expense_amount > 0.005) lines.push(`  - Kosten: € ${fmt(row.expense_amount)}`);
+          lines.push(`  - Brandstof: ${fmtL(row.fuel_liters)} L · € ${fmt(row.fuel_amount)}${rHasFuelStar ? " (*)" : ""}`);
+        if (row.expense_amount > 0.005)
+          lines.push(`  - Kosten: € ${fmt(row.expense_amount)}${rHasExpStar ? (rHasFuelStar ? " (**)" : " (*)") : ""}`);
         lines.push(`  - Saldo: ${sign(row.balance)}`);
+        if (rHasFuelStar)
+          lines.push(`  - _(*) ${row.fuel_settled_count} tankbeurt${row.fuel_settled_count !== 1 ? "en" : ""} (${fmtL(row.fuel_settled_liters)} L) buiten afrekening_`);
+        if (rHasExpStar) {
+          const prefix = rHasFuelStar ? "(**)" : "(*)";
+          lines.push(`  - _(${prefix}) ${row.expense_settled_count} kost${row.expense_settled_count !== 1 ? "en" : ""} (€ ${fmt(row.expense_settled_amount)}) buiten afrekening_`);
+        }
       }
       lines.push(`- **Gebruik andere wagens: ${sign(s1c)}**`);
       lines.push(`- **Netto: ${sign(net)}**`);

--- a/app/admin/settlement/page.tsx
+++ b/app/admin/settlement/page.tsx
@@ -25,14 +25,16 @@ function fmtDetail(
   settledFuelLiters?: number,
   settledExpAmt?: number
 ): string {
+  const hasFuelSettled = (settledFuelLiters ?? 0) > 0.05;
+  const hasExpSettled = (settledExpAmt ?? 0) > 0.005;
   const parts: string[] = [];
   if (km > 0) parts.push(`+${km} km`);
   if (liters > 0.05) {
-    const star = (settledFuelLiters ?? 0) > 0.05 ? "(*)" : "";
+    const star = hasFuelSettled ? " (*)" : "";
     parts.push(`−${fmtL(liters)} L${star}`);
   }
   if (expAmt > 0.005) {
-    const star = (settledExpAmt ?? 0) > 0.005 ? "(*)" : "";
+    const star = hasExpSettled ? (hasFuelSettled ? " (**)" : " (*)") : "";
     parts.push(`− € ${expAmt.toFixed(2).replace(".", ",")}${star}`);
   }
   return parts.length > 0 ? `(${parts.join(", ")})` : "";
@@ -53,23 +55,31 @@ function SettledNote({
   const fuelHas = fuelLiters > 0.05;
   const expHas = expAmt > 0.005;
   if (!fuelHas && !expHas) return null;
-  const parts: string[] = [];
-  if (fuelHas)
-    parts.push(`${fuelCount} tankbeurt${fuelCount !== 1 ? "en" : ""} (${fmtL(fuelLiters)} L)`);
-  if (expHas) parts.push(`${expCount} kost${expCount !== 1 ? "en" : ""} (${fmtMoney(expAmt)})`);
+  const expPrefix = fuelHas ? "(**)" : "(*)";
+  const noteStyle: React.CSSProperties = {
+    fontFamily: fontMono,
+    fontSize: 8,
+    color: paper.inkMute,
+    paddingLeft: 16,
+    marginTop: 4,
+    fontStyle: "italic",
+  };
   return (
-    <div
-      style={{
-        fontFamily: fontMono,
-        fontSize: 8,
-        color: paper.inkMute,
-        paddingLeft: 16,
-        marginTop: 6,
-        fontStyle: "italic",
-      }}
-    >
-      {"(*) "}
-      {parts.join(" en ")} {t("settlement.settled_outside_note")}
+    <div style={{ marginTop: 6 }}>
+      {fuelHas && (
+        <div style={noteStyle}>
+          {"(*) "}
+          {fuelCount} tankbeurt{fuelCount !== 1 ? "en" : ""} ({fmtL(fuelLiters)} L){" "}
+          {t("settlement.settled_outside_note")}
+        </div>
+      )}
+      {expHas && (
+        <div style={noteStyle}>
+          {expPrefix}{" "}
+          {expCount} kost{expCount !== 1 ? "en" : ""} ({fmtMoney(expAmt)}){" "}
+          {t("settlement.settled_outside_note")}
+        </div>
+      )}
     </div>
   );
 }
@@ -694,7 +704,7 @@ function MemberCard({
                   )}
                   {item.row.fuel_liters > 0 && (
                     <BreakdownCarRow
-                      car={`brandstof (${fmtL(item.row.fuel_liters)} L)`}
+                      car={`brandstof (${fmtL(item.row.fuel_liters)} L)${item.row.fuel_settled_liters > 0.05 ? " (*)" : ""}`}
                       detail={null}
                       amount={`+ ${fmtMoney(item.row.fuel_amount)}`}
                       amountColor={paper.green}
@@ -702,7 +712,7 @@ function MemberCard({
                   )}
                   {item.row.expense_amount > 0 && (
                     <BreakdownCarRow
-                      car="kosten"
+                      car={`kosten${item.row.expense_settled_amount > 0.005 ? (item.row.fuel_settled_liters > 0.05 ? " (**)" : " (*)") : ""}`}
                       detail={null}
                       amount={`+ ${fmtMoney(item.row.expense_amount)}`}
                       amountColor={paper.green}
@@ -741,7 +751,7 @@ function MemberCard({
                 )}
                 {era.expense_amount > 0 && (
                   <BreakdownCarRow
-                    car={`${t("settlement.breakdown_costs")}${(era.expense_settled_amount ?? 0) > 0.005 ? " (*)" : ""}`}
+                    car={`${t("settlement.breakdown_costs")}${(era.expense_settled_amount ?? 0) > 0.005 ? ((era.fuel_settled_liters ?? 0) > 0.05 ? " (**)" : " (*)") : ""}`}
                     detail={null}
                     amount={`+ ${fmtMoney(era.expense_amount)}`}
                     amountColor={paper.green}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -164,10 +164,54 @@ function ReceiptRow({
   return inner;
 }
 
+function DashboardSettledNote({
+  fuelCount,
+  fuelLiters,
+  expCount,
+  expAmt,
+}: {
+  fuelCount?: number;
+  fuelLiters?: number;
+  expCount?: number;
+  expAmt?: number;
+}) {
+  const fuelHas = (fuelLiters ?? 0) > 0.05;
+  const expHas = (expAmt ?? 0) > 0.005;
+  if (!fuelHas && !expHas) return null;
+  const expPrefix = fuelHas ? "(**)" : "(*)";
+  const noteStyle: React.CSSProperties = {
+    fontFamily: fontMono,
+    fontSize: 8,
+    color: paper.inkMute,
+    paddingLeft: 8,
+    marginTop: 3,
+    fontStyle: "italic",
+  };
+  return (
+    <div style={{ marginTop: 4 }}>
+      {fuelHas && (
+        <div style={noteStyle}>
+          {"(*) "}
+          {fuelCount} tankbeurt{fuelCount !== 1 ? "en" : ""} ({(fuelLiters ?? 0).toFixed(1)} L){" "}
+          buiten afrekening
+        </div>
+      )}
+      {expHas && (
+        <div style={noteStyle}>
+          {expPrefix}{" "}
+          {expCount} kost{expCount !== 1 ? "en" : ""} buiten afrekening
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ── Car Breakdown Section ─────────────────────────────────────────
 function CarBreakdownSection({ bd, year }: { bd: CarDashboardBreakdown; year: number }) {
   const fmtL = (l: number) => l.toFixed(0);
-  const headerLabel = `${bd.car_short} — ${bd.car_name}`;
+  const headerLabel = bd.is_own_car
+    ? `${bd.car_short} — ${bd.car_name} (Eigen wagen)`
+    : `${bd.car_short} — ${bd.car_name}`;
   const headerNet = bd.net_car;
 
   if (bd.is_own_car) {
@@ -218,7 +262,7 @@ function CarBreakdownSection({ bd, year }: { bd: CarDashboardBreakdown; year: nu
             {bd.fuel_count > 0 && (
               <ReceiptRow
                 href={`/fuel?mine=false&car=${bd.car_short}&year=${year}`}
-                label={`${bd.fuel_count} tankbeurten, ${fmtL(bd.fuel_liters)} L`}
+                label={`${bd.fuel_count} tankbeurten, ${fmtL(bd.fuel_liters)} L${(bd.fuel_settled_liters ?? 0) > 0.05 ? " (*)" : ""}`}
                 value={`− ${fmtMoney(bd.fuel_amount)}`}
                 color={paper.accent}
               />
@@ -226,11 +270,17 @@ function CarBreakdownSection({ bd, year }: { bd: CarDashboardBreakdown; year: nu
             {bd.expense_count > 0 && (
               <ReceiptRow
                 href={`/expenses?mine=false&car=${bd.car_short}&year=${year}`}
-                label={`${bd.expense_count} kosten`}
+                label={`${bd.expense_count} kosten${(bd.expense_settled_amount ?? 0) > 0.005 ? ((bd.fuel_settled_liters ?? 0) > 0.05 ? " (**)" : " (*)") : ""}`}
                 value={`− ${fmtMoney(bd.expense_amount)}`}
                 color={paper.accent}
               />
             )}
+            <DashboardSettledNote
+              fuelCount={bd.fuel_settled_count}
+              fuelLiters={bd.fuel_settled_liters}
+              expCount={bd.expense_settled_count}
+              expAmt={bd.expense_settled_amount}
+            />
           </div>
         )}
 
@@ -309,7 +359,7 @@ function CarBreakdownSection({ bd, year }: { bd: CarDashboardBreakdown; year: nu
         {bd.fuel_count > 0 && (
           <ReceiptRow
             href={`/fuel?mine=true&car=${bd.car_short}&year=${year}`}
-            label={`${bd.fuel_count} tankbeurten, ${fmtL(bd.fuel_liters)} L`}
+            label={`${bd.fuel_count} tankbeurten, ${fmtL(bd.fuel_liters)} L${(bd.fuel_settled_liters ?? 0) > 0.05 ? " (*)" : ""}`}
             value={`+ ${fmtMoney(bd.fuel_amount)}`}
             color={paper.green}
           />
@@ -317,11 +367,17 @@ function CarBreakdownSection({ bd, year }: { bd: CarDashboardBreakdown; year: nu
         {bd.expense_count > 0 && (
           <ReceiptRow
             href={`/expenses?mine=true&car=${bd.car_short}&year=${year}`}
-            label={`${bd.expense_count} kosten`}
+            label={`${bd.expense_count} kosten${(bd.expense_settled_amount ?? 0) > 0.005 ? ((bd.fuel_settled_liters ?? 0) > 0.05 ? " (**)" : " (*)") : ""}`}
             value={`+ ${fmtMoney(bd.expense_amount)}`}
             color={paper.green}
           />
         )}
+        <DashboardSettledNote
+          fuelCount={bd.fuel_settled_count}
+          fuelLiters={bd.fuel_settled_liters}
+          expCount={bd.expense_settled_count}
+          expAmt={bd.expense_settled_amount}
+        />
       </div>
     </div>
   );

--- a/lib/__tests__/queries.test.ts
+++ b/lib/__tests__/queries.test.ts
@@ -344,4 +344,60 @@ describe("getDashboard", () => {
     const rows = getDashboard(db, 2026);
     expect(rows[0].expense_count).toBe(2);
   });
+
+  it("populates fuel_settled_* on own-car others breakdown", () => {
+    const db = makeDb();
+    const ownerId = insertPerson(db, { ...basePerson, first_name: "Owner A" });
+    const memberId = insertPerson(db, { ...basePerson, first_name: "Alice" });
+    const cid = insertCar(db, { short: "JF", name: "Car JF", price_per_km: 0.25, brand: null, color: null });
+    db.prepare("UPDATE cars SET owner_person_id = ? WHERE id = ?").run(ownerId, cid);
+
+    insertFuelFillup(db, {
+      person_id: memberId, car_id: cid, date: "2026-01-10",
+      amount: 40, liters: 25, price_per_liter: null, full_tank: 0,
+      odometer: null, receipt: null, location: null, gps_coords: null,
+      settled_outside: 1,
+    });
+    insertFuelFillup(db, {
+      person_id: memberId, car_id: cid, date: "2026-01-11",
+      amount: 20, liters: 12, price_per_liter: null, full_tank: 0,
+      odometer: null, receipt: null, location: null, gps_coords: null,
+      settled_outside: 0,
+    });
+
+    const rows = getDashboard(db, 2026);
+    const ownerRow = rows.find((r) => r.person_id === ownerId)!;
+    const ownCarBd = ownerRow.car_breakdowns.find((b) => b.is_own_car)!;
+    expect(ownCarBd.fuel_settled_count).toBe(1);
+    expect(ownCarBd.fuel_settled_liters).toBeCloseTo(25);
+    expect(ownCarBd.expense_settled_count).toBe(0);
+    expect(ownCarBd.expense_settled_amount).toBeCloseTo(0);
+  });
+
+  it("populates fuel_settled_* on cross-car breakdown", () => {
+    const db = makeDb();
+    const ownerId = insertPerson(db, { ...basePerson, first_name: "Owner A" });
+    const owner2Id = insertPerson(db, { ...basePerson, first_name: "Owner B" });
+    const cid = insertCar(db, { short: "JF", name: "Car JF", price_per_km: 0.25, brand: null, color: null });
+    const cid2 = insertCar(db, { short: "LW", name: "Car LW", price_per_km: 0.25, brand: null, color: null });
+    db.prepare("UPDATE cars SET owner_person_id = ? WHERE id = ?").run(ownerId, cid);
+    db.prepare("UPDATE cars SET owner_person_id = ? WHERE id = ?").run(owner2Id, cid2);
+
+    insertTrip(db, {
+      person_id: ownerId, car_id: cid2, date: "2026-02-01",
+      start_odometer: 0, end_odometer: 100, location: null,
+    });
+    insertFuelFillup(db, {
+      person_id: ownerId, car_id: cid2, date: "2026-02-01",
+      amount: 50, liters: 30, price_per_liter: null, full_tank: 0,
+      odometer: null, receipt: null, location: null, gps_coords: null,
+      settled_outside: 1,
+    });
+
+    const rows = getDashboard(db, 2026);
+    const ownerARow = rows.find((r) => r.person_id === ownerId)!;
+    const crossBd = ownerARow.car_breakdowns.find((b) => !b.is_own_car && b.car_short === "LW")!;
+    expect(crossBd.fuel_settled_count).toBe(1);
+    expect(crossBd.fuel_settled_liters).toBeCloseTo(30);
+  });
 });

--- a/lib/queries/dashboard.ts
+++ b/lib/queries/dashboard.ts
@@ -37,6 +37,10 @@ interface OwnCarRow {
   others_fuel_amount: number;
   others_expense_count: number;
   others_expense_amount: number;
+  others_fuel_settled_count: number;
+  others_fuel_settled_liters: number;
+  others_expense_settled_count: number;
+  others_expense_settled_amount: number;
   own_trip_count: number;
   own_trip_km: number;
   own_fuel_count: number;
@@ -57,6 +61,10 @@ interface CrossCarRow {
   fuel_amount: number;
   expense_count: number;
   expense_amount: number;
+  fuel_settled_count: number;
+  fuel_settled_liters: number;
+  expense_settled_count: number;
+  expense_settled_amount: number;
 }
 
 export function getEarliestYear(db: Database.Database): number {
@@ -165,6 +173,18 @@ export function getDashboard(db: Database.Database, year: number): DashboardRow[
         COALESCE((SELECT SUM(e.amount) FROM expenses e
           WHERE e.car_id = c.id AND e.person_id != p_owner.id
             AND e.settled_outside = 0 AND strftime('%Y', e.date) = ?), 0)  AS others_expense_amount,
+        COALESCE((SELECT COUNT(*) FROM fuel_fillups f
+          WHERE f.car_id = c.id AND f.person_id != p_owner.id
+            AND f.settled_outside = 1 AND strftime('%Y', f.date) = ?), 0)  AS others_fuel_settled_count,
+        COALESCE((SELECT SUM(f.liters) FROM fuel_fillups f
+          WHERE f.car_id = c.id AND f.person_id != p_owner.id
+            AND f.settled_outside = 1 AND strftime('%Y', f.date) = ?), 0)  AS others_fuel_settled_liters,
+        COALESCE((SELECT COUNT(*) FROM expenses e
+          WHERE e.car_id = c.id AND e.person_id != p_owner.id
+            AND e.settled_outside = 1 AND strftime('%Y', e.date) = ?), 0)  AS others_expense_settled_count,
+        COALESCE((SELECT SUM(e.amount) FROM expenses e
+          WHERE e.car_id = c.id AND e.person_id != p_owner.id
+            AND e.settled_outside = 1 AND strftime('%Y', e.date) = ?), 0)  AS others_expense_settled_amount,
         COUNT(CASE WHEN t.person_id = p_owner.id THEN 1 END)               AS own_trip_count,
         COALESCE(SUM(CASE WHEN t.person_id = p_owner.id THEN t.km END), 0) AS own_trip_km,
         COALESCE((SELECT COUNT(*) FROM fuel_fillups f
@@ -184,17 +204,20 @@ export function getDashboard(db: Database.Database, year: number): DashboardRow[
       `
     )
     .all(
-      yearStr,
-      yearStr,
-      yearStr,
-      yearStr,
-      yearStr,
-      yearStr,
-      yearStr,
-      yearStr,
-      yearStr
+      yearStr, // others_fuel_count
+      yearStr, // others_fuel_liters
+      yearStr, // others_fuel_amount
+      yearStr, // others_expense_count
+      yearStr, // others_expense_amount
+      yearStr, // others_fuel_settled_count
+      yearStr, // others_fuel_settled_liters
+      yearStr, // others_expense_settled_count
+      yearStr, // others_expense_settled_amount
+      yearStr, // own_fuel_count
+      yearStr, // own_fuel_liters
+      yearStr, // own_expense_count
+      yearStr  // LEFT JOIN trips date filter
     ) as OwnCarRow[];
-  // bind count: 5 subquery params (fuel_count,liters,amount,expense_count,amount) + 2 own subqueries (fuel,expense) + 1 own expense count + 1 LEFT JOIN = 9
 
   // Owners: trips/fuel/expenses on OTHER owners' cars
   const crossCarRows = db
@@ -222,7 +245,19 @@ export function getDashboard(db: Database.Database, year: number): DashboardRow[
             AND e.settled_outside = 0 AND strftime('%Y', e.date) = ?), 0)  AS expense_count,
         COALESCE((SELECT SUM(e.amount) FROM expenses e
           WHERE e.car_id = c.id AND e.person_id = t.person_id
-            AND e.settled_outside = 0 AND strftime('%Y', e.date) = ?), 0)  AS expense_amount
+            AND e.settled_outside = 0 AND strftime('%Y', e.date) = ?), 0)  AS expense_amount,
+        COALESCE((SELECT COUNT(*) FROM fuel_fillups f
+          WHERE f.car_id = c.id AND f.person_id = t.person_id
+            AND f.settled_outside = 1 AND strftime('%Y', f.date) = ?), 0)  AS fuel_settled_count,
+        COALESCE((SELECT SUM(f.liters) FROM fuel_fillups f
+          WHERE f.car_id = c.id AND f.person_id = t.person_id
+            AND f.settled_outside = 1 AND strftime('%Y', f.date) = ?), 0)  AS fuel_settled_liters,
+        COALESCE((SELECT COUNT(*) FROM expenses e
+          WHERE e.car_id = c.id AND e.person_id = t.person_id
+            AND e.settled_outside = 1 AND strftime('%Y', e.date) = ?), 0)  AS expense_settled_count,
+        COALESCE((SELECT SUM(e.amount) FROM expenses e
+          WHERE e.car_id = c.id AND e.person_id = t.person_id
+            AND e.settled_outside = 1 AND strftime('%Y', e.date) = ?), 0)  AS expense_settled_amount
       FROM trips t
       JOIN cars c ON t.car_id = c.id
       JOIN people p_owner ON c.owner_person_id = p_owner.id
@@ -232,7 +267,7 @@ export function getDashboard(db: Database.Database, year: number): DashboardRow[
       GROUP BY t.person_id, c.id
       `
     )
-    .all(yearStr, yearStr, yearStr, yearStr, yearStr, yearStr) as CrossCarRow[];
+    .all(yearStr, yearStr, yearStr, yearStr, yearStr, yearStr, yearStr, yearStr, yearStr, yearStr) as CrossCarRow[];
 
   const ownCarByPerson = new Map<number, OwnCarRow[]>();
   for (const row of ownCarRows) {
@@ -295,6 +330,10 @@ export function getDashboard(db: Database.Database, year: number): DashboardRow[
         own_fuel_count: c.own_fuel_count,
         own_fuel_liters: c.own_fuel_liters,
         own_expense_count: c.own_expense_count,
+        fuel_settled_count: c.others_fuel_settled_count,
+        fuel_settled_liters: c.others_fuel_settled_liters,
+        expense_settled_count: c.others_expense_settled_count,
+        expense_settled_amount: c.others_expense_settled_amount,
       })),
       ...crossCars.map((c) => ({
         car_short: c.car_short,
@@ -314,6 +353,10 @@ export function getDashboard(db: Database.Database, year: number): DashboardRow[
         own_fuel_count: 0,
         own_fuel_liters: 0,
         own_expense_count: 0,
+        fuel_settled_count: c.fuel_settled_count,
+        fuel_settled_liters: c.fuel_settled_liters,
+        expense_settled_count: c.expense_settled_count,
+        expense_settled_amount: c.expense_settled_amount,
       })),
     ];
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -152,6 +152,12 @@ export interface CarDashboardBreakdown {
   own_fuel_count: number;
   own_fuel_liters: number;
   own_expense_count: number;
+
+  // Settled-outside counts (settled_outside=1, excluded from amounts above):
+  fuel_settled_count?: number;
+  fuel_settled_liters?: number;
+  expense_settled_count?: number;
+  expense_settled_amount?: number;
 }
 
 export interface DashboardRow {


### PR DESCRIPTION
## Summary
- Adds `(*)` / `(**)` markers on fuel/expense lines with `settled_outside=1` records on both settlement card and dashboard car breakdown; fuel gets `(*)`, expense gets `(**)` when both apply; separate footnote per type
- Adds "Eigen wagen" label to own-car header on dashboard
- Reorders owner settlement card: own cars (EIGEN WAGEN) shown first, cross-car usage after
- Updates markdown download and send message to include asterisk markers and footnote lines

## Test Plan
- [ ] `npm test` passes (368 tests)
- [ ] Dashboard: Malvina's JF tankbeurten line shows `(*)`, footnote `(*) 5 tankbeurten (124,0 L) buiten afrekening` appears
- [ ] Dashboard: own-car header shows `(Eigen wagen)` label
- [ ] Settlement card: fuel `(*)` / expense `(**)` when both settled; two separate footnotes
- [ ] Settlement card (owner): own car section appears before cross-car section
- [ ] Markdown download: asterisk markers + italic footnote lines present
- [ ] Send message: asterisk markers + plain-text footnote lines present

Closes #167