### PR TITLE
feat(calendar): subscribe button + Google Calendar setup docs (#180)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,86 +125,9 @@ NEXT_PUBLIC_BASE_URL=https://your-domain
 
 ## Google Calendar Integration (optional)
 
-When configured, reservations are automatically pushed to a shared Google Calendar. Car owners receive an invite and can confirm or decline by RSVPing — the app updates the reservation status automatically.
+When configured, reservations are automatically pushed to a shared Google Calendar. Car owners receive a personal invite and can confirm or decline by RSVPing directly in their calendar app — the app updates the reservation status automatically.
 
-### Step 1 — Create a Google Cloud project and enable the Calendar API
-
-1. Go to [console.cloud.google.com](https://console.cloud.google.com) and create a project.
-2. Enable the **Google Calendar API** (APIs & Services → Library → search "Google Calendar API" → Enable).
-
-### Step 2 — Configure the OAuth consent screen
-
-1. Go to **APIs & Services → OAuth consent screen**.
-2. Choose user type: **Internal** (Google Workspace org) or **External** (personal accounts).
-3. Fill in app name and contact email. Click Save.
-4. Under **Scopes**, add `https://www.googleapis.com/auth/calendar`.
-5. If you chose _External_, go to **Test users** and add the Google account that owns the shared calendar.
-
-### Step 3 — Create an OAuth 2.0 Client ID
-
-1. Go to **APIs & Services → Credentials → Create Credentials → OAuth 2.0 Client ID**.
-2. Application type: **Web application**.
-3. Under **Authorized redirect URIs**, add: `https://developers.google.com/oauthplayground`
-4. Click **Create**. Copy the **Client ID** and **Client Secret**.
-
-### Step 4 — Add credentials to your environment
-
-```env
-GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
-GOOGLE_CLIENT_SECRET=your-client-secret
-CRON_SECRET=a-random-secret-string
-NEXT_PUBLIC_BASE_URL=https://your-domain
-```
-
-**Note on accounts:**
-
-- **Client ID + Client Secret** — tied to the Google Cloud project, not a personal account.
-- **Refresh token** — tied to the Google account that went through OAuth. This account must have editor access to the shared calendar.
-- **Calendar ID** — any Google calendar. Share it with the OAuth account if it's not owned by it.
-
-`NEXT_PUBLIC_BASE_URL` must be a publicly reachable HTTPS URL (Google sends webhook events here). For local testing, use an ngrok or cloudflared tunnel.
-
-### Step 5 — Get a refresh token
-
-1. Go to [developers.google.com/oauthplayground](https://developers.google.com/oauthplayground).
-2. Click the gear icon → enable **Use your own OAuth credentials** → enter Client ID and Client Secret.
-3. Enter scope `https://www.googleapis.com/auth/calendar` → **Authorise APIs**.
-4. Sign in with the calendar owner account.
-5. Click **Exchange authorisation code for tokens** → copy the **Refresh token**.
-
-### Step 6 — Configure in the admin settings
-
-1. Open the app → **Admin → Instellingen**.
-2. Enter the **Google Calendar ID** (found in Google Calendar settings, looks like `abc123@group.calendar.google.com`).
-3. Enter the **OAuth Refresh Token** from Step 5.
-4. Click Save.
-
-### Step 7 — Register the watch channel
-
-```bash
-curl -X GET https://your-domain/api/admin/calendar-renew \
-  -H "Authorization: Bearer a-random-secret-string"
-```
-
-### Step 8 — Set up the cron job
-
-The watch channel expires every 7 days. Add a daily cron job to renew it:
-
-```cron
-0 3 * * * curl -s -X GET https://your-domain/api/admin/calendar-renew \
-  -H "Authorization: Bearer a-random-secret-string"
-```
-
-### Step 9 — Link cars to owners
-
-In **Admin → Wagens**, set the owner for each car. In **Admin → Leden**, make sure each owner has their email address filled in (used to send calendar invites).
-
-### How it works
-
-- **Reservation created** → event pushed to Google Calendar; owner receives an invite.
-- **Owner RSVPs accepted** → reservation status → _confirmed_.
-- **Owner RSVPs declined** → reservation status → _rejected_.
-- **Reservation updated/deleted** → calendar event updated or removed.
+For full setup instructions, see **[docs/google-calendar-setup.md](docs/google-calendar-setup.md)**.
 
 ## License
 

--- a/app/api/calendar-id/route.ts
+++ b/app/api/calendar-id/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import { getSetting } from "@/lib/queries/settings";
+
+export function GET() {
+  const db = getDb();
+  const calendarId = getSetting(db, "google_calendar_id");
+  return NextResponse.json({ calendarId: calendarId || null });
+}

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -21,6 +21,9 @@ import { PickCalendar } from "@/components/pick-calendar";
 import { CarBadge } from "@/components/car-badge";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { Fab } from "@/components/fab";
+import { useQuery } from "@tanstack/react-query";
+import { apiFetch } from "@/lib/api/client";
+import { CalendarPlus } from "lucide-react";
 
 // ── Bottom Sheet ──────────────────────────────────────────────
 function BottomSheet({
@@ -111,6 +114,10 @@ function CalendarContent() {
 
   const { data: reservations = [], isLoading } = useReservations();
   const { data: cars = [] } = useCars();
+  const { data: calendarMeta } = useQuery<{ calendarId: string | null }>({
+    queryKey: ["calendar-id"],
+    queryFn: () => apiFetch("/api/calendar-id"),
+  });
   const createR = useCreateReservation();
   const updateR = useUpdateReservation();
   const deleteR = useDeleteReservation();
@@ -188,10 +195,22 @@ function CalendarContent() {
     router.push(`${pathname}?${params.toString()}`, { scroll: false });
   };
 
+  const subscribeButton = calendarMeta?.calendarId ? (
+    <a
+      href={`https://calendar.google.com/calendar/r?cid=${encodeURIComponent(calendarMeta.calendarId)}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={t("calendar.subscribe")}
+      style={{ display: "flex", alignItems: "center", color: paper.inkDim, padding: 4 }}
+    >
+      <CalendarPlus size={18} />
+    </a>
+  ) : null;
+
   if (isLoading)
     return (
       <div style={{ background: paper.paperDeep, minHeight: "100dvh" }}>
-        <PageHeader title={t("page.reservations")} />
+        <PageHeader title={t("page.reservations")} right={subscribeButton} />
         <div
           style={{
             padding: "32px 20px",
@@ -208,7 +227,7 @@ function CalendarContent() {
 
   return (
     <div style={{ background: paper.paperDeep, minHeight: "100dvh", paddingBottom: 80 }}>
-      <PageHeader title={t("page.reservations")} />
+      <PageHeader title={t("page.reservations")} right={subscribeButton} />
 
       {/* Legend */}
       <div

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -90,11 +90,11 @@ Enter the IBAN of the cooperative's bank account. This is inserted automatically
 
 ### Google Calendar integration
 
-If you want approved reservations to appear in a shared Google Calendar, configure the integration here:
+When configured, approved reservations are automatically pushed to a shared Google Calendar. Car owners receive a personal invite for reservations on their car and can confirm or decline directly from their calendar app — no app login required.
 
 | Field                   | Description                                                |
 | ----------------------- | ---------------------------------------------------------- |
-| **Google Calendar ID**  | The calendar ID from Google Calendar settings              |
+| **Google Calendar ID**  | The calendar ID of the shared calendar                     |
 | **OAuth Refresh Token** | A long-lived token that lets the app write to the calendar |
 
 After saving, click **Test connection** to verify the credentials are working. If the token expires, paste a new one here without touching any other settings.
@@ -102,6 +102,60 @@ After saving, click **Test connection** to verify the credentials are working. I
 Click **Sync upcoming reservations** to push all future confirmed reservations to the calendar immediately — useful after first-time setup or after a token refresh.
 
 Leave both fields empty to disable the calendar integration.
+
+#### Step 1 — Create a Google Cloud project
+
+1. Go to [console.cloud.google.com](https://console.cloud.google.com)
+2. Create a new project (e.g. "autodelen")
+3. Enable the **Google Calendar API** (APIs & Services → Library → search "Google Calendar API")
+4. Go to **APIs & Services → Credentials → Create Credentials → OAuth 2.0 Client ID**
+   - Application type: **Web application**
+   - Add `https://developers.google.com/oauthplayground` as an authorized redirect URI
+5. Copy the **Client ID** and **Client Secret** → add to your `.env.local` and `docker-compose.yml`:
+   ```
+   GOOGLE_CLIENT_ID=your-client-id
+   GOOGLE_CLIENT_SECRET=your-client-secret
+   ```
+
+#### Step 2 — Get the shared calendar ID
+
+1. Open [Google Calendar](https://calendar.google.com) with the shared Gmail account
+2. In the left sidebar, click the three dots next to the shared calendar → **Settings and sharing**
+3. Scroll down to **Integrate calendar** → copy the **Calendar ID** (looks like `abc123@group.calendar.google.com` or a Gmail address for personal calendars)
+4. Paste it into the **Google Calendar ID** field in Admin → Settings
+
+#### Step 3 — Generate an OAuth refresh token
+
+1. Go to [OAuth 2.0 Playground](https://developers.google.com/oauthplayground)
+2. Click the gear icon (top right) → check **Use your own OAuth credentials** → enter your Client ID and Client Secret
+3. In the left panel, find **Google Calendar API v3** → select `https://www.googleapis.com/auth/calendar` → click **Authorize APIs**
+4. Sign in with the shared Gmail account that owns the calendar
+5. Click **Exchange authorization code for tokens**
+6. Copy the **Refresh token** value → paste it into the **OAuth Refresh Token** field in Admin → Settings
+
+#### Step 4 — Complete per-owner setup
+
+For each car owner to receive personal calendar invites:
+
+1. Go to **Admin → Members** → expand the owner's row → set their **email address**
+2. Go to **Admin → Cars** → edit each car → set the **Owner** to the correct person
+
+#### Step 5 — Register the webhook (one-time)
+
+The app uses a webhook to receive RSVP responses from owners in real time. Register it once:
+
+```bash
+curl -sf -H "Authorization: Bearer $CRON_SECRET" \
+  https://autodelen.bluette.be/api/admin/calendar-renew
+```
+
+The webhook registration expires every ~4 weeks. A daily cron job on the VPS renews it automatically (see deployment docs). Alternatively, call this endpoint manually after any credentials change.
+
+#### Step 6 — Verify
+
+1. Click **Test connection** in Admin → Settings — should return success
+2. Click **Sync upcoming reservations** to backfill existing confirmed reservations
+3. Create a test reservation and confirm it — it should appear in the shared Google Calendar within seconds
 
 ---
 

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -90,72 +90,20 @@ Enter the IBAN of the cooperative's bank account. This is inserted automatically
 
 ### Google Calendar integration
 
-When configured, approved reservations are automatically pushed to a shared Google Calendar. Car owners receive a personal invite for reservations on their car and can confirm or decline directly from their calendar app — no app login required.
+When configured, approved reservations are automatically pushed to a shared Google Calendar. Car owners receive a personal invite and can confirm or decline directly from their calendar app — no app login required.
 
 | Field                   | Description                                                |
 | ----------------------- | ---------------------------------------------------------- |
 | **Google Calendar ID**  | The calendar ID of the shared calendar                     |
 | **OAuth Refresh Token** | A long-lived token that lets the app write to the calendar |
 
-After saving, click **Test connection** to verify the credentials are working. If the token expires, paste a new one here without touching any other settings.
+After saving, click **Test connection** to verify credentials are working. If the token expires, paste a new one here without touching any other settings.
 
-Click **Sync upcoming reservations** to push all future confirmed reservations to the calendar immediately — useful after first-time setup or after a token refresh.
+Click **Sync upcoming reservations** to push all future confirmed reservations immediately — useful after first-time setup or after a token refresh.
 
-Leave both fields empty to disable the calendar integration.
+Leave both fields empty to disable the integration.
 
-#### Step 1 — Create a Google Cloud project
-
-1. Go to [console.cloud.google.com](https://console.cloud.google.com)
-2. Create a new project (e.g. "autodelen")
-3. Enable the **Google Calendar API** (APIs & Services → Library → search "Google Calendar API")
-4. Go to **APIs & Services → Credentials → Create Credentials → OAuth 2.0 Client ID**
-   - Application type: **Web application**
-   - Add `https://developers.google.com/oauthplayground` as an authorized redirect URI
-5. Copy the **Client ID** and **Client Secret** → add to your `.env.local` and `docker-compose.yml`:
-   ```
-   GOOGLE_CLIENT_ID=your-client-id
-   GOOGLE_CLIENT_SECRET=your-client-secret
-   ```
-
-#### Step 2 — Get the shared calendar ID
-
-1. Open [Google Calendar](https://calendar.google.com) with the shared Gmail account
-2. In the left sidebar, click the three dots next to the shared calendar → **Settings and sharing**
-3. Scroll down to **Integrate calendar** → copy the **Calendar ID** (looks like `abc123@group.calendar.google.com` or a Gmail address for personal calendars)
-4. Paste it into the **Google Calendar ID** field in Admin → Settings
-
-#### Step 3 — Generate an OAuth refresh token
-
-1. Go to [OAuth 2.0 Playground](https://developers.google.com/oauthplayground)
-2. Click the gear icon (top right) → check **Use your own OAuth credentials** → enter your Client ID and Client Secret
-3. In the left panel, find **Google Calendar API v3** → select `https://www.googleapis.com/auth/calendar` → click **Authorize APIs**
-4. Sign in with the shared Gmail account that owns the calendar
-5. Click **Exchange authorization code for tokens**
-6. Copy the **Refresh token** value → paste it into the **OAuth Refresh Token** field in Admin → Settings
-
-#### Step 4 — Complete per-owner setup
-
-For each car owner to receive personal calendar invites:
-
-1. Go to **Admin → Members** → expand the owner's row → set their **email address**
-2. Go to **Admin → Cars** → edit each car → set the **Owner** to the correct person
-
-#### Step 5 — Register the webhook (one-time)
-
-The app uses a webhook to receive RSVP responses from owners in real time. Register it once:
-
-```bash
-curl -sf -H "Authorization: Bearer $CRON_SECRET" \
-  https://autodelen.bluette.be/api/admin/calendar-renew
-```
-
-The webhook registration expires every ~4 weeks. A daily cron job on the VPS renews it automatically (see deployment docs). Alternatively, call this endpoint manually after any credentials change.
-
-#### Step 6 — Verify
-
-1. Click **Test connection** in Admin → Settings — should return success
-2. Click **Sync upcoming reservations** to backfill existing confirmed reservations
-3. Create a test reservation and confirm it — it should appear in the shared Google Calendar within seconds
+For full setup instructions (Google Cloud project, OAuth token, cron job, per-owner setup), see **[google-calendar-setup.md](google-calendar-setup.md)**.
 
 ---
 

--- a/docs/google-calendar-setup.md
+++ b/docs/google-calendar-setup.md
@@ -1,0 +1,151 @@
+# Google Calendar Setup
+
+This guide explains how to configure the optional Google Calendar integration for autodelen.
+
+---
+
+## How it works
+
+Autodelen has a two-way sync with a shared Google Calendar:
+
+- **App → Google Calendar:** Every reservation that is created, updated, or deleted is automatically pushed to a shared Google Calendar. The event shows the car, the member's name, and the reservation dates.
+- **Google Calendar → App:** Each car owner receives a personal calendar invite for reservations on their car. When the owner accepts or declines the invite directly in their calendar app, autodelen picks up the RSVP response and updates the reservation status automatically — no app login required.
+
+**Event status mapping:**
+
+| App status  | Google Calendar event |
+| ----------- | --------------------- |
+| Pending     | Tentative             |
+| Confirmed   | Confirmed             |
+| Rejected    | Cancelled (removed)   |
+
+**Who needs an email address?**
+Only car owners — they receive personal invites. Regular members do not need an email address for this feature.
+
+The integration is **opt-in**: it is disabled until both `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` (environment variables) and the calendar ID + refresh token (admin settings) are configured.
+
+---
+
+## Prerequisites
+
+- A Google account that owns or has editor access to the shared calendar
+- A Google Cloud project (free tier is fine)
+- The app must be reachable via a public HTTPS URL (Google sends webhook events here)
+
+---
+
+## Step 1 — Create a Google Cloud project and enable the Calendar API
+
+1. Go to [console.cloud.google.com](https://console.cloud.google.com) and create a project (e.g. "autodelen").
+2. Enable the **Google Calendar API**: APIs & Services → Library → search "Google Calendar API" → Enable.
+
+---
+
+## Step 2 — Configure the OAuth consent screen
+
+1. Go to **APIs & Services → OAuth consent screen**.
+2. Choose user type: **Internal** (Google Workspace org) or **External** (personal accounts).
+3. Fill in app name and contact email. Click Save.
+4. Under **Scopes**, add `https://www.googleapis.com/auth/calendar`.
+5. If you chose _External_, go to **Test users** and add the Google account that owns the shared calendar.
+
+---
+
+## Step 3 — Create an OAuth 2.0 Client ID
+
+1. Go to **APIs & Services → Credentials → Create Credentials → OAuth 2.0 Client ID**.
+2. Application type: **Web application**.
+3. Under **Authorized redirect URIs**, add: `https://developers.google.com/oauthplayground`
+4. Click **Create**. Copy the **Client ID** and **Client Secret**.
+
+**Note on accounts:**
+- **Client ID + Client Secret** — tied to the Google Cloud project, not a personal account.
+- **Refresh token** — tied to the Google account that went through OAuth. This account must have editor access to the shared calendar.
+- **Calendar ID** — any Google Calendar. Share it with the OAuth account if it is not owned by it.
+
+---
+
+## Step 4 — Add credentials to your environment
+
+Add to `.env.local` and the `docker-compose.yml` env block:
+
+```env
+GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=your-client-secret
+CRON_SECRET=a-random-secret-string
+NEXT_PUBLIC_BASE_URL=https://your-domain
+```
+
+`NEXT_PUBLIC_BASE_URL` must be a publicly reachable HTTPS URL — Google sends webhook events here. For local testing, use an ngrok or cloudflared tunnel.
+
+---
+
+## Step 5 — Get a refresh token
+
+1. Go to [developers.google.com/oauthplayground](https://developers.google.com/oauthplayground).
+2. Click the gear icon (top right) → enable **Use your own OAuth credentials** → enter your Client ID and Client Secret.
+3. In the left panel, find **Google Calendar API v3** → select `https://www.googleapis.com/auth/calendar` → click **Authorise APIs**.
+4. Sign in with the Google account that owns the shared calendar.
+5. Click **Exchange authorisation code for tokens** → copy the **Refresh token**.
+
+---
+
+## Step 6 — Find your calendar ID
+
+1. Open [Google Calendar](https://calendar.google.com) with the shared account.
+2. In the left sidebar, click the three dots next to the shared calendar → **Settings and sharing**.
+3. Scroll down to **Integrate calendar** → copy the **Calendar ID** (looks like `abc123@group.calendar.google.com`).
+
+---
+
+## Step 7 — Configure in admin settings
+
+1. Open the app → **Admin → Settings**.
+2. Enter the **Google Calendar ID** from Step 6.
+3. Enter the **OAuth Refresh Token** from Step 5.
+4. Click **Save**.
+5. Click **Test connection** — should return success.
+6. Click **Sync upcoming reservations** to backfill all existing confirmed reservations.
+
+---
+
+## Step 8 — Register the webhook
+
+The app uses a push webhook to receive RSVP responses in real time. Register it once after initial setup:
+
+```bash
+curl -sf -X GET https://your-domain/api/admin/calendar-renew \
+  -H "Authorization: Bearer your-cron-secret"
+```
+
+---
+
+## Step 9 — Set up the cron job
+
+The watch channel expires every ~4 weeks. A daily cron job renews it automatically. Add to the VPS crontab (`/etc/cron.d/autodelen` or root crontab):
+
+```cron
+0 3 * * * curl -s -X GET https://your-domain/api/admin/calendar-renew \
+  -H "Authorization: Bearer your-cron-secret" \
+  >> /var/log/autodelen-calendar-renew.log 2>&1
+```
+
+---
+
+## Step 10 — Link cars to owners
+
+For owners to receive personal invites:
+
+1. **Admin → Cars** — edit each car and set the **Owner** to the correct person.
+2. **Admin → Members** — expand each owner's row and fill in their **email address**.
+
+---
+
+## Ongoing maintenance
+
+| Event                        | Action                                                                 |
+| ---------------------------- | ---------------------------------------------------------------------- |
+| Refresh token expires        | Repeat Step 5 and paste the new token in Admin → Settings              |
+| Watch channel stops working  | Call `/api/admin/calendar-renew` manually (cron should handle this)    |
+| New car added                | Set its owner in Admin → Cars; ensure owner email is set               |
+| Calendar sync seems stuck    | Click **Sync upcoming reservations** in Admin → Settings               |

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -270,6 +270,7 @@ export const en: Messages = {
   "calendar.upcoming": "Upcoming",
   "calendar.all_filter": "All",
   "calendar.mine_filter": "Mine",
+  "calendar.subscribe": "Add to calendar app",
   "calendar.prev_weeks": "Previous weeks",
   "calendar.next_weeks": "Next weeks",
   "location.use_gps": "Use current location",

--- a/lib/i18n/messages/nl.ts
+++ b/lib/i18n/messages/nl.ts
@@ -268,6 +268,7 @@ export const nl = {
   "calendar.upcoming": "Aankomend",
   "calendar.all_filter": "Alles",
   "calendar.mine_filter": "Mijn",
+  "calendar.subscribe": "Voeg toe aan kalender-app",
   "calendar.prev_weeks": "Vorige weken",
   "calendar.next_weeks": "Volgende weken",
   "location.use_gps": "Huidige locatie gebruiken",


### PR DESCRIPTION
## Summary

- Add `GET /api/calendar-id` public endpoint — returns configured calendar ID (no auth needed, calendar ID is not a secret)
- Add **CalendarPlus** subscribe button in `/calendar` page header — only shown when a calendar is configured; links to `calendar.google.com/calendar/r?cid=...` so users can add the shared calendar to their calendar app
- New `docs/google-calendar-setup.md` — canonical 10-step setup guide with how-it-works intro, event status mapping, who needs an email address, and ongoing maintenance table
- Trim README Google Calendar section to 3-line summary + link to new doc
- Trim `docs/admin-guide.md` Google Calendar section to summary + link to new doc

Closes #180

## Test Plan

- [ ] Run `npm test` — 418 tests pass
- [ ] Visit `/calendar` when `google_calendar_id` is set in settings — CalendarPlus icon appears in header
- [ ] Click icon — opens Google Calendar subscribe URL in new tab
- [ ] Visit `/calendar` when no calendar ID configured — icon hidden
- [ ] `GET /api/calendar-id` returns `{ calendarId: "..." }` or `{ calendarId: null }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)