### PR TITLE
fix(calendar): diagnostic messages for test connection (no access / read-only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ public/workbox-*.js.map
 data
 coverage/
 test-results/
+.mcp.json

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "gh": {
+      "command": "/home/roeland/.npm-global/bin/mcp-server-github",
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "your_pat_here"
+      }
+    }
+  }
+}

--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -303,6 +303,8 @@ export default function AdminSettingsPage() {
                         invalid_client: t("settings.test_invalid_client"),
                         invalid_grant: t("settings.test_invalid_grant"),
                         calendar_not_found: t("settings.test_not_found"),
+                        calendar_no_access: t("settings.test_no_access"),
+                        no_write_access: t("settings.test_no_write"),
                       };
                       const msg =
                         errorMap[body.error] ??

--- a/app/api/admin/calendar-test/route.ts
+++ b/app/api/admin/calendar-test/route.ts
@@ -12,6 +12,7 @@ function googleErrorCode(e: unknown): string {
     const response = err.response as Record<string, unknown> | undefined;
     const status = response?.status;
     if (status === 404) return "calendar_not_found";
+    if (status === 403) return "calendar_no_access";
     const data = response?.data;
     if (data && typeof data === "object" && "error" in data) {
       const errVal = (data as Record<string, unknown>).error;
@@ -43,6 +44,10 @@ export const GET = json(async (req) => {
     const client = getOAuthClient(refreshToken);
     const cal = google.calendar({ version: "v3", auth: client });
     const res = await cal.calendars.get({ calendarId });
+    const role = res.data.accessRole;
+    if (role === "reader" || role === "freeBusyReader" || role === "none") {
+      return NextResponse.json({ ok: false, error: "no_write_access" });
+    }
     return NextResponse.json({ ok: true, summary: res.data.summary ?? calendarId });
   } catch (e) {
     return NextResponse.json({ ok: false, error: googleErrorCode(e) });

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -542,8 +542,11 @@ export const en: Messages = {
     "✗ Invalid Client ID or Secret — check GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET in .env.local. The OAuth client may have been deleted in Google Cloud Console.",
   "settings.test_invalid_grant":
     "✗ Token expired or revoked. Get a new Refresh Token from OAuth Playground and save it again.",
-  "settings.test_not_found":
-    "✗ Calendar not found. Check the calendar ID and make sure the OAuth account has read access.",
+  "settings.test_not_found": "✗ Calendar not found. Check the calendar ID.",
+  "settings.test_no_access":
+    "✗ No access to this calendar. Share the calendar with the OAuth account and grant write access.",
+  "settings.test_no_write":
+    "✗ Read-only access — the app cannot create events. Change the sharing permission to 'Make changes to events'.",
   "settings.test_fail": "✗ Unexpected error: {error}",
   "settings.backfill": "Sync upcoming reservations",
 

--- a/lib/i18n/messages/nl.ts
+++ b/lib/i18n/messages/nl.ts
@@ -541,8 +541,11 @@ export const nl = {
     "✗ Ongeldige Client ID of Secret — controleer GOOGLE_CLIENT_ID en GOOGLE_CLIENT_SECRET in .env.local. De OAuth-client is mogelijk verwijderd in Google Cloud Console.",
   "settings.test_invalid_grant":
     "✗ Token verlopen of ingetrokken. Haal een nieuw Refresh Token op via OAuth Playground en sla het opnieuw op.",
-  "settings.test_not_found":
-    "✗ Kalender niet gevonden. Controleer het kalender-ID en zorg dat het OAuth-account leesrechten heeft.",
+  "settings.test_not_found": "✗ Kalender niet gevonden. Controleer of het kalender-ID correct is.",
+  "settings.test_no_access":
+    "✗ Geen toegang tot deze kalender. Deel de kalender met het OAuth-account en geef schrijfrechten.",
+  "settings.test_no_write":
+    "✗ Alleen leesrechten — de app kan geen afspraken aanmaken. Wijzig de deling naar 'Wijzigingen aanbrengen in evenementen'.",
   "settings.test_fail": "✗ Onverwachte fout: {error}",
   "settings.backfill": "Toekomstige reserveringen synchroniseren",
 


### PR DESCRIPTION
## Summary

- `calendars.get` returning 403 → `calendar_no_access` with message: "Share the calendar with the OAuth account and grant write access."
- `calendars.get` returning 200 but `accessRole` is `reader`/`freeBusyReader` → `no_write_access` with message: "Read-only access — change sharing to 'Make changes to events'."
- Updated NL + EN i18n strings

## Test Plan

- [ ] Calendar shared with read access → shows write-access error message
- [ ] Calendar shared with write access → shows ✓ success
- [ ] Wrong calendar ID → shows not-found message
- [ ] No access at all → shows no-access message

🤖 Generated with [Claude Code](https://claude.com/claude-code)