### PR TITLE
feat(trips/fuel): lazy-render GroupedList — show 3 months, auto-load on scroll

### DIFF
--- a/components/__tests__/grouped-list.test.tsx
+++ b/components/__tests__/grouped-list.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { GroupedList } from "../grouped-list";
+
+type IOCallback = (entries: { isIntersecting: boolean }[]) => void;
+let observerCallback: IOCallback | null = null;
+const mockObserve = vi.fn();
+const mockDisconnect = vi.fn();
+
+beforeEach(() => {
+  observerCallback = null;
+  mockObserve.mockClear();
+  mockDisconnect.mockClear();
+  vi.stubGlobal(
+    "IntersectionObserver",
+    class {
+      constructor(cb: IOCallback) {
+        observerCallback = cb;
+      }
+      observe = mockObserve;
+      disconnect = mockDisconnect;
+    }
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function makeItems(months: string[]) {
+  return months.flatMap((month) => [
+    { id: `${month}-a`, month },
+    { id: `${month}-b`, month },
+  ]);
+}
+
+const props = {
+  getKey: (item: { month: string }) => item.month,
+  getGroupLabel: (key: string) => key,
+  getGroupTotal: () => 0,
+  totalSuffix: "km" as const,
+  renderItem: (item: { id: string }) => <div data-testid={item.id}>{item.id}</div>,
+};
+
+describe("GroupedList lazy rendering", () => {
+  it("renders only the first 3 month groups initially", () => {
+    const months = ["2026-05", "2026-04", "2026-03", "2026-02", "2026-01"];
+    render(<GroupedList items={makeItems(months)} {...props} />);
+    expect(screen.getByText("2026-05")).toBeInTheDocument();
+    expect(screen.getByText("2026-04")).toBeInTheDocument();
+    expect(screen.getByText("2026-03")).toBeInTheDocument();
+    expect(screen.queryByText("2026-02")).not.toBeInTheDocument();
+    expect(screen.queryByText("2026-01")).not.toBeInTheDocument();
+  });
+
+  it("renders all groups when total ≤ 3", () => {
+    const months = ["2026-05", "2026-04"];
+    render(<GroupedList items={makeItems(months)} {...props} />);
+    expect(screen.getByText("2026-05")).toBeInTheDocument();
+    expect(screen.getByText("2026-04")).toBeInTheDocument();
+  });
+
+  it("does not render sentinel when all groups are visible", () => {
+    const months = ["2026-05", "2026-04"];
+    const { container } = render(<GroupedList items={makeItems(months)} {...props} />);
+    expect(container.querySelector('[style*="height: 1px"]')).not.toBeInTheDocument();
+  });
+
+  it("renders sentinel when more groups exist", () => {
+    const months = ["2026-05", "2026-04", "2026-03", "2026-02"];
+    const { container } = render(<GroupedList items={makeItems(months)} {...props} />);
+    expect(container.querySelector('[style*="height: 1px"]')).toBeInTheDocument();
+  });
+
+  it("reveals next 3 groups when sentinel intersects", () => {
+    const months = ["2026-07", "2026-06", "2026-05", "2026-04", "2026-03", "2026-02", "2026-01"];
+    render(<GroupedList items={makeItems(months)} {...props} />);
+    expect(screen.queryByText("2026-04")).not.toBeInTheDocument();
+    act(() => {
+      observerCallback!([{ isIntersecting: true }]);
+    });
+    expect(screen.getByText("2026-04")).toBeInTheDocument();
+    expect(screen.queryByText("2026-01")).not.toBeInTheDocument();
+  });
+
+  it("resets to 3 visible groups when items prop changes", () => {
+    const months = ["2026-06", "2026-05", "2026-04", "2026-03", "2026-02", "2026-01"];
+    const { rerender } = render(<GroupedList items={makeItems(months)} {...props} />);
+    act(() => {
+      observerCallback!([{ isIntersecting: true }]);
+    });
+    expect(screen.getByText("2026-03")).toBeInTheDocument();
+    const filtered = ["2026-06", "2026-05", "2026-04", "2026-03", "2026-02"];
+    rerender(<GroupedList items={makeItems(filtered)} {...props} />);
+    expect(screen.getByText("2026-06")).toBeInTheDocument();
+    expect(screen.queryByText("2026-03")).not.toBeInTheDocument();
+  });
+
+  it("disconnects observer on unmount", () => {
+    const months = ["2026-05", "2026-04", "2026-03", "2026-02"];
+    const { unmount } = render(<GroupedList items={makeItems(months)} {...props} />);
+    unmount();
+    expect(mockDisconnect).toHaveBeenCalled();
+  });
+});

--- a/components/grouped-list.tsx
+++ b/components/grouped-list.tsx
@@ -1,5 +1,9 @@
-import React from "react";
-import { paper, fontMono, fontSerif, fmtYearMonth } from "@/lib/paper-theme";
+"use client";
+import React, { useState, useEffect, useRef } from "react";
+import { paper, fontSerif } from "@/lib/paper-theme";
+
+const INITIAL_GROUPS = 3;
+const INCREMENT = 3;
 
 interface GroupedListProps<T> {
   items: T[];
@@ -26,14 +30,38 @@ export function GroupedList<T>({
   }
   const sortedKeys = Array.from(groups.keys()).sort().reverse();
 
+  const [visibleCount, setVisibleCount] = useState(INITIAL_GROUPS);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setVisibleCount(INITIAL_GROUPS);
+  }, [items]);
+
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          setVisibleCount((prev) => Math.min(prev + INCREMENT, sortedKeys.length));
+        }
+      },
+      { rootMargin: "200px" }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [sortedKeys.length]);
+
+  const visibleKeys = sortedKeys.slice(0, visibleCount);
+  const hasMore = visibleCount < sortedKeys.length;
+
   return (
     <div>
-      {sortedKeys.map((key) => {
+      {visibleKeys.map((key) => {
         const groupItems = groups.get(key)!;
         const total = getGroupTotal(groupItems);
         return (
           <div key={key}>
-            {/* Month header */}
             <div
               className="group-month-header"
               style={{
@@ -57,14 +85,15 @@ export function GroupedList<T>({
               </span>
               <span
                 style={{
-                  fontFamily: "var(--font-sans, var(--font-inter, 'Inter', system-ui, sans-serif))",
+                  fontFamily:
+                    "var(--font-sans, var(--font-inter, 'Inter', system-ui, sans-serif))",
                   fontSize: 13,
                   color: paper.inkDim,
                   fontWeight: 500,
                 }}
               >
                 {totalSuffix === "€"
-                  ? `€\u00a0${total.toLocaleString("nl-BE", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+                  ? `€ ${total.toLocaleString("nl-BE", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
                   : `${total.toLocaleString("nl-BE")} ${totalSuffix}`}
               </span>
             </div>
@@ -76,6 +105,7 @@ export function GroupedList<T>({
           </div>
         );
       })}
+      {hasMore && <div ref={sentinelRef} style={{ height: "1px" }} />}
     </div>
   );
 }

--- a/lib/__tests__/migration_0004.test.ts
+++ b/lib/__tests__/migration_0004.test.ts
@@ -40,6 +40,7 @@ describe("migration 0004 — car owner era", () => {
       INSERT INTO _migrations (filename) VALUES ('0017_drop_people_name.sql');
       INSERT INTO _migrations (filename) VALUES ('0018_people_theme_preference.sql');
       INSERT INTO _migrations (filename) VALUES ('0019_default_theme_mono.sql');
+      INSERT INTO _migrations (filename) VALUES ('0020_date_indexes.sql');
     `);
     runMigrations(db2);
     const car = db2.prepare("SELECT owner_from FROM cars WHERE short = 'XX'").get() as {

--- a/migrations/0020_date_indexes.sql
+++ b/migrations/0020_date_indexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_trips_date ON trips(date DESC);
+CREATE INDEX IF NOT EXISTS idx_fuel_fillups_date ON fuel_fillups(date DESC);


### PR DESCRIPTION
## Summary

- `GroupedList` now renders only the 3 most recent month-groups initially
- `IntersectionObserver` sentinel at bottom auto-loads next 3 months on scroll (no button)
- Filter change (car, year, mine/others) resets back to top 3 months
- DB: two date indexes on `trips` and `fuel_fillups` for faster queries

## Test Plan

- [ ] `/trips` and `/fuel` show only 3 months on initial load
- [ ] Scrolling to bottom auto-reveals next months
- [ ] Changing car/year filter resets to top 3 months
- [ ] All 418 tests pass

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)