### PR TITLE
fix(trips): sort by date DESC instead of car_id ASC

### DIFF
--- a/lib/queries/trips.ts
+++ b/lib/queries/trips.ts
@@ -17,7 +17,7 @@ export function getTrips(db: Database.Database): Trip[] {
     FROM trips t
     JOIN people p ON p.id = t.person_id
     JOIN cars c ON c.id = t.car_id
-    ORDER BY t.car_id ASC, t.start_odometer DESC, t.id DESC
+    ORDER BY t.date DESC, t.id DESC
   `
     )
     .all() as Trip[];
@@ -55,9 +55,9 @@ function compute(db: Database.Database, input: TripInput) {
 export function insertTrip(db: Database.Database, input: TripInput): number {
   // Idempotency: if a client_id is provided and already exists, return that row's id.
   if (input.client_id) {
-    const existing = db
-      .prepare("SELECT id FROM trips WHERE client_id = ?")
-      .get(input.client_id) as { id: number } | undefined;
+    const existing = db.prepare("SELECT id FROM trips WHERE client_id = ?").get(input.client_id) as
+      | { id: number }
+      | undefined;
     if (existing) return existing.id;
   }
   const { km, amount } = compute(db, input);


### PR DESCRIPTION
## Summary

- `getTrips` query was ordering by `car_id ASC` first, causing the car with the lowest ID (ETH) to dominate the overview's "Recente ritten" section
- Both overview and `/trips` page share the same `useTrips()` hook — one-line fix in `lib/queries/trips.ts`
- New order: `date DESC, id DESC` — most recent trips first, cross-car safe; `id DESC` as tiebreaker handles same-day retroactive entries correctly

## Test Plan

- [ ] Overview "Recente ritten" shows most recent trips across all cars (not ETH-first)
- [ ] `/trips` page still groups correctly by month with newest months first
- [ ] Retroactively entered trips sort to their actual date, not to the top

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)