### PR TITLE
fix(api): POST routes return full record — fix crash after saving trip/fuel/expense

### DIFF
--- a/app/api/expenses/route.ts
+++ b/app/api/expenses/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getExpenses, insertExpense } from "@/lib/queries/expenses";
+import { getExpenses, getExpenseById, insertExpense } from "@/lib/queries/expenses";
 import { expenseSchema } from "@/lib/schemas/expense";
 import { listHandler } from "@/lib/api/crud-handler";
 import { json } from "@/lib/api";
@@ -11,6 +11,7 @@ export const POST = json(async (req: Request) => {
   const raw = await req.json();
   const data = expenseSchema.parse(raw);
   const client_id = typeof raw.client_id === "string" ? raw.client_id : null;
-  const id = insertExpense(getDb(), { ...data, client_id });
-  return NextResponse.json({ id }, { status: 201 });
+  const db = getDb();
+  const id = insertExpense(db, { ...data, client_id });
+  return NextResponse.json(getExpenseById(db, id), { status: 201 });
 });

--- a/app/api/fuel/route.ts
+++ b/app/api/fuel/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getFuelFillups, insertFuelFillup } from "@/lib/queries/fuel-fillups";
+import { getFuelFillups, getFuelFillupById, insertFuelFillup } from "@/lib/queries/fuel-fillups";
 import { fuelFillupSchema } from "@/lib/schemas/fuel-fillup";
 import { listHandler } from "@/lib/api/crud-handler";
 import { json } from "@/lib/api";
@@ -11,6 +11,7 @@ export const POST = json(async (req: Request) => {
   const raw = await req.json();
   const data = fuelFillupSchema.parse(raw);
   const client_id = typeof raw.client_id === "string" ? raw.client_id : null;
-  const id = insertFuelFillup(getDb(), { ...data, client_id });
-  return NextResponse.json({ id }, { status: 201 });
+  const db = getDb();
+  const id = insertFuelFillup(db, { ...data, client_id });
+  return NextResponse.json(getFuelFillupById(db, id), { status: 201 });
 });

--- a/app/api/trips/route.ts
+++ b/app/api/trips/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
-import { getTrips, insertTrip } from "@/lib/queries/trips";
+import { getTrips, getTripById, insertTrip } from "@/lib/queries/trips";
 import { tripSchema } from "@/lib/schemas/trip";
 import { listHandler } from "@/lib/api/crud-handler";
-import { json, readBody } from "@/lib/api";
+import { json } from "@/lib/api";
 import { getDb } from "@/lib/db";
 
 export const GET = listHandler(getTrips);
@@ -11,6 +11,7 @@ export const POST = json(async (req: Request) => {
   const raw = await req.json();
   const data = tripSchema.parse(raw);
   const client_id = typeof raw.client_id === "string" ? raw.client_id : null;
-  const id = insertTrip(getDb(), { ...data, client_id });
-  return NextResponse.json({ id }, { status: 201 });
+  const db = getDb();
+  const id = insertTrip(db, { ...data, client_id });
+  return NextResponse.json(getTripById(db, id), { status: 201 });
 });


### PR DESCRIPTION
Fixes #185

## Summary
- `POST /api/trips`, `POST /api/fuel`, `POST /api/expenses` all returned only `{ id }`
- Hooks cast the response as the full type and called `replaceCreate`, putting `{ id, date: undefined, ... }` into the React Query cache
- On the next render, `trip.date.slice(0, 7)` (and similar calls) crashed with "Cannot read properties of undefined (reading 'slice')"
- Fix: return the full record immediately after insert via the existing `getTripById` / `getFuelFillupById` / `getExpenseById` functions, reusing the same db handle

## Test Plan
- [ ] Save a new trip — list updates without crash, new trip appears with correct date/name/car
- [ ] Save a new fuel fillup — same
- [ ] Save a new expense — same
- [ ] All 377 unit tests pass