### PR TITLE
fix(modal): close edit form opened via direct URL without navigating away

### DIFF
--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -130,6 +130,9 @@ function CalendarContent() {
       ? (reservations.find((r) => r.id === Number(editIdParam)) ?? null)
       : null;
 
+  const [sheetClosed, setSheetClosed] = useState(false);
+  useEffect(() => { setSheetClosed(false); }, [editIdParam, actionParam]);
+
   // Refetch reservations whenever the new-reservation sheet opens online —
   // the conflict warning needs to see the freshest server state.
   const qc = useQueryClient();
@@ -165,7 +168,10 @@ function CalendarContent() {
     router.push(`${pathname}?${params.toString()}`, { scroll: false });
   };
 
-  const closeSheet = () => router.back();
+  const closeSheet = () => {
+    setSheetClosed(true);
+    window.history.replaceState(null, "", pathname);
+  };
 
   const openAdd = () => {
     setPrefillCarId(undefined);
@@ -307,7 +313,7 @@ function CalendarContent() {
       <Fab onClick={openAdd} label={t("page.reservation_add")} />
 
       {/* Add sheet */}
-      <BottomSheet open={sheet === "add"} onClose={() => closeSheet()}>
+      <BottomSheet open={sheet === "add" && !sheetClosed} onClose={() => closeSheet()}>
         <ReservationForm
           defaultValues={
             prefillCarId !== undefined
@@ -332,7 +338,7 @@ function CalendarContent() {
       </BottomSheet>
 
       {/* Edit sheet */}
-      <BottomSheet open={sheet === "edit" && !!editing} onClose={() => closeSheet()}>
+      <BottomSheet open={sheet === "edit" && !!editing && !sheetClosed} onClose={() => closeSheet()}>
         {editing && (
           <>
             <ReservationForm

--- a/app/expenses/page.tsx
+++ b/app/expenses/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Suspense } from "react";
+import { Suspense, useState, useEffect } from "react";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import { toast } from "sonner";
 import * as Dialog from "@radix-ui/react-dialog";
@@ -68,6 +68,9 @@ function ExpensesContent() {
   const editing =
     !isLoading && editingId ? (expenses.find((e) => e.id === editingId) ?? null) : null;
 
+  const [modalClosed, setModalClosed] = useState(false);
+  useEffect(() => { setModalClosed(false); }, [editingId]);
+
   const isMine = mineParam === "true";
   const isOthers = mineParam === "false";
   const canFilter = me?.personId != null;
@@ -99,7 +102,10 @@ function ExpensesContent() {
     router.push(`${pathname}?${params.toString()}`, { scroll: false });
   };
 
-  const closeModal = () => router.back();
+  const closeModal = () => {
+    setModalClosed(true);
+    window.history.replaceState(null, "", pathname);
+  };
 
   const filterBtnStyle = (active: boolean): React.CSSProperties =>
     mono
@@ -269,7 +275,7 @@ function ExpensesContent() {
       </Dialog.Root>
 
       <Dialog.Root
-        open={!!editing}
+        open={!!editing && !modalClosed}
         onOpenChange={(open) => {
           if (!open) closeModal();
         }}

--- a/app/fuel/page.tsx
+++ b/app/fuel/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Suspense } from "react";
+import { Suspense, useState, useEffect } from "react";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import { toast } from "sonner";
 import * as Dialog from "@radix-ui/react-dialog";
@@ -68,6 +68,9 @@ function FuelContent() {
   const editing =
     !isLoading && editingId ? (fillups.find((f) => f.id === editingId) ?? null) : null;
 
+  const [modalClosed, setModalClosed] = useState(false);
+  useEffect(() => { setModalClosed(false); }, [editingId]);
+
   const isMine = mineParam === "true";
   const isOthers = mineParam === "false";
   const canFilter = me?.personId != null;
@@ -99,7 +102,10 @@ function FuelContent() {
     router.push(`${pathname}?${params.toString()}`, { scroll: false });
   };
 
-  const closeModal = () => router.back();
+  const closeModal = () => {
+    setModalClosed(true);
+    window.history.replaceState(null, "", pathname);
+  };
 
   const filterBtnStyle = (active: boolean): React.CSSProperties =>
     mono
@@ -269,7 +275,7 @@ function FuelContent() {
       </Dialog.Root>
 
       <Dialog.Root
-        open={!!editing}
+        open={!!editing && !modalClosed}
         onOpenChange={(open) => {
           if (!open) closeModal();
         }}

--- a/app/trips/page.tsx
+++ b/app/trips/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Suspense } from "react";
+import { Suspense, useState, useEffect } from "react";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import { toast } from "sonner";
 import * as Dialog from "@radix-ui/react-dialog";
@@ -65,6 +65,9 @@ function TripsContent() {
   const editing =
     !isLoading && editingId ? (trips.find((tr) => tr.id === editingId) ?? null) : null;
 
+  const [modalClosed, setModalClosed] = useState(false);
+  useEffect(() => { setModalClosed(false); }, [editingId]);
+
   const isMine = mineParam === "true";
   const isOthers = mineParam === "false";
   const canFilter = me?.personId != null;
@@ -96,7 +99,10 @@ function TripsContent() {
     router.push(`${pathname}?${params.toString()}`, { scroll: false });
   };
 
-  const closeModal = () => router.back();
+  const closeModal = () => {
+    setModalClosed(true);
+    window.history.replaceState(null, "", pathname);
+  };
 
   const filterBtnStyle = (active: boolean): React.CSSProperties =>
     mono
@@ -266,7 +272,7 @@ function TripsContent() {
       </Dialog.Root>
 
       <Dialog.Root
-        open={!!editing}
+        open={!!editing && !modalClosed}
         onOpenChange={(open) => {
           if (!open) closeModal();
         }}

--- a/e2e/direct-url-edit.spec.ts
+++ b/e2e/direct-url-edit.spec.ts
@@ -1,0 +1,141 @@
+import { test, expect } from "@playwright/test";
+import { loginAndGetCsrf, loginAndGetSession, makeApi, getTestEntities } from "./helpers";
+
+/**
+ * Regression test for issue #171:
+ * Closing an edit form opened via direct URL (?edit=<id>) should stay on the
+ * current page — not navigate away via router.back() into browser history.
+ */
+
+const TODAY = new Date().toISOString().slice(0, 10);
+const START_ODO = 888_800;
+const END_ODO = 888_842;
+const LOCATION = "E2E-DirectUrl-Test";
+
+test.describe("direct URL edit — close stays on page", () => {
+  let csrf: string;
+  let api: ReturnType<typeof makeApi>;
+  let tripId: number;
+  let personId: number;
+  let carId: number;
+
+  test.beforeEach(async ({ request }) => {
+    const session = await loginAndGetSession(request);
+    csrf = session.csrf;
+    api = makeApi(request, csrf);
+    const entities = await getTestEntities(api);
+    personId = session.personId ?? entities.personId;
+    carId = entities.carId;
+
+    const res = await api.post<{ id: number }>("/api/trips", {
+      person_id: personId,
+      car_id: carId,
+      date: TODAY,
+      start_odometer: START_ODO,
+      end_odometer: END_ODO,
+      location: LOCATION,
+    });
+    tripId = res.id;
+  });
+
+  test.afterEach(async ({ request }) => {
+    if (!tripId) return;
+    try {
+      const cleanupCsrf = await loginAndGetCsrf(request);
+      await makeApi(request, cleanupCsrf).delete(`/api/trips/${tripId}`);
+    } catch {
+      // already deleted
+    }
+  });
+
+  test("closing edit form opened via direct URL stays on /trips", async ({ page }) => {
+    await page.request.post("/api/auth/login", {
+      data: { username: process.env.TEST_EMAIL ?? "alice", password: process.env.TEST_PASSWORD ?? "alice" },
+    });
+    // Navigate directly to the edit URL — no prior history
+    await page.goto(`/trips?edit=${tripId}`);
+    await page.waitForLoadState("networkidle");
+
+    // Edit form should be open
+    await expect(page.locator("form")).toBeVisible({ timeout: 10_000 });
+
+    // Click the × close button
+    await page.locator('button[aria-label="Sluiten"], button[aria-label="Close"]').first().click();
+
+    // Form must be gone and URL must stay on /trips
+    await expect(page.locator("form")).not.toBeVisible({ timeout: 5_000 });
+    await expect(page).toHaveURL(/^[^?]*\/trips$/, { timeout: 5_000 });
+  });
+
+  test("saving edit form opened via direct URL closes form and stays on /trips", async ({ page }) => {
+    await page.request.post("/api/auth/login", {
+      data: { username: process.env.TEST_EMAIL ?? "alice", password: process.env.TEST_PASSWORD ?? "alice" },
+    });
+    await page.goto(`/trips?edit=${tripId}`);
+    await page.waitForLoadState("networkidle");
+    await expect(page.locator("form")).toBeVisible({ timeout: 10_000 });
+
+    // Submit without changes — just press Save
+    await page.locator('button[type="submit"]').click();
+
+    // Form must close, toast shown, URL stays on /trips without ?edit=
+    await expect(page.locator("form")).not.toBeVisible({ timeout: 8_000 });
+    await expect(page).toHaveURL(/^[^?]*\/trips$/, { timeout: 5_000 });
+  });
+
+  test("closing edit form opened via direct URL stays on /fuel", async ({ page, request }) => {
+    const fuelCsrf = await loginAndGetCsrf(request);
+    const fuelApi = makeApi(request, fuelCsrf);
+    const entities = await getTestEntities(fuelApi);
+
+    const fuel = await fuelApi.post<{ id: number }>("/api/fuel", {
+      person_id: entities.personId,
+      car_id: entities.carId,
+      date: TODAY,
+      amount: 50,
+      liters: 30,
+      full_tank: 0,
+      settled_outside: 0,
+    });
+
+    await page.request.post("/api/auth/login", {
+      data: { username: process.env.TEST_EMAIL ?? "alice", password: process.env.TEST_PASSWORD ?? "alice" },
+    });
+    await page.goto(`/fuel?edit=${fuel.id}`);
+    await page.waitForLoadState("networkidle");
+    await expect(page.locator("form")).toBeVisible({ timeout: 10_000 });
+
+    await page.locator('button[aria-label="Sluiten"], button[aria-label="Close"]').first().click();
+    await expect(page).toHaveURL(/\/fuel/, { timeout: 5_000 });
+
+    // cleanup
+    try { await fuelApi.delete(`/api/fuel/${fuel.id}`); } catch { /**/ }
+  });
+
+  test("closing edit form opened via direct URL stays on /expenses", async ({ page, request }) => {
+    const expCsrf = await loginAndGetCsrf(request);
+    const expApi = makeApi(request, expCsrf);
+    const entities = await getTestEntities(expApi);
+
+    const exp = await expApi.post<{ id: number }>("/api/expenses", {
+      person_id: entities.personId,
+      car_id: entities.carId,
+      date: TODAY,
+      amount: 25,
+      description: "E2E-DirectUrl-Expense",
+      category: "diversen",
+    });
+
+    await page.request.post("/api/auth/login", {
+      data: { username: process.env.TEST_EMAIL ?? "alice", password: process.env.TEST_PASSWORD ?? "alice" },
+    });
+    await page.goto(`/expenses?edit=${exp.id}`);
+    await page.waitForLoadState("networkidle");
+    await expect(page.locator("form")).toBeVisible({ timeout: 10_000 });
+
+    await page.locator('button[aria-label="Sluiten"], button[aria-label="Close"]').first().click();
+    await expect(page).toHaveURL(/\/expenses/, { timeout: 5_000 });
+
+    try { await expApi.delete(`/api/expenses/${exp.id}`); } catch { /**/ }
+  });
+});

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -13,6 +13,14 @@ export async function loginAndGetCsrf(
   email = process.env.TEST_EMAIL ?? "test@example.com",
   password = process.env.TEST_PASSWORD ?? "changeme"
 ): Promise<string> {
+  return (await loginAndGetSession(request, email, password)).csrf;
+}
+
+export async function loginAndGetSession(
+  request: APIRequestContext,
+  email = process.env.TEST_EMAIL ?? "test@example.com",
+  password = process.env.TEST_PASSWORD ?? "changeme"
+): Promise<{ csrf: string; personId: number | null }> {
   const res = await request.post("/api/auth/login", {
     data: { username: email, password },
   });
@@ -20,16 +28,13 @@ export async function loginAndGetCsrf(
     throw new Error(`Login failed: ${res.status()} ${await res.text()}`);
   }
 
-  // Read the csrf-token cookie that is set by /api/me (GET) — the login
-  // response itself doesn't write it, but the GET call after login does.
-  // Trigger it now so the cookie is present.
   const meRes = await request.get("/api/me");
+  const meBody = await meRes.json() as { personId?: number | null };
   const cookies = await meRes.headersArray();
-  // The csrf-token is set as a cookie — extract it from Set-Cookie
   for (const h of cookies) {
     if (h.name.toLowerCase() === "set-cookie") {
       const m = h.value.match(/csrf-token=([^;]+)/);
-      if (m) return decodeURIComponent(m[1]);
+      if (m) return { csrf: decodeURIComponent(m[1]), personId: meBody.personId ?? null };
     }
   }
 


### PR DESCRIPTION
Fixes #171

## Summary

- Replace `router.back()` with `window.history.replaceState(null, '', pathname)` + `modalClosed` local state in trips, fuel, expenses, and calendar pages
- `modalClosed` state closes the dialog immediately (synchronously) while the URL is cleaned up via the browser history API
- `useEffect` resets `modalClosed` when `editIdParam` changes so re-opening works correctly

## Test Plan

- [x] Regression tests added: `e2e/direct-url-edit.spec.ts` — 4 tests covering close and save on trips, fuel, expenses
- [x] All 4 tests pass against prod build
- [ ] Manual test: open `/trips?edit=<id>`, `/fuel?edit=<id>`, `/expenses?edit=<id>`, `/calendar?edit=<id>` directly — click × — form closes, stays on page, URL cleaned up