### PR TITLE
feat(admin): show gap subtotals per year and in section header

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -31,11 +31,14 @@ function groupByYear<T extends { date?: string; after_date?: string }>(
   return Array.from(map.entries()).sort((a, b) => b[0].localeCompare(a[0]));
 }
 
-function YearGroup({ year, children }: { year: string; children: React.ReactNode }) {
+function YearGroup({ year, count, children }: { year: string; count: number; children: React.ReactNode }) {
   return (
     <div style={{ marginBottom: 4 }}>
       <div
         style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "baseline",
           fontFamily: fontMono,
           fontSize: 9,
           fontWeight: 700,
@@ -47,7 +50,8 @@ function YearGroup({ year, children }: { year: string; children: React.ReactNode
           marginBottom: 6,
         }}
       >
-        {year}
+        <span>{year}</span>
+        <span>{count}</span>
       </div>
       {children}
     </div>
@@ -366,7 +370,7 @@ export default function AdminInboxPage() {
         </div>
       ) : (
         gapsByYear.map(([yr, items]) => (
-          <YearGroup key={yr} year={yr}>
+          <YearGroup key={yr} year={yr} count={items.length}>
             {items.map((gap) => {
               const key = gapKey(gap);
               const expanded = expandedGap === key;

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -31,7 +31,8 @@ function groupByYear<T extends { date?: string; after_date?: string }>(
   return Array.from(map.entries()).sort((a, b) => b[0].localeCompare(a[0]));
 }
 
-function YearGroup({ year, count, children }: { year: string; count: number; children: React.ReactNode }) {
+function YearGroup({ year, count, totalKm, children }: { year: string; count: number; totalKm: number; children: React.ReactNode }) {
+  const t = useT();
   return (
     <div style={{ marginBottom: 4 }}>
       <div
@@ -51,7 +52,7 @@ function YearGroup({ year, count, children }: { year: string; count: number; chi
         }}
       >
         <span>{year}</span>
-        <span>{count}</span>
+        <span>{count} {t("admin.gaps_noun")} · {totalKm.toLocaleString("nl-BE")} km</span>
       </div>
       {children}
     </div>
@@ -62,11 +63,13 @@ function SectionHeader({
   label,
   count,
   countSuffix,
+  totalKm,
   isLoading,
 }: {
   label: string;
   count: number;
   countSuffix: string;
+  totalKm?: number;
   isLoading?: boolean;
 }) {
   return (
@@ -91,7 +94,7 @@ function SectionHeader({
       ) : (
         count > 0 && (
           <span style={{ color: paper.accent }}>
-            {count} {countSuffix}
+            {count} {countSuffix}{totalKm != null ? ` · ${totalKm.toLocaleString("nl-BE")} km` : ""}
           </span>
         )
       )}
@@ -345,7 +348,8 @@ export default function AdminInboxPage() {
       <SectionHeader
         label={t("admin.km_gaps_title")}
         count={gaps.length}
-        countSuffix={t("admin.gaps_count")}
+        countSuffix={t("admin.gaps_noun")}
+        totalKm={gaps.reduce((s, g) => s + g.missing_km, 0)}
         isLoading={isAdminLoading}
       />
 
@@ -370,7 +374,7 @@ export default function AdminInboxPage() {
         </div>
       ) : (
         gapsByYear.map(([yr, items]) => (
-          <YearGroup key={yr} year={yr} count={items.length}>
+          <YearGroup key={yr} year={yr} count={items.length} totalKm={items.reduce((s, g) => s + g.missing_km, 0)}>
             {items.map((gap) => {
               const key = gapKey(gap);
               const expanded = expandedGap === key;

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -326,6 +326,7 @@ export const en: Messages = {
   "admin.km_missing": "{km} km missing",
   "admin.km_missing_suffix": "km missing",
   "admin.gaps_count": "missing",
+  "admin.gaps_noun": "gaps",
   "admin.after_trip": "After trip {date}: end {odometer}",
   "admin.before_trip": "Before trip {date}: start {odometer}",
   "admin.trip_ref": "Trip ID #{a} → #{b}",

--- a/lib/i18n/messages/nl.ts
+++ b/lib/i18n/messages/nl.ts
@@ -324,6 +324,7 @@ export const nl = {
   "admin.km_missing": "{km} km ontbreekt",
   "admin.km_missing_suffix": "km ontbreekt",
   "admin.gaps_count": "ontbreekt",
+  "admin.gaps_noun": "gaten",
   "admin.after_trip": "Na rit {date}: eind {odometer}",
   "admin.before_trip": "Voor rit {date}: start {odometer}",
   "admin.trip_ref": "Rit-ID #{a} → #{b}",


### PR DESCRIPTION
## Summary
- Year header in odometer gaps section now shows gap count + total missing km: `N gaten · X km`
- Section header total also updated to same format: `N gaten · X km`
- Added `admin.gaps_noun` i18n key (`gaten` / `gaps`)

## Test plan
- [ ] Go to http://localhost:3194/admin (Inbox tab)
- [ ] Scroll to "Gaten in kilometerstand" — section header shows total count + km
- [ ] Each year group header shows count + km right-aligned

Closes #194