### PR TITLE
feat: ACL — enforce creator/car-owner/admin permissions on edit & delete

### DIFF
--- a/app/api/expenses/[id]/route.ts
+++ b/app/api/expenses/[id]/route.ts
@@ -1,18 +1,27 @@
 import { NextResponse } from "next/server";
-import { getExpenseById, updateExpense, deleteExpense, ConflictError } from "@/lib/queries/expenses";
+import {
+  getExpenseById,
+  updateExpense,
+  deleteExpense,
+  ConflictError,
+} from "@/lib/queries/expenses";
 import { expenseSchema } from "@/lib/schemas/expense";
 import { getOneHandler } from "@/lib/api/crud-handler";
-import { json, readBody, readId } from "@/lib/api";
+import { json, readBody, readId, notFound, requireCanEdit } from "@/lib/api";
 import { getDb } from "@/lib/db";
 
 export const GET = getOneHandler(getExpenseById);
 
 export const PUT = json(async (req: Request, ctx) => {
   const id = await readId(ctx);
+  const db = getDb();
+  const existing = getExpenseById(db, id);
+  if (!existing) notFound();
+  await requireCanEdit(req, existing, db);
   const data = await readBody(req, expenseSchema);
   const expectedUpdatedAt = req.headers.get("X-Expected-Updated-At") ?? undefined;
   try {
-    updateExpense(getDb(), id, data, { expectedUpdatedAt });
+    updateExpense(db, id, data, { expectedUpdatedAt });
     return NextResponse.json({ ok: true });
   } catch (e) {
     if (e instanceof ConflictError) {
@@ -22,8 +31,12 @@ export const PUT = json(async (req: Request, ctx) => {
   }
 });
 
-export const DELETE = json(async (_req: Request, ctx) => {
+export const DELETE = json(async (req: Request, ctx) => {
   const id = await readId(ctx);
-  const result = getDb().prepare("DELETE FROM expenses WHERE id = ?").run(id);
-  return NextResponse.json({ deleted: result.changes > 0 });
+  const db = getDb();
+  const existing = getExpenseById(db, id);
+  if (!existing) notFound();
+  await requireCanEdit(req, existing, db);
+  deleteExpense(db, id);
+  return NextResponse.json({ deleted: true });
 });

--- a/app/api/fuel/[id]/route.ts
+++ b/app/api/fuel/[id]/route.ts
@@ -7,17 +7,21 @@ import {
 } from "@/lib/queries/fuel-fillups";
 import { fuelFillupSchema } from "@/lib/schemas/fuel-fillup";
 import { getOneHandler } from "@/lib/api/crud-handler";
-import { json, readBody, readId } from "@/lib/api";
+import { json, readBody, readId, notFound, requireCanEdit } from "@/lib/api";
 import { getDb } from "@/lib/db";
 
 export const GET = getOneHandler(getFuelFillupById);
 
 export const PUT = json(async (req: Request, ctx) => {
   const id = await readId(ctx);
+  const db = getDb();
+  const existing = getFuelFillupById(db, id);
+  if (!existing) notFound();
+  await requireCanEdit(req, existing, db);
   const data = await readBody(req, fuelFillupSchema);
   const expectedUpdatedAt = req.headers.get("X-Expected-Updated-At") ?? undefined;
   try {
-    updateFuelFillup(getDb(), id, data, { expectedUpdatedAt });
+    updateFuelFillup(db, id, data, { expectedUpdatedAt });
     return NextResponse.json({ ok: true });
   } catch (e) {
     if (e instanceof ConflictError) {
@@ -27,8 +31,12 @@ export const PUT = json(async (req: Request, ctx) => {
   }
 });
 
-export const DELETE = json(async (_req: Request, ctx) => {
+export const DELETE = json(async (req: Request, ctx) => {
   const id = await readId(ctx);
-  const result = getDb().prepare("DELETE FROM fuel_fillups WHERE id = ?").run(id);
-  return NextResponse.json({ deleted: result.changes > 0 });
+  const db = getDb();
+  const existing = getFuelFillupById(db, id);
+  if (!existing) notFound();
+  await requireCanEdit(req, existing, db);
+  deleteFuelFillup(db, id);
+  return NextResponse.json({ deleted: true });
 });

--- a/app/api/reservations/[id]/route.ts
+++ b/app/api/reservations/[id]/route.ts
@@ -6,7 +6,7 @@ import {
   deleteReservation,
   ConflictError,
 } from "@/lib/queries/reservations";
-import { json, readBody, readId, notFound } from "@/lib/api";
+import { json, readBody, readId, notFound, requireCanEdit } from "@/lib/api";
 import { reservationSchema } from "@/lib/schemas/reservation";
 import { syncReservationUpdate, syncReservationDelete } from "@/lib/reservation-sync";
 
@@ -19,9 +19,12 @@ export const GET = json(async (_req, ctx) => {
 
 export const PUT = json(async (req, ctx) => {
   const id = await readId(ctx);
+  const db = getDb();
+  const existing = getReservationById(db, id);
+  if (!existing) notFound();
+  await requireCanEdit(req, existing, db);
   const body = await readBody(req, reservationSchema);
   const expectedUpdatedAt = req.headers.get("X-Expected-Updated-At") ?? undefined;
-  const db = getDb();
   try {
     updateReservation(db, id, body, { expectedUpdatedAt });
     syncReservationUpdate(db, id).catch(() => {});
@@ -34,9 +37,12 @@ export const PUT = json(async (req, ctx) => {
   }
 });
 
-export const DELETE = json(async (_req, ctx) => {
+export const DELETE = json(async (req, ctx) => {
   const id = await readId(ctx);
   const db = getDb();
+  const existing = getReservationById(db, id);
+  if (!existing) notFound();
+  await requireCanEdit(req, existing, db);
   await syncReservationDelete(db, id).catch(() => {});
   deleteReservation(db, id);
   return NextResponse.json({ deleted: true });

--- a/app/api/trips/[id]/route.ts
+++ b/app/api/trips/[id]/route.ts
@@ -2,17 +2,21 @@ import { NextResponse } from "next/server";
 import { getTripById, updateTrip, deleteTrip, ConflictError } from "@/lib/queries/trips";
 import { tripSchema } from "@/lib/schemas/trip";
 import { getOneHandler } from "@/lib/api/crud-handler";
-import { json, readBody, readId } from "@/lib/api";
+import { json, readBody, readId, notFound, requireCanEdit } from "@/lib/api";
 import { getDb } from "@/lib/db";
 
 export const GET = getOneHandler(getTripById);
 
 export const PUT = json(async (req: Request, ctx) => {
   const id = await readId(ctx);
+  const db = getDb();
+  const existing = getTripById(db, id);
+  if (!existing) notFound();
+  await requireCanEdit(req, existing, db);
   const data = await readBody(req, tripSchema);
-  const expectedUpdatedAt = (req as Request).headers.get("X-Expected-Updated-At") ?? undefined;
+  const expectedUpdatedAt = req.headers.get("X-Expected-Updated-At") ?? undefined;
   try {
-    updateTrip(getDb(), id, data, { expectedUpdatedAt });
+    updateTrip(db, id, data, { expectedUpdatedAt });
     return NextResponse.json({ ok: true });
   } catch (e) {
     if (e instanceof ConflictError) {
@@ -22,8 +26,12 @@ export const PUT = json(async (req: Request, ctx) => {
   }
 });
 
-export const DELETE = json(async (_req: Request, ctx) => {
+export const DELETE = json(async (req: Request, ctx) => {
   const id = await readId(ctx);
-  const result = getDb().prepare("DELETE FROM trips WHERE id = ?").run(id);
-  return NextResponse.json({ deleted: result.changes > 0 });
+  const db = getDb();
+  const existing = getTripById(db, id);
+  if (!existing) notFound();
+  await requireCanEdit(req, existing, db);
+  deleteTrip(db, id);
+  return NextResponse.json({ deleted: true });
 });

--- a/hooks/use-expenses.ts
+++ b/hooks/use-expenses.ts
@@ -101,7 +101,7 @@ export function useUpdateExpense() {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         invalidateAll(qc);
         return res.json();
-      } catch {
+      } catch (e) {
         if (typeof navigator !== "undefined" && !navigator.onLine) {
           await enqueue({
             url: `${PATH}/${id}`,
@@ -114,6 +114,8 @@ export function useUpdateExpense() {
           return {};
         }
         if (existing) applyUpdate<Expense>(qc, [QUERY_KEY], id, existing);
+        if (e instanceof Error && e.message === "HTTP 403")
+          throw new Error("No permission to update this record");
         throw new Error("Failed to update expense");
       }
     },
@@ -134,7 +136,7 @@ export function useDeleteExpense() {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         invalidateAll(qc);
         return res.json();
-      } catch {
+      } catch (e) {
         if (typeof navigator !== "undefined" && !navigator.onLine) {
           await enqueue({
             url: `${PATH}/${id}`,
@@ -146,6 +148,8 @@ export function useDeleteExpense() {
           return {};
         }
         invalidateAll(qc);
+        if (e instanceof Error && e.message === "HTTP 403")
+          throw new Error("No permission to delete this record");
         throw new Error("Failed to delete expense");
       }
     },

--- a/hooks/use-fuel-fillups.ts
+++ b/hooks/use-fuel-fillups.ts
@@ -106,7 +106,7 @@ export function useUpdateFuelFillup() {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         invalidateAll(qc);
         return res.json();
-      } catch {
+      } catch (e) {
         if (typeof navigator !== "undefined" && !navigator.onLine) {
           await enqueue({
             url: `${PATH}/${id}`,
@@ -119,6 +119,8 @@ export function useUpdateFuelFillup() {
           return {};
         }
         if (existing) applyUpdate<FuelFillup>(qc, [QUERY_KEY], id, existing);
+        if (e instanceof Error && e.message === "HTTP 403")
+          throw new Error("No permission to update this record");
         throw new Error("Failed to update fuel fillup");
       }
     },
@@ -139,7 +141,7 @@ export function useDeleteFuelFillup() {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         invalidateAll(qc);
         return res.json();
-      } catch {
+      } catch (e) {
         if (typeof navigator !== "undefined" && !navigator.onLine) {
           await enqueue({
             url: `${PATH}/${id}`,
@@ -151,6 +153,8 @@ export function useDeleteFuelFillup() {
           return {};
         }
         invalidateAll(qc);
+        if (e instanceof Error && e.message === "HTTP 403")
+          throw new Error("No permission to delete this record");
         throw new Error("Failed to delete fuel fillup");
       }
     },

--- a/hooks/use-reservations.ts
+++ b/hooks/use-reservations.ts
@@ -103,7 +103,7 @@ export function useUpdateReservation() {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         invalidateAll(qc);
         return res.json();
-      } catch {
+      } catch (e) {
         if (typeof navigator !== "undefined" && !navigator.onLine) {
           await enqueue({
             url: `${PATH}/${id}`,
@@ -116,6 +116,8 @@ export function useUpdateReservation() {
           return {};
         }
         if (existing) applyUpdate<Reservation>(qc, [QUERY_KEY], id, existing);
+        if (e instanceof Error && e.message === "HTTP 403")
+          throw new Error("No permission to update this record");
         throw new Error("Failed to update reservation");
       }
     },
@@ -136,7 +138,7 @@ export function useDeleteReservation() {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         invalidateAll(qc);
         return res.json();
-      } catch {
+      } catch (e) {
         if (typeof navigator !== "undefined" && !navigator.onLine) {
           await enqueue({
             url: `${PATH}/${id}`,
@@ -148,6 +150,8 @@ export function useDeleteReservation() {
           return {};
         }
         invalidateAll(qc);
+        if (e instanceof Error && e.message === "HTTP 403")
+          throw new Error("No permission to delete this record");
         throw new Error("Failed to delete reservation");
       }
     },

--- a/hooks/use-trips.ts
+++ b/hooks/use-trips.ts
@@ -4,7 +4,13 @@ import { toast } from "sonner";
 import { apiFetch } from "@/lib/api/client";
 import { newUuid } from "@/lib/offline/uuid";
 import { enqueue } from "@/lib/offline/outbox";
-import { applyCreate, replaceCreate, rollbackCreate, applyUpdate, applyDelete } from "@/lib/offline/optimistic";
+import {
+  applyCreate,
+  replaceCreate,
+  rollbackCreate,
+  applyUpdate,
+  applyDelete,
+} from "@/lib/offline/optimistic";
 import type { Trip, TripInput } from "@/types";
 
 const QUERY_KEY = "trips";
@@ -98,7 +104,7 @@ export function useUpdateTrip() {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         invalidateAll(qc);
         return res.json();
-      } catch {
+      } catch (e) {
         if (typeof navigator !== "undefined" && !navigator.onLine) {
           await enqueue({
             url: `${PATH}/${id}`,
@@ -112,6 +118,8 @@ export function useUpdateTrip() {
         }
         // rollback: re-apply the old values
         if (existing) applyUpdate<Trip>(qc, [QUERY_KEY], id, existing);
+        if (e instanceof Error && e.message === "HTTP 403")
+          throw new Error("No permission to update this record");
         throw new Error("Failed to update trip");
       }
     },
@@ -134,7 +142,7 @@ export function useDeleteTrip() {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         invalidateAll(qc);
         return res.json();
-      } catch {
+      } catch (e) {
         if (typeof navigator !== "undefined" && !navigator.onLine) {
           await enqueue({
             url: `${PATH}/${id}`,
@@ -146,6 +154,8 @@ export function useDeleteTrip() {
           return {};
         }
         invalidateAll(qc); // re-fetch to restore
+        if (e instanceof Error && e.message === "HTTP 403")
+          throw new Error("No permission to delete this record");
         throw new Error("Failed to delete trip");
       }
     },

--- a/lib/__tests__/api_helpers.test.ts
+++ b/lib/__tests__/api_helpers.test.ts
@@ -2,7 +2,7 @@
 // Tests for the pure/synchronous helpers in lib/api.ts
 import { describe, it, expect } from "vitest";
 import { z } from "zod";
-import { HttpError, notFound, badRequest, forbidden, readBody, readId } from "../api";
+import { HttpError, notFound, badRequest, forbidden, readBody, readId, canEdit } from "../api";
 
 describe("HttpError", () => {
   it("creates an error with the given status and message", () => {
@@ -120,5 +120,32 @@ describe("readId", () => {
   it("throws badRequest for float id", async () => {
     const ctx = { params: Promise.resolve({ id: "3.14" }) };
     await expect(readId(ctx)).rejects.toThrow(HttpError);
+  });
+});
+
+describe("canEdit", () => {
+  const record = { person_id: 2, car_id: 10 };
+  const carOwner = 5;
+
+  it("allows admin regardless of person_id", () => {
+    expect(canEdit(99, true, record, carOwner)).toBe(true);
+  });
+  it("allows admin even when car has no owner", () => {
+    expect(canEdit(99, true, record, null)).toBe(true);
+  });
+  it("allows the creator of the record", () => {
+    expect(canEdit(2, false, record, carOwner)).toBe(true);
+  });
+  it("allows the car owner", () => {
+    expect(canEdit(5, false, record, carOwner)).toBe(true);
+  });
+  it("rejects a third party", () => {
+    expect(canEdit(99, false, record, carOwner)).toBe(false);
+  });
+  it("rejects third party when car has no owner", () => {
+    expect(canEdit(99, false, record, null)).toBe(false);
+  });
+  it("still allows creator when car has no owner", () => {
+    expect(canEdit(2, false, record, null)).toBe(true);
   });
 });

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -57,6 +57,46 @@ export async function requireAdminOrOwner(req: Request) {
   return session;
 }
 
+/** Pure function. Returns true if the person may edit/delete the given record. */
+export function canEdit(
+  personId: number,
+  isAdmin: boolean,
+  record: { person_id: number; car_id: number },
+  carOwnerPersonId: number | null
+): boolean {
+  if (isAdmin) return true;
+  if (record.person_id === personId) return true;
+  if (carOwnerPersonId !== null && carOwnerPersonId === personId) return true;
+  return false;
+}
+
+/** Reads session from request; throws 403 if not authenticated (no personId). */
+export async function requireSession(req: Request) {
+  const { getIronSession } = await import("iron-session");
+  const { sessionOptions } = await import("./session");
+  const session = await getIronSession<SessionData>(req, NextResponse.next(), sessionOptions);
+  if (!session.personId) forbidden("Not authenticated");
+  return session;
+}
+
+/**
+ * Throws 403 if the session user may not edit/delete the record.
+ * Allowed: admin, record creator (person_id), or car owner (owner_person_id).
+ */
+export async function requireCanEdit(
+  req: Request,
+  record: { person_id: number; car_id: number },
+  db: import("better-sqlite3").Database
+): Promise<void> {
+  const session = await requireSession(req);
+  if (session.isAdmin) return;
+  const { getCarById } = await import("./queries/cars");
+  const car = getCarById(db, record.car_id);
+  if (!canEdit(session.personId!, false, record, car?.owner_person_id ?? null)) {
+    forbidden("Not allowed to edit this record");
+  }
+}
+
 type Handler<T> = (
   req: Request,
   ctx: { params: Promise<Record<string, string>> }


### PR DESCRIPTION
## Summary

- Add `canEdit`, `requireSession`, `requireCanEdit` helpers to `lib/api.ts`
- Enforce permissions on PUT/DELETE for trips, fuel fillups, expenses, reservations — only creator, car owner, or admin may edit/delete
- Show "No permission to update/delete this record" on 403 in mutation hooks instead of generic error

## Related

Closes #173

Follow-ups: #171 (closeModal fix), #172 (frontend read-only forms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)