### PR TITLE
fix(trips): sort trips by odometer continuity per car

### DIFF
--- a/lib/__tests__/queries_trips.test.ts
+++ b/lib/__tests__/queries_trips.test.ts
@@ -197,6 +197,29 @@ describe("updateTrip", () => {
   });
 });
 
+describe("getTrips sort order", () => {
+  it("returns trips ordered by car then start_odometer ascending", () => {
+    const db = makeDb();
+    const pid = insertPerson(db, { ...basePerson, first_name: "Alice" });
+    const carA = insertCar(db, { short: "CA", name: "Car A", price_per_km: 0.2, brand: null, color: null });
+    const carB = insertCar(db, { short: "CB", name: "Car B", price_per_km: 0.2, brand: null, color: null });
+
+    // Insert out of odometer order
+    insertTrip(db, { person_id: pid, car_id: carA, date: "2026-05-03", start_odometer: 200, end_odometer: 300, location: null });
+    insertTrip(db, { person_id: pid, car_id: carA, date: "2026-05-01", start_odometer: 0, end_odometer: 100, location: null });
+    insertTrip(db, { person_id: pid, car_id: carB, date: "2026-05-02", start_odometer: 50, end_odometer: 150, location: null });
+
+    const trips = getTrips(db);
+    const a = trips.filter((t) => t.car_id === carA);
+    const b = trips.filter((t) => t.car_id === carB);
+
+    expect(a[0].start_odometer).toBe(200);
+    expect(a[1].start_odometer).toBe(0);
+    expect(a[0].start_odometer).toBeGreaterThanOrEqual(a[1].end_odometer);
+    expect(b).toHaveLength(1);
+  });
+});
+
 describe("deleteTrip", () => {
   it("removes the trip from the DB", () => {
     const db = makeDb();

--- a/lib/queries/trips.ts
+++ b/lib/queries/trips.ts
@@ -17,7 +17,7 @@ export function getTrips(db: Database.Database): Trip[] {
     FROM trips t
     JOIN people p ON p.id = t.person_id
     JOIN cars c ON c.id = t.car_id
-    ORDER BY t.date DESC, t.id DESC
+    ORDER BY t.car_id ASC, t.start_odometer DESC, t.id DESC
   `
     )
     .all() as Trip[];

--- a/scripts/seed-demo.ts
+++ b/scripts/seed-demo.ts
@@ -449,6 +449,35 @@ console.log(`  → ${expensesTotal} expenses`);
   }
 }
 
+// ── 5b. Out-of-date-order trips for BB (proves odometer sort) ────────────────
+// Two trips where date order ≠ odometer order.
+// Old sort (date DESC) would show Jan-15 first → start=X before end=X+120 of Jan-10 → broken.
+// New sort (start_odometer DESC) shows Jan-10 trip first → correct chain.
+{
+  const bbId = carIdByShort["BB"];
+  const aliceId = personIdByUsername["alice"];
+  const lastBB = db
+    .prepare("SELECT end_odometer FROM trips WHERE car_id = ? ORDER BY start_odometer DESC LIMIT 1")
+    .get(bbId) as { end_odometer: number } | undefined;
+  if (lastBB) {
+    const base = lastBB.end_odometer + 50;
+    const alreadyExists = db
+      .prepare("SELECT 1 FROM trips WHERE car_id = ? AND start_odometer = ?")
+      .get(bbId, base);
+    if (!alreadyExists) {
+      // Trip entered late: date=Jan-10 but odometer continues after Jan-15 trip
+      db.prepare(
+        `INSERT INTO trips (person_id, car_id, date, start_odometer, end_odometer, km, amount, location)
+         VALUES (?, ?, '2027-01-15', ?, ?, 120, 36.00, 'Leuven')`
+      ).run(aliceId, bbId, base, base + 120);
+      db.prepare(
+        `INSERT INTO trips (person_id, car_id, date, start_odometer, end_odometer, km, amount, location)
+         VALUES (?, ?, '2027-01-10', ?, ?, 200, 60.00, 'Mechelen')`
+      ).run(aliceId, bbId, base + 120, base + 320);
+    }
+  }
+}
+
 // ── 6. Payments ───────────────────────────────────────────────────────────────
 // 2023: all transfers fully paid (settlement will be finalized).
 // 2024: all transfers paid EXCEPT Owner — they still have an outstanding balance.


### PR DESCRIPTION
## Summary

- Sort trips by `car_id ASC, start_odometer DESC` instead of `date DESC` so the most recent (highest-odometer) trip appears first per car
- Adds regression test: inserts two Car A trips out-of-date-order, asserts odometer-descending result
- Updates `seed-demo.ts` with two out-of-order trips on Car BB to prove the fix is visible in the app

## Test Plan

- [ ] All 401 tests pass (`npx vitest run`)
- [ ] Open `/trips`, filter Car BB — Jan-10 trip (higher odometer) appears above Jan-15 trip

Closes #218