### PR TITLE
fix(trips): sort same-day trips by start_odometer DESC

### DIFF
--- a/lib/queries/trips.ts
+++ b/lib/queries/trips.ts
@@ -17,7 +17,7 @@ export function getTrips(db: Database.Database): Trip[] {
     FROM trips t
     JOIN people p ON p.id = t.person_id
     JOIN cars c ON c.id = t.car_id
-    ORDER BY t.date DESC, t.id DESC
+    ORDER BY t.date DESC, t.start_odometer DESC, t.id DESC
   `
     )
     .all() as Trip[];


### PR DESCRIPTION
## Summary

- Within same date, `id DESC` was an arbitrary tiebreaker — could show trips out of chronological order
- `start_odometer DESC` gives actual drive order: higher odo = later trip in the day
- Final order: `date DESC, start_odometer DESC, id DESC`

## Test Plan

- [ ] Two trips on same day for same car: higher start_odometer appears first
- [ ] Cross-day ordering still correct (newest date first)
- [ ] Overview "Recente ritten" unaffected

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)