### PR TITLE
Clarify Inbox section in owner guide

### DIFF
--- a/docs/owner-guide.md
+++ b/docs/owner-guide.md
@@ -9,7 +9,9 @@ This guide covers the admin-only pages available to car sharing owners.
 
 ## 1. Inbox
 
-The Inbox collects items that require your attention — primarily **reservation requests** from members, and **odometer gap warnings** where trip odometer readings don't line up.
+The Inbox collects items that require your attention — primarily :
+- **reservation requests** from members for your car(s), only you and admin can confirm these
+- and **odometer gap warnings** for your car(s)  _note: gap = when trip odometer readings don't line up previous and next_
 
 ![Inbox page full view](screenshots/owner-100-inbox.png)
 


### PR DESCRIPTION
Clarified the description of the Inbox section, specifying that it collects reservation requests and odometer gap warnings for cars.