### PR TITLE
fix(theme): make mono the default theme for all users

### DIFF
--- a/lib/__tests__/migration_0004.test.ts
+++ b/lib/__tests__/migration_0004.test.ts
@@ -39,6 +39,7 @@ describe("migration 0004 — car owner era", () => {
       INSERT INTO _migrations (filename) VALUES ('0016_cars_drop_owner_name.sql');
       INSERT INTO _migrations (filename) VALUES ('0017_drop_people_name.sql');
       INSERT INTO _migrations (filename) VALUES ('0018_people_theme_preference.sql');
+      INSERT INTO _migrations (filename) VALUES ('0019_default_theme_mono.sql');
     `);
     runMigrations(db2);
     const car = db2.prepare("SELECT owner_from FROM cars WHERE short = 'XX'").get() as {

--- a/lib/__tests__/queries_people.test.ts
+++ b/lib/__tests__/queries_people.test.ts
@@ -152,6 +152,42 @@ describe("insertPerson", () => {
   });
 });
 
+describe("theme_preference default", () => {
+  it("new person without explicit theme gets mono", () => {
+    const db = makeDb();
+    const id = insertPerson(db, {
+      ...basePerson,
+      first_name: "Alice",
+      theme_preference: undefined as unknown as "mono",
+    });
+    const row = db.prepare("SELECT theme_preference FROM people WHERE id=?").get(id) as any;
+    expect(row.theme_preference).toBe("mono");
+  });
+
+  it("migration 0019 converts existing paper rows to mono", () => {
+    // Run only migrations up to 0018 so we can insert a 'paper' row before 0019 runs
+    const db = new Database(":memory:");
+    db.pragma("foreign_keys = ON");
+    const { readdirSync, readFileSync } = require("fs");
+    const path = require("path");
+    const migrationsDir = path.join(process.cwd(), "migrations");
+    db.exec(`CREATE TABLE IF NOT EXISTS _migrations (id INTEGER PRIMARY KEY AUTOINCREMENT, filename TEXT NOT NULL UNIQUE, applied_at TEXT NOT NULL DEFAULT (datetime('now')))`);
+    const files = readdirSync(migrationsDir).filter((f: string) => f.endsWith(".sql") && f <= "0018_people_theme_preference.sql").sort();
+    for (const f of files) {
+      db.pragma("foreign_keys = OFF");
+      db.exec(readFileSync(path.join(migrationsDir, f), "utf-8"));
+      db.pragma("foreign_keys = ON");
+      db.prepare("INSERT INTO _migrations (filename) VALUES (?)").run(f);
+    }
+    // Insert legacy 'paper' row before migration 0019
+    db.prepare("INSERT INTO people (first_name, last_name, discount, discount_long, active, bank_account, theme_preference) VALUES ('Legacy','User',0,0,1,'','paper')").run();
+    // Apply remaining migrations (0019)
+    runMigrations(db);
+    const row = db.prepare("SELECT theme_preference FROM people WHERE first_name='Legacy'").get() as any;
+    expect(row.theme_preference).toBe("mono");
+  });
+});
+
 describe("updatePerson", () => {
   it("updates person fields", () => {
     const db = makeDb();

--- a/lib/queries/people.ts
+++ b/lib/queries/people.ts
@@ -49,7 +49,7 @@ export function insertPerson(
       data.is_admin ?? 0,
       data.bank_account ?? "",
       data.email ?? null,
-      data.theme_preference ?? "paper"
+      data.theme_preference ?? "mono"
     );
   return result.lastInsertRowid as number;
 }
@@ -71,7 +71,7 @@ export function updatePerson(
     data.is_admin ?? 0,
     data.bank_account ?? "",
     data.email ?? null,
-    data.theme_preference ?? "paper",
+    data.theme_preference ?? "mono",
     id
   );
 }

--- a/migrations/0019_default_theme_mono.sql
+++ b/migrations/0019_default_theme_mono.sql
@@ -1,0 +1,1 @@
+UPDATE people SET theme_preference = 'mono' WHERE theme_preference = 'paper';


### PR DESCRIPTION
## Summary

- Migration 0019 converts all existing `theme_preference = 'paper'` rows to `'mono'`
- `insertPerson` / `updatePerson` fallback changed from `"paper"` to `"mono"` for new users
- Adds regression tests: new user default and migration backfill

## Test Plan

- [ ] 402 tests pass (`npx vitest run`)
- [ ] Login as any user — mono theme active by default
- [ ] Profile edit page — theme selector shows mono selected

Closes #183