### PR TITLE
fix(admin): sort odometer gaps descending (most recent first)

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -28,7 +28,14 @@ function groupByYear<T extends { date?: string; after_date?: string }>(
     if (!map.has(year)) map.set(year, []);
     map.get(year)!.push(item);
   }
-  return Array.from(map.entries()).sort((a, b) => b[0].localeCompare(a[0]));
+  return Array.from(map.entries())
+    .sort((a, b) => b[0].localeCompare(a[0]))
+    .map(([yr, bucket]) => [
+      yr,
+      [...bucket].sort((a, b) =>
+        (b.after_date ?? b.date ?? "").localeCompare(a.after_date ?? a.date ?? "")
+      ),
+    ] as [string, T[]]);
 }
 
 function YearGroup({ year, count, totalKm, children }: { year: string; count: number; totalKm: number; children: React.ReactNode }) {


### PR DESCRIPTION
## Summary
- Gaps within each year group now show most recent first
- `groupByYear` sorts items within each bucket by `after_date` DESC (years were already sorted DESC, items weren't)

## Test plan
- [ ] Go to http://localhost:3192/admin (or prod) → Inbox tab → "Gaten in kilometerstand"
- [ ] Most recent gap in each year appears at the top

Closes #192