### PR TITLE
chore(pages): extract useEditModal, ListFilterBar, ModalSheet + a11y fixes

### DIFF
--- a/app/admin/members/page.tsx
+++ b/app/admin/members/page.tsx
@@ -133,90 +133,94 @@ function PersonRow({
     >
       {/* Collapsed header */}
       <div
-        role="button"
-        tabIndex={0}
-        onClick={onToggle}
-        onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && onToggle()}
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
         style={{
           display: "flex",
           alignItems: "center",
-          gap: 6,
-          padding: "12px 14px 12px 14px",
-          cursor: "pointer",
-          userSelect: "none",
           minWidth: 0,
         }}
       >
-        <span
+        <button
+          onClick={onToggle}
           style={{
-            fontFamily: fontSerif,
-            fontSize: 15,
-            fontWeight: 700,
-            color: paper.ink,
-            whiteSpace: "nowrap",
+            flex: 1,
+            display: "flex",
+            alignItems: "center",
+            gap: 6,
+            padding: "12px 14px",
+            cursor: "pointer",
+            userSelect: "none",
+            minWidth: 0,
+            background: "none",
+            border: "none",
+            textAlign: "left",
           }}
         >
-          {fullNameOf(person)}
-        </span>
+          <span
+            style={{
+              fontFamily: fontSerif,
+              fontSize: 15,
+              fontWeight: 700,
+              color: paper.ink,
+              whiteSpace: "nowrap",
+            }}
+          >
+            {fullNameOf(person)}
+          </span>
+          {person.username && (
+            <span
+              style={{
+                fontFamily: fontMono,
+                fontSize: 10,
+                color: paper.inkDim,
+                whiteSpace: "nowrap",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+              }}
+            >
+              {person.username}
+            </span>
+          )}
+          {hasDiscount && (
+            <div
+              style={{
+                fontFamily: fontMono,
+                fontSize: 9,
+                color: paper.inkDim,
+                fontWeight: 700,
+                letterSpacing: 1,
+                border: `1px solid ${paper.amber}`,
+                padding: "2px 5px",
+                textTransform: "uppercase",
+                flexShrink: 0,
+              }}
+            >
+              {t("admin.discount_badge")}
+            </div>
+          )}
+        </button>
         <Link
           href={`/user/${person.id}/edit`}
           aria-label={t("admin.edit_member").replace("{name}", fullNameOf(person))}
-          onClick={(e) => e.stopPropagation()}
           style={{
             display: "inline-flex",
             alignItems: "center",
             color: paper.inkDim,
             opacity: hovered ? 1 : 0,
             transition: "opacity 0.15s",
-            marginRight: 10,
+            padding: "0 6px",
           }}
         >
           <Pencil size={11} />
         </Link>
-        {person.username && (
-          <span
-            style={{
-              fontFamily: fontMono,
-              fontSize: 10,
-              color: paper.inkDim,
-              whiteSpace: "nowrap",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-            }}
-          >
-            {person.username}
-          </span>
-        )}
-        {hasDiscount && (
-          <div
-            style={{
-              fontFamily: fontMono,
-              fontSize: 9,
-              color: paper.inkDim,
-              fontWeight: 700,
-              letterSpacing: 1,
-              border: `1px solid ${paper.amber}`,
-              padding: "2px 5px",
-              textTransform: "uppercase",
-              flexShrink: 0,
-            }}
-          >
-            {t("admin.discount_badge")}
-          </div>
-        )}
-        <div style={{ flex: 1 }} />
         {onCloak && (
           <button
-            onClick={(e) => {
-              e.stopPropagation();
-              onCloak(person.id);
-            }}
+            onClick={() => onCloak(person.id)}
             style={{
               background: "none",
               border: "none",
-              padding: 0,
+              padding: "0 14px 0 0",
               cursor: "pointer",
               fontFamily: fontMono,
               fontSize: 9,

--- a/app/expenses/page.tsx
+++ b/app/expenses/page.tsx
@@ -1,75 +1,36 @@
 "use client";
-import { Suspense, useState, useEffect } from "react";
-import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import { Suspense } from "react";
 import { toast } from "sonner";
-import * as Dialog from "@radix-ui/react-dialog";
 import { PageHeader } from "@/components/page-header";
 import { GroupedList } from "@/components/grouped-list";
 import { Fab } from "@/components/fab";
+import { ListFilterBar } from "@/components/list-filter-bar";
+import { ModalSheet } from "@/components/modal-sheet";
 import { ExpenseForm } from "./expense-form";
-import {
-  useExpenses,
-  useCreateExpense,
-  useUpdateExpense,
-  useDeleteExpense,
-} from "@/hooks/use-expenses";
+import { useExpenses, useCreateExpense, useUpdateExpense, useDeleteExpense } from "@/hooks/use-expenses";
 import { useMe } from "@/hooks/use-me";
 import { useQueryParam } from "@/hooks/use-query-param";
-import { YearSelect } from "@/components/year-select";
-import type { Expense } from "@/types";
+import { useEditModal } from "@/hooks/use-edit-modal";
 import { paper, fontMono, fmtYearMonth } from "@/lib/paper-theme";
-import { useTheme } from "@/lib/theme-context";
 import { useT } from "@/components/locale-provider";
 import { ExpenseCard } from "@/components/expense-card";
 import { ErrorBoundary } from "@/components/error-boundary";
 
-const overlayStyle: React.CSSProperties = {
-  position: "fixed",
-  inset: 0,
-  background: "rgba(0,0,0,0.45)",
-  zIndex: 49,
-};
-const sheetStyle: React.CSSProperties = {
-  position: "fixed",
-  bottom: 0,
-  left: "50%",
-  transform: "translateX(-50%)",
-  width: "min(100%, 480px)",
-  maxHeight: "92dvh",
-  borderRadius: "14px 14px 0 0",
-  background: paper.paperDeep,
-  zIndex: 50,
-  overflowY: "auto",
-};
-
 function ExpensesContent() {
   const t = useT();
-  const { theme } = useTheme();
-  const mono = theme === "mono";
   const { data: expenses = [], isLoading } = useExpenses();
   const { data: me } = useMe();
   const createE = useCreateExpense();
   const updateE = useUpdateExpense();
   const deleteE = useDeleteExpense();
 
-  const searchParams = useSearchParams();
-  const router = useRouter();
-  const pathname = usePathname();
-
   const [mineParam, setMineParam] = useQueryParam("mine", "");
   const [carFilter, setCarFilter] = useQueryParam("car", "");
   const [yearFilter, setYearFilter] = useQueryParam("year", "");
 
-  const actionParam = searchParams.get("action");
-  const editIdParam = searchParams.get("edit");
+  const { adding, editingId, modalClosed, openAdd, openEdit, closeModal } = useEditModal();
 
-  const adding = actionParam === "add";
-  const editingId = editIdParam ? Number(editIdParam) : null;
-  const editing =
-    !isLoading && editingId ? (expenses.find((e) => e.id === editingId) ?? null) : null;
-
-  const [modalClosed, setModalClosed] = useState(false);
-  useEffect(() => { setModalClosed(false); }, [editingId]);
+  const editing = !isLoading && editingId ? (expenses.find((e) => e.id === editingId) ?? null) : null;
 
   const isMine = mineParam === "true";
   const isOthers = mineParam === "false";
@@ -77,9 +38,7 @@ function ExpensesContent() {
   const cars = Array.from(
     new Set(expenses.map((e) => e.car_short).filter((s): s is string => !!s))
   ).sort();
-  const years = Array.from(new Set(expenses.map((e) => e.date.slice(0, 4))))
-    .sort()
-    .reverse();
+  const years = Array.from(new Set(expenses.map((e) => e.date.slice(0, 4)))).sort().reverse();
 
   const visible = expenses
     .filter((e) => {
@@ -90,64 +49,11 @@ function ExpensesContent() {
     .filter((e) => (carFilter ? e.car_short === carFilter : true))
     .filter((e) => (yearFilter ? e.date.startsWith(yearFilter) : true));
 
-  const openAdd = () => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.set("action", "add");
-    router.push(`${pathname}?${params.toString()}`, { scroll: false });
-  };
-
-  const openEdit = (expense: Expense) => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.set("edit", String(expense.id));
-    router.push(`${pathname}?${params.toString()}`, { scroll: false });
-  };
-
-  const closeModal = () => {
-    setModalClosed(true);
-    window.history.replaceState(null, "", pathname);
-  };
-
-  const filterBtnStyle = (active: boolean): React.CSSProperties =>
-    mono
-      ? {
-          padding: "5px 11px",
-          background: active ? paper.ink : "transparent",
-          color: active ? paper.paper : paper.inkDim,
-          border: "none",
-          borderRadius: "var(--radius-pill, 999px)",
-          fontFamily: "var(--font-inter, 'Inter', system-ui, sans-serif)",
-          fontSize: 11.5,
-          fontWeight: 500,
-          letterSpacing: 0,
-          cursor: "pointer",
-          transition: "background 0.15s",
-        }
-      : {
-          padding: "5px 12px",
-          background: active ? paper.ink : "transparent",
-          color: active ? paper.paper : paper.inkDim,
-          border: `1.5px solid ${paper.ink}`,
-          fontFamily: fontMono,
-          fontSize: 9,
-          fontWeight: 700,
-          letterSpacing: 2,
-          textTransform: "uppercase",
-          cursor: "pointer",
-        };
-
   if (isLoading)
     return (
       <div style={{ background: paper.paperDeep, minHeight: "100dvh" }}>
         <PageHeader title={t("page.expenses")} />
-        <div
-          style={{
-            padding: "32px 20px",
-            fontFamily: fontMono,
-            fontSize: 11,
-            color: paper.inkDim,
-            letterSpacing: 1,
-          }}
-        >
+        <div style={{ padding: "32px 20px", fontFamily: fontMono, fontSize: 11, color: paper.inkDim, letterSpacing: 1 }}>
           {t("state.loading")}
         </div>
       </div>
@@ -157,62 +63,17 @@ function ExpensesContent() {
     <div style={{ background: paper.paperDeep, minHeight: "100dvh", paddingBottom: 80 }}>
       <PageHeader title={t("page.expenses")} />
 
-      <div
-        style={{
-          padding: "10px 16px 8px",
-          borderBottom: mono ? "none" : `1px solid ${paper.paperDark}`,
-          display: "flex",
-          flexDirection: "column",
-          gap: 6,
-        }}
-      >
-        {(canFilter || years.length > 1) && (
-          <div style={{ display: "flex", alignItems: "center" }}>
-            {canFilter && (
-              <div style={mono ? { display: "inline-flex", alignSelf: "flex-start", border: `1px solid ${paper.paperDark}`, borderRadius: "var(--radius-pill, 999px)", padding: 2, gap: 1 } : { display: "flex", gap: 0 }}>
-                {(["all", "mine"] as const).map((v, i, arr) => (
-                  <button
-                    key={v}
-                    onClick={() => setMineParam(v === "mine" ? "true" : "")}
-                    style={{
-                      ...filterBtnStyle(v === "mine" ? isMine : !isMine),
-                      ...(mono ? {} : { borderRight: i < arr.length - 1 ? "none" : `1.5px solid ${paper.ink}` }),
-                    }}
-                  >
-                    {v === "all" ? t("filter.all") : t("filter.mine")}
-                  </button>
-                ))}
-              </div>
-            )}
-            {years.length > 1 && (
-              <div style={{ marginLeft: "auto" }}>
-                <YearSelect
-                  value={yearFilter}
-                  onChange={setYearFilter}
-                  years={years}
-                  allLabel={t("filter.all")}
-                />
-              </div>
-            )}
-          </div>
-        )}
-        {cars.length > 1 && (
-          <div style={mono ? { display: "inline-flex", alignSelf: "flex-start", border: `1px solid ${paper.paperDark}`, borderRadius: "var(--radius-pill, 999px)", padding: 2, gap: 1 } : { display: "flex", gap: 0 }}>
-            {[null, ...cars].map((car, i, arr) => (
-              <button
-                key={car ?? "__all"}
-                onClick={() => setCarFilter(car ?? "")}
-                style={{
-                  ...filterBtnStyle(carFilter === (car ?? "")),
-                  ...(mono ? {} : { borderRight: i < arr.length - 1 ? "none" : `1.5px solid ${paper.ink}` }),
-                }}
-              >
-                {car ?? t("filter.all")}
-              </button>
-            ))}
-          </div>
-        )}
-      </div>
+      <ListFilterBar
+        canFilter={canFilter}
+        isMine={isMine}
+        cars={cars}
+        carFilter={carFilter}
+        years={years}
+        yearFilter={yearFilter}
+        onMineChange={setMineParam}
+        onCarChange={setCarFilter}
+        onYearChange={setYearFilter}
+      />
 
       <GroupedList
         items={visible}
@@ -220,107 +81,47 @@ function ExpensesContent() {
         getGroupLabel={(key) => fmtYearMonth(key + "-01")}
         getGroupTotal={(items) => items.reduce((s, e) => s + e.amount, 0)}
         totalSuffix="€"
-        renderItem={(e) => <ExpenseCard key={e.id} expense={e} onClick={() => openEdit(e)} />}
+        renderItem={(e) => <ExpenseCard key={e.id} expense={e} onClick={() => openEdit(e.id)} />}
       />
 
       {visible.length === 0 && (
-        <div
-          style={{
-            padding: "32px 20px",
-            textAlign: "center",
-            fontFamily: fontMono,
-            fontSize: 11,
-            color: paper.inkDim,
-            letterSpacing: 1,
-          }}
-        >
+        <div style={{ padding: "32px 20px", textAlign: "center", fontFamily: fontMono, fontSize: 11, color: paper.inkDim, letterSpacing: 1 }}>
           {t("state.empty_expenses")}
         </div>
       )}
 
-      <Dialog.Root
-        open={adding}
-        onOpenChange={(open) => {
-          if (!open) closeModal();
-        }}
-      >
-        <Dialog.Portal>
-          <Dialog.Overlay style={overlayStyle} />
-          <Dialog.Content style={sheetStyle} aria-describedby={undefined}>
-            <Dialog.Title
-              style={{
-                position: "absolute",
-                width: 1,
-                height: 1,
-                overflow: "hidden",
-                clip: "rect(0,0,0,0)",
-              }}
-            >
-              {t("page.expense_add")}
-            </Dialog.Title>
-            <ExpenseForm
-              onSubmit={(data) =>
-                createE.mutate(data as any, {
-                  onSuccess: () => {
-                    closeModal();
-                    toast.success(t("toast.saved"));
-                  },
-                  onError: (e) => toast.error(e.message),
-                })
-              }
-              onCancel={closeModal}
-            />
-          </Dialog.Content>
-        </Dialog.Portal>
-      </Dialog.Root>
+      <ModalSheet open={adding} onClose={closeModal} title={t("page.expense_add")}>
+        <ExpenseForm
+          onSubmit={(data) =>
+            createE.mutate(data as any, {
+              onSuccess: () => { closeModal(); toast.success(t("toast.saved")); },
+              onError: (e) => toast.error(e.message),
+            })
+          }
+          onCancel={closeModal}
+        />
+      </ModalSheet>
 
-      <Dialog.Root
-        open={!!editing && !modalClosed}
-        onOpenChange={(open) => {
-          if (!open) closeModal();
-        }}
-      >
-        <Dialog.Portal>
-          <Dialog.Overlay style={overlayStyle} />
-          <Dialog.Content style={sheetStyle} aria-describedby={undefined}>
-            <Dialog.Title
-              style={{
-                position: "absolute",
-                width: 1,
-                height: 1,
-                overflow: "hidden",
-                clip: "rect(0,0,0,0)",
-              }}
-            >
-              {t("page.expense_edit")}
-            </Dialog.Title>
-            {editing && (
-              <ExpenseForm
-                defaultValues={editing}
-                onSubmit={(data) =>
-                  updateE.mutate({ id: editing.id, ...data } as any, {
-                    onSuccess: () => {
-                      closeModal();
-                      toast.success(t("toast.saved"));
-                    },
-                    onError: (e) => toast.error(e.message),
-                  })
-                }
-                onCancel={closeModal}
-                onDelete={() =>
-                  deleteE.mutate(editing.id, {
-                    onSuccess: () => {
-                      closeModal();
-                      toast.success(t("toast.saved"));
-                    },
-                    onError: (e) => toast.error(e.message),
-                  })
-                }
-              />
-            )}
-          </Dialog.Content>
-        </Dialog.Portal>
-      </Dialog.Root>
+      <ModalSheet open={!!editing && !modalClosed} onClose={closeModal} title={t("page.expense_edit")}>
+        {editing && (
+          <ExpenseForm
+            defaultValues={editing}
+            onSubmit={(data) =>
+              updateE.mutate({ id: editing.id, ...data } as any, {
+                onSuccess: () => { closeModal(); toast.success(t("toast.saved")); },
+                onError: (e) => toast.error(e.message),
+              })
+            }
+            onCancel={closeModal}
+            onDelete={() =>
+              deleteE.mutate(editing.id, {
+                onSuccess: () => { closeModal(); toast.success(t("toast.saved")); },
+                onError: (e) => toast.error(e.message),
+              })
+            }
+          />
+        )}
+      </ModalSheet>
 
       <Fab onClick={openAdd} label={t("page.expense_add")} />
     </div>

--- a/app/fuel/page.tsx
+++ b/app/fuel/page.tsx
@@ -1,75 +1,36 @@
 "use client";
-import { Suspense, useState, useEffect } from "react";
-import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import { Suspense } from "react";
 import { toast } from "sonner";
-import * as Dialog from "@radix-ui/react-dialog";
 import { PageHeader } from "@/components/page-header";
 import { GroupedList } from "@/components/grouped-list";
 import { Fab } from "@/components/fab";
+import { ListFilterBar } from "@/components/list-filter-bar";
+import { ModalSheet } from "@/components/modal-sheet";
 import { FuelForm } from "./fuel-form";
-import {
-  useFuelFillups,
-  useCreateFuelFillup,
-  useUpdateFuelFillup,
-  useDeleteFuelFillup,
-} from "@/hooks/use-fuel-fillups";
+import { useFuelFillups, useCreateFuelFillup, useUpdateFuelFillup, useDeleteFuelFillup } from "@/hooks/use-fuel-fillups";
 import { useMe } from "@/hooks/use-me";
 import { useQueryParam } from "@/hooks/use-query-param";
-import { YearSelect } from "@/components/year-select";
-import type { FuelFillup } from "@/types";
+import { useEditModal } from "@/hooks/use-edit-modal";
 import { paper, fontMono, fmtYearMonth } from "@/lib/paper-theme";
-import { useTheme } from "@/lib/theme-context";
 import { useT } from "@/components/locale-provider";
 import { FuelCard } from "@/components/fuel-card";
 import { ErrorBoundary } from "@/components/error-boundary";
 
-const overlayStyle: React.CSSProperties = {
-  position: "fixed",
-  inset: 0,
-  background: "rgba(0,0,0,0.45)",
-  zIndex: 49,
-};
-const sheetStyle: React.CSSProperties = {
-  position: "fixed",
-  bottom: 0,
-  left: "50%",
-  transform: "translateX(-50%)",
-  width: "min(100%, 480px)",
-  maxHeight: "92dvh",
-  borderRadius: "14px 14px 0 0",
-  background: paper.paperDeep,
-  zIndex: 50,
-  overflowY: "auto",
-};
-
 function FuelContent() {
   const t = useT();
-  const { theme } = useTheme();
-  const mono = theme === "mono";
   const { data: fillups = [], isLoading } = useFuelFillups();
   const { data: me } = useMe();
   const createF = useCreateFuelFillup();
   const updateF = useUpdateFuelFillup();
   const deleteF = useDeleteFuelFillup();
 
-  const searchParams = useSearchParams();
-  const router = useRouter();
-  const pathname = usePathname();
-
   const [mineParam, setMineParam] = useQueryParam("mine", "");
   const [carFilter, setCarFilter] = useQueryParam("car", "");
   const [yearFilter, setYearFilter] = useQueryParam("year", "");
 
-  const actionParam = searchParams.get("action");
-  const editIdParam = searchParams.get("edit");
+  const { adding, editingId, modalClosed, openAdd, openEdit, closeModal } = useEditModal();
 
-  const adding = actionParam === "add";
-  const editingId = editIdParam ? Number(editIdParam) : null;
-  const editing =
-    !isLoading && editingId ? (fillups.find((f) => f.id === editingId) ?? null) : null;
-
-  const [modalClosed, setModalClosed] = useState(false);
-  useEffect(() => { setModalClosed(false); }, [editingId]);
+  const editing = !isLoading && editingId ? (fillups.find((f) => f.id === editingId) ?? null) : null;
 
   const isMine = mineParam === "true";
   const isOthers = mineParam === "false";
@@ -77,9 +38,7 @@ function FuelContent() {
   const cars = Array.from(
     new Set(fillups.map((f) => f.car_short).filter((s): s is string => !!s))
   ).sort();
-  const years = Array.from(new Set(fillups.map((f) => f.date.slice(0, 4))))
-    .sort()
-    .reverse();
+  const years = Array.from(new Set(fillups.map((f) => f.date.slice(0, 4)))).sort().reverse();
 
   const visible = fillups
     .filter((f) => {
@@ -90,64 +49,11 @@ function FuelContent() {
     .filter((f) => (carFilter ? f.car_short === carFilter : true))
     .filter((f) => (yearFilter ? f.date.startsWith(yearFilter) : true));
 
-  const openAdd = () => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.set("action", "add");
-    router.push(`${pathname}?${params.toString()}`, { scroll: false });
-  };
-
-  const openEdit = (fillup: FuelFillup) => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.set("edit", String(fillup.id));
-    router.push(`${pathname}?${params.toString()}`, { scroll: false });
-  };
-
-  const closeModal = () => {
-    setModalClosed(true);
-    window.history.replaceState(null, "", pathname);
-  };
-
-  const filterBtnStyle = (active: boolean): React.CSSProperties =>
-    mono
-      ? {
-          padding: "5px 11px",
-          background: active ? paper.ink : "transparent",
-          color: active ? paper.paper : paper.inkDim,
-          border: "none",
-          borderRadius: "var(--radius-pill, 999px)",
-          fontFamily: "var(--font-inter, 'Inter', system-ui, sans-serif)",
-          fontSize: 11.5,
-          fontWeight: 500,
-          letterSpacing: 0,
-          cursor: "pointer",
-          transition: "background 0.15s",
-        }
-      : {
-          padding: "5px 12px",
-          background: active ? paper.ink : "transparent",
-          color: active ? paper.paper : paper.inkDim,
-          border: `1.5px solid ${paper.ink}`,
-          fontFamily: fontMono,
-          fontSize: 9,
-          fontWeight: 700,
-          letterSpacing: 2,
-          textTransform: "uppercase",
-          cursor: "pointer",
-        };
-
   if (isLoading)
     return (
       <div style={{ background: paper.paperDeep, minHeight: "100dvh" }}>
         <PageHeader title={t("page.fuel")} />
-        <div
-          style={{
-            padding: "32px 20px",
-            fontFamily: fontMono,
-            fontSize: 11,
-            color: paper.inkDim,
-            letterSpacing: 1,
-          }}
-        >
+        <div style={{ padding: "32px 20px", fontFamily: fontMono, fontSize: 11, color: paper.inkDim, letterSpacing: 1 }}>
           {t("state.loading")}
         </div>
       </div>
@@ -157,62 +63,17 @@ function FuelContent() {
     <div style={{ background: paper.paperDeep, minHeight: "100dvh", paddingBottom: 80 }}>
       <PageHeader title={t("page.fuel")} />
 
-      <div
-        style={{
-          padding: "10px 16px 8px",
-          borderBottom: mono ? "none" : `1px solid ${paper.paperDark}`,
-          display: "flex",
-          flexDirection: "column",
-          gap: 6,
-        }}
-      >
-        {(canFilter || years.length > 1) && (
-          <div style={{ display: "flex", alignItems: "center" }}>
-            {canFilter && (
-              <div style={mono ? { display: "inline-flex", alignSelf: "flex-start", border: `1px solid ${paper.paperDark}`, borderRadius: "var(--radius-pill, 999px)", padding: 2, gap: 1 } : { display: "flex", gap: 0 }}>
-                {(["all", "mine"] as const).map((v, i, arr) => (
-                  <button
-                    key={v}
-                    onClick={() => setMineParam(v === "mine" ? "true" : "")}
-                    style={{
-                      ...filterBtnStyle(v === "mine" ? isMine : !isMine),
-                      ...(mono ? {} : { borderRight: i < arr.length - 1 ? "none" : `1.5px solid ${paper.ink}` }),
-                    }}
-                  >
-                    {v === "all" ? t("filter.all") : t("filter.mine")}
-                  </button>
-                ))}
-              </div>
-            )}
-            {years.length > 1 && (
-              <div style={{ marginLeft: "auto" }}>
-                <YearSelect
-                  value={yearFilter}
-                  onChange={setYearFilter}
-                  years={years}
-                  allLabel={t("filter.all")}
-                />
-              </div>
-            )}
-          </div>
-        )}
-        {cars.length > 1 && (
-          <div style={mono ? { display: "inline-flex", alignSelf: "flex-start", border: `1px solid ${paper.paperDark}`, borderRadius: "var(--radius-pill, 999px)", padding: 2, gap: 1 } : { display: "flex", gap: 0 }}>
-            {[null, ...cars].map((car, i, arr) => (
-              <button
-                key={car ?? "__all"}
-                onClick={() => setCarFilter(car ?? "")}
-                style={{
-                  ...filterBtnStyle(carFilter === (car ?? "")),
-                  ...(mono ? {} : { borderRight: i < arr.length - 1 ? "none" : `1.5px solid ${paper.ink}` }),
-                }}
-              >
-                {car ?? t("filter.all")}
-              </button>
-            ))}
-          </div>
-        )}
-      </div>
+      <ListFilterBar
+        canFilter={canFilter}
+        isMine={isMine}
+        cars={cars}
+        carFilter={carFilter}
+        years={years}
+        yearFilter={yearFilter}
+        onMineChange={setMineParam}
+        onCarChange={setCarFilter}
+        onYearChange={setYearFilter}
+      />
 
       <GroupedList
         items={visible}
@@ -220,107 +81,47 @@ function FuelContent() {
         getGroupLabel={(key) => fmtYearMonth(key + "-01")}
         getGroupTotal={(items) => items.reduce((s, f) => s + f.amount, 0)}
         totalSuffix="€"
-        renderItem={(f) => <FuelCard key={f.id} fuel={f} onClick={() => openEdit(f)} />}
+        renderItem={(f) => <FuelCard key={f.id} fuel={f} onClick={() => openEdit(f.id)} />}
       />
 
       {visible.length === 0 && (
-        <div
-          style={{
-            padding: "32px 20px",
-            textAlign: "center",
-            fontFamily: fontMono,
-            fontSize: 11,
-            color: paper.inkDim,
-            letterSpacing: 1,
-          }}
-        >
+        <div style={{ padding: "32px 20px", textAlign: "center", fontFamily: fontMono, fontSize: 11, color: paper.inkDim, letterSpacing: 1 }}>
           {t("state.empty_fuel")}
         </div>
       )}
 
-      <Dialog.Root
-        open={adding}
-        onOpenChange={(open) => {
-          if (!open) closeModal();
-        }}
-      >
-        <Dialog.Portal>
-          <Dialog.Overlay style={overlayStyle} />
-          <Dialog.Content style={sheetStyle} aria-describedby={undefined}>
-            <Dialog.Title
-              style={{
-                position: "absolute",
-                width: 1,
-                height: 1,
-                overflow: "hidden",
-                clip: "rect(0,0,0,0)",
-              }}
-            >
-              {t("page.fuel_add")}
-            </Dialog.Title>
-            <FuelForm
-              onSubmit={(data) =>
-                createF.mutate(data as any, {
-                  onSuccess: () => {
-                    closeModal();
-                    toast.success(t("toast.saved"));
-                  },
-                  onError: (e) => toast.error(e.message),
-                })
-              }
-              onCancel={closeModal}
-            />
-          </Dialog.Content>
-        </Dialog.Portal>
-      </Dialog.Root>
+      <ModalSheet open={adding} onClose={closeModal} title={t("page.fuel_add")}>
+        <FuelForm
+          onSubmit={(data) =>
+            createF.mutate(data as any, {
+              onSuccess: () => { closeModal(); toast.success(t("toast.saved")); },
+              onError: (e) => toast.error(e.message),
+            })
+          }
+          onCancel={closeModal}
+        />
+      </ModalSheet>
 
-      <Dialog.Root
-        open={!!editing && !modalClosed}
-        onOpenChange={(open) => {
-          if (!open) closeModal();
-        }}
-      >
-        <Dialog.Portal>
-          <Dialog.Overlay style={overlayStyle} />
-          <Dialog.Content style={sheetStyle} aria-describedby={undefined}>
-            <Dialog.Title
-              style={{
-                position: "absolute",
-                width: 1,
-                height: 1,
-                overflow: "hidden",
-                clip: "rect(0,0,0,0)",
-              }}
-            >
-              {t("page.fuel_edit")}
-            </Dialog.Title>
-            {editing && (
-              <FuelForm
-                defaultValues={editing}
-                onSubmit={(data) =>
-                  updateF.mutate({ id: editing.id, ...data } as any, {
-                    onSuccess: () => {
-                      closeModal();
-                      toast.success(t("toast.saved"));
-                    },
-                    onError: (e) => toast.error(e.message),
-                  })
-                }
-                onCancel={closeModal}
-                onDelete={() =>
-                  deleteF.mutate(editing.id, {
-                    onSuccess: () => {
-                      closeModal();
-                      toast.success(t("toast.saved"));
-                    },
-                    onError: (e) => toast.error(e.message),
-                  })
-                }
-              />
-            )}
-          </Dialog.Content>
-        </Dialog.Portal>
-      </Dialog.Root>
+      <ModalSheet open={!!editing && !modalClosed} onClose={closeModal} title={t("page.fuel_edit")}>
+        {editing && (
+          <FuelForm
+            defaultValues={editing}
+            onSubmit={(data) =>
+              updateF.mutate({ id: editing.id, ...data } as any, {
+                onSuccess: () => { closeModal(); toast.success(t("toast.saved")); },
+                onError: (e) => toast.error(e.message),
+              })
+            }
+            onCancel={closeModal}
+            onDelete={() =>
+              deleteF.mutate(editing.id, {
+                onSuccess: () => { closeModal(); toast.success(t("toast.saved")); },
+                onError: (e) => toast.error(e.message),
+              })
+            }
+          />
+        )}
+      </ModalSheet>
 
       <Fab onClick={openAdd} label={t("page.fuel_add")} />
     </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -213,7 +213,7 @@ function DashboardSettledNote({
   const noteStyle: React.CSSProperties = {
     fontFamily: fontMono,
     fontSize: 8,
-    color: paper.inkMute,
+    color: paper.inkDim,
     paddingLeft: 8,
     marginTop: 3,
     fontStyle: "italic",
@@ -454,13 +454,13 @@ function BalanceCardSkeleton() {
           {/* Year browser */}
           <div style={{ display: "flex", justifyContent: "center", marginBottom: 14, pointerEvents: "none" }}>
             <div style={{ display: "flex", border: `1.5px solid ${paper.paperDark}`, borderRadius: "var(--radius-pill, 999px)", padding: 2, gap: 1 }}>
-              <div style={{ padding: "4px 12px", fontFamily: fontMono, fontSize: 10, fontWeight: 700, color: paper.inkMute, borderRadius: "var(--radius-pill, 999px)" }}>
+              <div style={{ padding: "4px 12px", fontFamily: fontMono, fontSize: 10, fontWeight: 700, color: paper.inkDim, borderRadius: "var(--radius-pill, 999px)" }}>
                 ← {currentYear - 1}
               </div>
               <div style={{ padding: "4px 16px", fontFamily: fontMono, fontSize: 10, fontWeight: 700, background: paper.paperDark, color: paper.inkDim, borderRadius: "var(--radius-pill, 999px)" }}>
                 {currentYear}
               </div>
-              <div style={{ padding: "4px 12px", fontFamily: fontMono, fontSize: 10, fontWeight: 700, color: paper.inkMute, borderRadius: "var(--radius-pill, 999px)" }}>
+              <div style={{ padding: "4px 12px", fontFamily: fontMono, fontSize: 10, fontWeight: 700, color: paper.inkDim, borderRadius: "var(--radius-pill, 999px)" }}>
                 {currentYear + 1} →
               </div>
             </div>
@@ -593,7 +593,7 @@ function BalanceReceipt({ fullName, personId }: { fullName: string; personId: nu
                 fontWeight: 700,
                 letterSpacing: mono ? 0 : 1,
                 background: "transparent",
-                color: year <= earliestYear ? paper.inkMute : (mono ? paper.inkDim : paper.ink),
+                color: year <= earliestYear ? paper.inkDim : (mono ? paper.inkDim : paper.ink),
                 border: "none",
                 borderRadius: "var(--radius-pill, 999px)",
                 cursor: year <= earliestYear ? "default" : "pointer",
@@ -625,7 +625,7 @@ function BalanceReceipt({ fullName, personId }: { fullName: string; personId: nu
                 fontWeight: 700,
                 letterSpacing: mono ? 0 : 1,
                 background: "transparent",
-                color: year >= currentYear ? paper.inkMute : (mono ? paper.inkDim : paper.ink),
+                color: year >= currentYear ? paper.inkDim : (mono ? paper.inkDim : paper.ink),
                 border: "none",
                 borderRadius: "var(--radius-pill, 999px)",
                 cursor: year >= currentYear ? "default" : "pointer",
@@ -875,7 +875,7 @@ function SectionHeader({ title, href }: { title: string; href: string }) {
           textTransform: mono ? "none" : ("uppercase" as const),
           borderBottom: mono ? "none" : `1px solid ${paper.inkDim}`,
           textDecoration: "none",
-          opacity: mono ? 0.7 : 1,
+          opacity: 1,
         }}
       >
         {t("action.see_all")}
@@ -1343,7 +1343,7 @@ function DashboardContent() {
           fontFamily: mono ? fontMono : fontSerif,
           fontSize: 12,
           fontStyle: mono ? "normal" : "italic",
-          color: paper.inkMute,
+          color: paper.inkDim,
           textAlign: "center",
           padding: "32px 32px 20px",
           lineHeight: 1.5,

--- a/app/trips/page.tsx
+++ b/app/trips/page.tsx
@@ -1,72 +1,36 @@
 "use client";
-import { Suspense, useState, useEffect } from "react";
-import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import { Suspense } from "react";
 import { toast } from "sonner";
-import * as Dialog from "@radix-ui/react-dialog";
 import { PageHeader } from "@/components/page-header";
 import { GroupedList } from "@/components/grouped-list";
 import { Fab } from "@/components/fab";
+import { ListFilterBar } from "@/components/list-filter-bar";
+import { ModalSheet } from "@/components/modal-sheet";
 import { TripForm } from "./trip-form";
 import { useTrips, useCreateTrip, useUpdateTrip, useDeleteTrip } from "@/hooks/use-trips";
 import { useMe } from "@/hooks/use-me";
 import { useQueryParam } from "@/hooks/use-query-param";
-import { YearSelect } from "@/components/year-select";
-import type { Trip } from "@/types";
+import { useEditModal } from "@/hooks/use-edit-modal";
 import { paper, fontMono, fmtYearMonth } from "@/lib/paper-theme";
-import { useTheme } from "@/lib/theme-context";
 import { useT } from "@/components/locale-provider";
 import { TripCard } from "@/components/trip-card";
 import { ErrorBoundary } from "@/components/error-boundary";
 
-const overlayStyle: React.CSSProperties = {
-  position: "fixed",
-  inset: 0,
-  background: "rgba(0,0,0,0.45)",
-  zIndex: 49,
-};
-const sheetStyle: React.CSSProperties = {
-  position: "fixed",
-  bottom: 0,
-  left: "50%",
-  transform: "translateX(-50%)",
-  width: "min(100%, 480px)",
-  maxHeight: "92dvh",
-  borderRadius: "14px 14px 0 0",
-  background: paper.paperDeep,
-  zIndex: 50,
-  overflowY: "auto",
-};
-
 function TripsContent() {
   const t = useT();
-  const { theme } = useTheme();
-  const mono = theme === "mono";
   const { data: trips = [], isLoading } = useTrips();
   const { data: me } = useMe();
   const createTrip = useCreateTrip();
   const updateTrip = useUpdateTrip();
   const deleteTrip = useDeleteTrip();
 
-  const searchParams = useSearchParams();
-  const router = useRouter();
-  const pathname = usePathname();
-
-  // Filter params (replace — no extra history entries)
   const [mineParam, setMineParam] = useQueryParam("mine", "");
   const [carFilter, setCarFilter] = useQueryParam("car", "");
   const [yearFilter, setYearFilter] = useQueryParam("year", "");
 
-  // Modal params (push — history entries for back-button support)
-  const actionParam = searchParams.get("action");
-  const editIdParam = searchParams.get("edit");
+  const { adding, editingId, modalClosed, openAdd, openEdit, closeModal } = useEditModal();
 
-  const adding = actionParam === "add";
-  const editingId = editIdParam ? Number(editIdParam) : null;
-  const editing =
-    !isLoading && editingId ? (trips.find((tr) => tr.id === editingId) ?? null) : null;
-
-  const [modalClosed, setModalClosed] = useState(false);
-  useEffect(() => { setModalClosed(false); }, [editingId]);
+  const editing = !isLoading && editingId ? (trips.find((tr) => tr.id === editingId) ?? null) : null;
 
   const isMine = mineParam === "true";
   const isOthers = mineParam === "false";
@@ -74,9 +38,7 @@ function TripsContent() {
   const cars = Array.from(
     new Set(trips.map((tr) => tr.car_short).filter((s): s is string => !!s))
   ).sort();
-  const years = Array.from(new Set(trips.map((tr) => tr.date.slice(0, 4))))
-    .sort()
-    .reverse();
+  const years = Array.from(new Set(trips.map((tr) => tr.date.slice(0, 4)))).sort().reverse();
 
   const visible = trips
     .filter((tr) => {
@@ -87,64 +49,11 @@ function TripsContent() {
     .filter((tr) => (carFilter ? tr.car_short === carFilter : true))
     .filter((tr) => (yearFilter ? tr.date.startsWith(yearFilter) : true));
 
-  const openAdd = () => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.set("action", "add");
-    router.push(`${pathname}?${params.toString()}`, { scroll: false });
-  };
-
-  const openEdit = (trip: Trip) => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.set("edit", String(trip.id));
-    router.push(`${pathname}?${params.toString()}`, { scroll: false });
-  };
-
-  const closeModal = () => {
-    setModalClosed(true);
-    window.history.replaceState(null, "", pathname);
-  };
-
-  const filterBtnStyle = (active: boolean): React.CSSProperties =>
-    mono
-      ? {
-          padding: "5px 11px",
-          background: active ? paper.ink : "transparent",
-          color: active ? paper.paper : paper.inkDim,
-          border: "none",
-          borderRadius: "var(--radius-pill, 999px)",
-          fontFamily: "var(--font-inter, 'Inter', system-ui, sans-serif)",
-          fontSize: 11.5,
-          fontWeight: 500,
-          letterSpacing: 0,
-          cursor: "pointer",
-          transition: "background 0.15s",
-        }
-      : {
-          padding: "5px 12px",
-          background: active ? paper.ink : "transparent",
-          color: active ? paper.paper : paper.inkDim,
-          border: `1.5px solid ${paper.ink}`,
-          fontFamily: fontMono,
-          fontSize: 9,
-          fontWeight: 700,
-          letterSpacing: 2,
-          textTransform: "uppercase",
-          cursor: "pointer",
-        };
-
   if (isLoading)
     return (
       <div style={{ background: paper.paperDeep, minHeight: "100dvh" }}>
         <PageHeader title={t("page.trips")} />
-        <div
-          style={{
-            padding: "32px 20px",
-            fontFamily: fontMono,
-            fontSize: 11,
-            color: paper.inkDim,
-            letterSpacing: 1,
-          }}
-        >
+        <div style={{ padding: "32px 20px", fontFamily: fontMono, fontSize: 11, color: paper.inkDim, letterSpacing: 1 }}>
           {t("state.loading")}
         </div>
       </div>
@@ -154,62 +63,17 @@ function TripsContent() {
     <div style={{ background: paper.paperDeep, minHeight: "100dvh", paddingBottom: 80 }}>
       <PageHeader title={t("page.trips")} />
 
-      <div
-        style={{
-          padding: "10px 16px 8px",
-          borderBottom: mono ? "none" : `1px solid ${paper.paperDark}`,
-          display: "flex",
-          flexDirection: "column",
-          gap: 6,
-        }}
-      >
-        {(canFilter || years.length > 1) && (
-          <div style={{ display: "flex", alignItems: "center" }}>
-            {canFilter && (
-              <div style={mono ? { display: "inline-flex", alignSelf: "flex-start", border: `1px solid ${paper.paperDark}`, borderRadius: "var(--radius-pill, 999px)", padding: 2, gap: 1 } : { display: "flex", gap: 0 }}>
-                {(["all", "mine"] as const).map((v, i, arr) => (
-                  <button
-                    key={v}
-                    onClick={() => setMineParam(v === "mine" ? "true" : "")}
-                    style={{
-                      ...filterBtnStyle(v === "mine" ? isMine : !isMine),
-                      ...(mono ? {} : { borderRight: i < arr.length - 1 ? "none" : `1.5px solid ${paper.ink}` }),
-                    }}
-                  >
-                    {v === "all" ? t("filter.all") : t("filter.mine")}
-                  </button>
-                ))}
-              </div>
-            )}
-            {years.length > 1 && (
-              <div style={{ marginLeft: "auto" }}>
-                <YearSelect
-                  value={yearFilter}
-                  onChange={setYearFilter}
-                  years={years}
-                  allLabel={t("filter.all")}
-                />
-              </div>
-            )}
-          </div>
-        )}
-        {cars.length > 1 && (
-          <div style={mono ? { display: "inline-flex", alignSelf: "flex-start", border: `1px solid ${paper.paperDark}`, borderRadius: "var(--radius-pill, 999px)", padding: 2, gap: 1 } : { display: "flex", gap: 0 }}>
-            {[null, ...cars].map((car, i, arr) => (
-              <button
-                key={car ?? "__all"}
-                onClick={() => setCarFilter(car ?? "")}
-                style={{
-                  ...filterBtnStyle(carFilter === (car ?? "")),
-                  ...(mono ? {} : { borderRight: i < arr.length - 1 ? "none" : `1.5px solid ${paper.ink}` }),
-                }}
-              >
-                {car ?? t("filter.all")}
-              </button>
-            ))}
-          </div>
-        )}
-      </div>
+      <ListFilterBar
+        canFilter={canFilter}
+        isMine={isMine}
+        cars={cars}
+        carFilter={carFilter}
+        years={years}
+        yearFilter={yearFilter}
+        onMineChange={setMineParam}
+        onCarChange={setCarFilter}
+        onYearChange={setYearFilter}
+      />
 
       <GroupedList
         items={visible}
@@ -217,107 +81,47 @@ function TripsContent() {
         getGroupLabel={(key) => fmtYearMonth(key + "-01")}
         getGroupTotal={(items) => items.reduce((s, trip) => s + trip.km, 0)}
         totalSuffix="km"
-        renderItem={(trip) => <TripCard key={trip.id} trip={trip} onClick={() => openEdit(trip)} />}
+        renderItem={(trip) => <TripCard key={trip.id} trip={trip} onClick={() => openEdit(trip.id)} />}
       />
 
       {visible.length === 0 && (
-        <div
-          style={{
-            padding: "32px 20px",
-            textAlign: "center",
-            fontFamily: fontMono,
-            fontSize: 11,
-            color: paper.inkDim,
-            letterSpacing: 1,
-          }}
-        >
+        <div style={{ padding: "32px 20px", textAlign: "center", fontFamily: fontMono, fontSize: 11, color: paper.inkDim, letterSpacing: 1 }}>
           {t("state.empty_trips")}
         </div>
       )}
 
-      <Dialog.Root
-        open={adding}
-        onOpenChange={(open) => {
-          if (!open) closeModal();
-        }}
-      >
-        <Dialog.Portal>
-          <Dialog.Overlay style={overlayStyle} />
-          <Dialog.Content style={sheetStyle} aria-describedby={undefined}>
-            <Dialog.Title
-              style={{
-                position: "absolute",
-                width: 1,
-                height: 1,
-                overflow: "hidden",
-                clip: "rect(0,0,0,0)",
-              }}
-            >
-              {t("page.trip_add")}
-            </Dialog.Title>
-            <TripForm
-              onSubmit={(data) =>
-                createTrip.mutate(data as any, {
-                  onSuccess: () => {
-                    closeModal();
-                    toast.success(t("toast.trip_saved"));
-                  },
-                  onError: (e) => toast.error(e.message),
-                })
-              }
-              onCancel={closeModal}
-            />
-          </Dialog.Content>
-        </Dialog.Portal>
-      </Dialog.Root>
+      <ModalSheet open={adding} onClose={closeModal} title={t("page.trip_add")}>
+        <TripForm
+          onSubmit={(data) =>
+            createTrip.mutate(data as any, {
+              onSuccess: () => { closeModal(); toast.success(t("toast.trip_saved")); },
+              onError: (e) => toast.error(e.message),
+            })
+          }
+          onCancel={closeModal}
+        />
+      </ModalSheet>
 
-      <Dialog.Root
-        open={!!editing && !modalClosed}
-        onOpenChange={(open) => {
-          if (!open) closeModal();
-        }}
-      >
-        <Dialog.Portal>
-          <Dialog.Overlay style={overlayStyle} />
-          <Dialog.Content style={sheetStyle} aria-describedby={undefined}>
-            <Dialog.Title
-              style={{
-                position: "absolute",
-                width: 1,
-                height: 1,
-                overflow: "hidden",
-                clip: "rect(0,0,0,0)",
-              }}
-            >
-              {t("page.trip_edit")}
-            </Dialog.Title>
-            {editing && (
-              <TripForm
-                defaultValues={editing}
-                onSubmit={(data) =>
-                  updateTrip.mutate({ id: editing.id, ...data } as any, {
-                    onSuccess: () => {
-                      closeModal();
-                      toast.success(t("toast.saved"));
-                    },
-                    onError: (e) => toast.error(e.message),
-                  })
-                }
-                onCancel={closeModal}
-                onDelete={() =>
-                  deleteTrip.mutate(editing.id, {
-                    onSuccess: () => {
-                      closeModal();
-                      toast.success(t("toast.trip_deleted"));
-                    },
-                    onError: (e) => toast.error(e.message),
-                  })
-                }
-              />
-            )}
-          </Dialog.Content>
-        </Dialog.Portal>
-      </Dialog.Root>
+      <ModalSheet open={!!editing && !modalClosed} onClose={closeModal} title={t("page.trip_edit")}>
+        {editing && (
+          <TripForm
+            defaultValues={editing}
+            onSubmit={(data) =>
+              updateTrip.mutate({ id: editing.id, ...data } as any, {
+                onSuccess: () => { closeModal(); toast.success(t("toast.saved")); },
+                onError: (e) => toast.error(e.message),
+              })
+            }
+            onCancel={closeModal}
+            onDelete={() =>
+              deleteTrip.mutate(editing.id, {
+                onSuccess: () => { closeModal(); toast.success(t("toast.trip_deleted")); },
+                onError: (e) => toast.error(e.message),
+              })
+            }
+          />
+        )}
+      </ModalSheet>
 
       <Fab onClick={openAdd} label={t("page.trip_add")} />
     </div>

--- a/components/expense-card.tsx
+++ b/components/expense-card.tsx
@@ -58,7 +58,7 @@ export function ExpenseCard({ expense, onClick }: ExpenseCardProps) {
           style={{
             fontFamily: fontMono,
             fontSize: mono ? 11.5 : 10,
-            color: mono ? paper.inkMute : paper.inkDim,
+            color: paper.inkDim,
             letterSpacing: mono ? 0 : 1,
             marginTop: 2,
           }}

--- a/components/fuel-card.tsx
+++ b/components/fuel-card.tsx
@@ -60,7 +60,7 @@ export function FuelCard({ fuel, onClick }: FuelCardProps) {
           style={{
             fontFamily: fontMono,
             fontSize: mono ? 11.5 : 10,
-            color: mono ? paper.inkMute : paper.inkDim,
+            color: paper.inkDim,
             letterSpacing: mono ? 0 : 1,
             marginTop: 2,
           }}
@@ -99,7 +99,7 @@ export function FuelCard({ fuel, onClick }: FuelCardProps) {
           )}
         </div>
         {fuel.price_per_liter && (
-          <div style={{ fontFamily: fontMono, fontSize: mono ? 11.5 : 10, color: mono ? paper.inkMute : paper.inkDim }}>
+          <div style={{ fontFamily: fontMono, fontSize: mono ? 11.5 : 10, color: paper.inkDim }}>
             €{fuel.price_per_liter.toFixed(3)}/L
           </div>
         )}

--- a/components/list-filter-bar.tsx
+++ b/components/list-filter-bar.tsx
@@ -1,0 +1,121 @@
+"use client";
+import { paper, fontMono } from "@/lib/paper-theme";
+import { useTheme } from "@/lib/theme-context";
+import { useT } from "@/components/locale-provider";
+import { YearSelect } from "@/components/year-select";
+
+interface ListFilterBarProps {
+  canFilter: boolean;
+  isMine: boolean;
+  cars: string[];
+  carFilter: string;
+  years: string[];
+  yearFilter: string;
+  onMineChange: (v: string) => void;
+  onCarChange: (v: string) => void;
+  onYearChange: (v: string) => void;
+}
+
+export function ListFilterBar({
+  canFilter,
+  isMine,
+  cars,
+  carFilter,
+  years,
+  yearFilter,
+  onMineChange,
+  onCarChange,
+  onYearChange,
+}: ListFilterBarProps) {
+  const t = useT();
+  const { theme } = useTheme();
+  const mono = theme === "mono";
+
+  const btnStyle = (active: boolean): React.CSSProperties =>
+    mono
+      ? {
+          padding: "5px 11px",
+          background: active ? paper.ink : "transparent",
+          color: active ? paper.paper : paper.inkDim,
+          border: "none",
+          borderRadius: "var(--radius-pill, 999px)",
+          fontFamily: "var(--font-inter, 'Inter', system-ui, sans-serif)",
+          fontSize: 11.5,
+          fontWeight: 500,
+          letterSpacing: 0,
+          cursor: "pointer",
+          transition: "background 0.15s",
+        }
+      : {
+          padding: "5px 12px",
+          background: active ? paper.ink : "transparent",
+          color: active ? paper.paper : paper.inkDim,
+          border: `1.5px solid ${paper.ink}`,
+          fontFamily: fontMono,
+          fontSize: 9,
+          fontWeight: 700,
+          letterSpacing: 2,
+          textTransform: "uppercase",
+          cursor: "pointer",
+        };
+
+  const pillGroup: React.CSSProperties = mono
+    ? { display: "inline-flex", alignSelf: "flex-start", border: `1px solid ${paper.paperDark}`, borderRadius: "var(--radius-pill, 999px)", padding: 2, gap: 1 }
+    : { display: "flex", gap: 0 };
+
+  if (!canFilter && years.length <= 1 && cars.length <= 1) return null;
+
+  return (
+    <div
+      style={{
+        padding: "10px 16px 8px",
+        borderBottom: mono ? "none" : `1px solid ${paper.paperDark}`,
+        display: "flex",
+        flexDirection: "column",
+        gap: 6,
+      }}
+    >
+      {(canFilter || years.length > 1) && (
+        <div style={{ display: "flex", alignItems: "center" }}>
+          {canFilter && (
+            <div style={pillGroup}>
+              {(["all", "mine"] as const).map((v, i, arr) => (
+                <button
+                  key={v}
+                  onClick={() => onMineChange(v === "mine" ? "true" : "")}
+                  style={{
+                    ...btnStyle(v === "mine" ? isMine : !isMine),
+                    ...(mono ? {} : { borderRight: i < arr.length - 1 ? "none" : `1.5px solid ${paper.ink}` }),
+                  }}
+                >
+                  {v === "all" ? t("filter.all") : t("filter.mine")}
+                </button>
+              ))}
+            </div>
+          )}
+          {years.length > 1 && (
+            <div style={{ marginLeft: "auto" }}>
+              <YearSelect value={yearFilter} onChange={onYearChange} years={years} allLabel={t("filter.all")} />
+            </div>
+          )}
+        </div>
+      )}
+      {cars.length > 1 && (
+        <div style={pillGroup}>
+          {[null, ...cars].map((car, i, arr) => (
+            <button
+              key={car ?? "__all"}
+              onClick={() => onCarChange(car ?? "")}
+              style={{
+                ...btnStyle(carFilter === (car ?? "")),
+                ...(mono ? {} : { borderRight: i < arr.length - 1 ? "none" : `1.5px solid ${paper.ink}` }),
+              }}
+            >
+              {car ?? t("filter.all")}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/modal-sheet.tsx
+++ b/components/modal-sheet.tsx
@@ -1,0 +1,52 @@
+"use client";
+import * as Dialog from "@radix-ui/react-dialog";
+import { paper } from "@/lib/paper-theme";
+
+const overlayStyle: React.CSSProperties = {
+  position: "fixed",
+  inset: 0,
+  background: "rgba(0,0,0,0.45)",
+  zIndex: 49,
+};
+
+const sheetStyle: React.CSSProperties = {
+  position: "fixed",
+  bottom: 0,
+  left: "50%",
+  transform: "translateX(-50%)",
+  width: "min(100%, 480px)",
+  maxHeight: "92dvh",
+  borderRadius: "14px 14px 0 0",
+  background: paper.paperDeep,
+  zIndex: 50,
+  overflowY: "auto",
+};
+
+const srOnly: React.CSSProperties = {
+  position: "absolute",
+  width: 1,
+  height: 1,
+  overflow: "hidden",
+  clip: "rect(0,0,0,0)",
+};
+
+interface ModalSheetProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  children: React.ReactNode;
+}
+
+export function ModalSheet({ open, onClose, title, children }: ModalSheetProps) {
+  return (
+    <Dialog.Root open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
+      <Dialog.Portal>
+        <Dialog.Overlay style={overlayStyle} />
+        <Dialog.Content style={sheetStyle} aria-describedby={undefined}>
+          <Dialog.Title style={srOnly}>{title}</Dialog.Title>
+          {children}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/components/page-header.tsx
+++ b/components/page-header.tsx
@@ -113,7 +113,7 @@ export function PageHeader({ title, subtitle, right, titleSize = 26 }: Props) {
                 ? "var(--font-jetbrains-mono, 'JetBrains Mono', monospace)"
                 : fontMono,
               fontSize: 8,
-              color: paper.inkMute,
+              color: paper.inkDim,
               letterSpacing: mono ? 0 : 1,
               textDecoration: "none",
             }}

--- a/components/reservation-card.tsx
+++ b/components/reservation-card.tsx
@@ -66,7 +66,7 @@ export function ReservationCard({ reservation, onClick }: ReservationCardProps) 
           style={{
             fontFamily: fontMono,
             fontSize: mono ? 11.5 : 10,
-            color: mono ? paper.inkMute : paper.inkDim,
+            color: paper.inkDim,
             letterSpacing: mono ? 0 : 1,
             marginTop: 2,
           }}

--- a/components/trip-card.tsx
+++ b/components/trip-card.tsx
@@ -60,7 +60,7 @@ export function TripCard({ trip, onClick }: TripCardProps) {
           style={{
             fontFamily: fontMono,
             fontSize: mono ? 11.5 : 10,
-            color: mono ? paper.inkMute : paper.inkDim,
+            color: paper.inkDim,
             letterSpacing: mono ? 0 : 1,
             marginTop: 2,
           }}
@@ -83,7 +83,7 @@ export function TripCard({ trip, onClick }: TripCardProps) {
         >
           {fmtMoney(trip.amount)}
         </div>
-        <div style={{ fontFamily: fontMono, fontSize: mono ? 11.5 : 10, color: mono ? paper.inkMute : paper.inkDim }}>{trip.km} km</div>
+        <div style={{ fontFamily: fontMono, fontSize: mono ? 11.5 : 10, color: paper.inkDim }}>{trip.km} km</div>
       </div>
     </button>
   );

--- a/e2e/a11y-audit.spec.ts
+++ b/e2e/a11y-audit.spec.ts
@@ -1,8 +1,20 @@
 import { test, expect, type Page } from "@playwright/test";
+import path from "path";
 
-// axe-core 4.10.3 injected from CDN — no npm package needed
-const AXE_CDN =
-  "https://cdnjs.cloudflare.com/ajax/libs/axe-core/4.10.3/axe.min.js";
+/**
+ * Accessibility audit using axe-core.
+ *
+ * Theme: ALL tests run in MONO theme.
+ * All demo.db users (alice, bob, carol, owner, admin) have theme_preference='mono'.
+ * Contrast thresholds must pass against the mono palette (paperDeep background,
+ * inkDim minimum for body text — inkMute is intentionally excluded from small text).
+ */
+
+// axe-core loaded from local node_modules — no CDN dependency
+const AXE_PATH = path.resolve(
+  __dirname,
+  "../node_modules/axe-core/axe.js"
+);
 
 type AxeViolation = {
   id: string;
@@ -13,8 +25,7 @@ type AxeViolation = {
 };
 
 async function runAxe(page: Page): Promise<AxeViolation[]> {
-  await page.addScriptTag({ url: AXE_CDN });
-  // Wait for axe to be available
+  await page.addScriptTag({ path: AXE_PATH });
   await page.waitForFunction(() => typeof (window as any).axe !== "undefined");
   return page.evaluate(async () => {
     const results = await (window as any).axe.run();

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -15,12 +15,12 @@ setup("log in", async ({ page }) => {
   // The label text comes from t("form.name") → "Naam *" (nl) / "Name *" (en)
   await page
     .getByLabel(/naam|name/i)
-    .fill(process.env.TEST_EMAIL ?? "test@example.com");
+    .fill(process.env.TEST_EMAIL ?? "alice");
 
   // t("form.password") → "Wachtwoord" (nl) / "Password" (en)
   await page
     .getByLabel(/wachtwoord|password/i)
-    .fill(process.env.TEST_PASSWORD ?? "changeme");
+    .fill(process.env.TEST_PASSWORD ?? "alice");
 
   // t("action.login") → "Inloggen" (nl) / "Log in" (en)
   await page.getByRole("button", { name: /inloggen|log\s*in/i }).click();

--- a/e2e/direct-url-edit.spec.ts
+++ b/e2e/direct-url-edit.spec.ts
@@ -20,7 +20,7 @@ test.describe("direct URL edit — close stays on page", () => {
   let carId: number;
 
   test.beforeEach(async ({ request }) => {
-    const session = await loginAndGetSession(request);
+    const session = await loginAndGetSession(request, "alice", "alice");
     csrf = session.csrf;
     api = makeApi(request, csrf);
     const entities = await getTestEntities(api);
@@ -41,7 +41,7 @@ test.describe("direct URL edit — close stays on page", () => {
   test.afterEach(async ({ request }) => {
     if (!tripId) return;
     try {
-      const cleanupCsrf = await loginAndGetCsrf(request);
+      const cleanupCsrf = await loginAndGetCsrf(request, "alice", "alice");
       await makeApi(request, cleanupCsrf).delete(`/api/trips/${tripId}`);
     } catch {
       // already deleted
@@ -84,7 +84,7 @@ test.describe("direct URL edit — close stays on page", () => {
   });
 
   test("closing edit form opened via direct URL stays on /fuel", async ({ page, request }) => {
-    const fuelCsrf = await loginAndGetCsrf(request);
+    const fuelCsrf = await loginAndGetCsrf(request, "alice", "alice");
     const fuelApi = makeApi(request, fuelCsrf);
     const entities = await getTestEntities(fuelApi);
 
@@ -113,7 +113,7 @@ test.describe("direct URL edit — close stays on page", () => {
   });
 
   test("closing edit form opened via direct URL stays on /expenses", async ({ page, request }) => {
-    const expCsrf = await loginAndGetCsrf(request);
+    const expCsrf = await loginAndGetCsrf(request, "alice", "alice");
     const expApi = makeApi(request, expCsrf);
     const entities = await getTestEntities(expApi);
 

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -10,16 +10,16 @@ import type { APIRequestContext } from "@playwright/test";
  */
 export async function loginAndGetCsrf(
   request: APIRequestContext,
-  email = process.env.TEST_EMAIL ?? "test@example.com",
-  password = process.env.TEST_PASSWORD ?? "changeme"
+  email = process.env.TEST_EMAIL ?? "alice",
+  password = process.env.TEST_PASSWORD ?? "alice"
 ): Promise<string> {
   return (await loginAndGetSession(request, email, password)).csrf;
 }
 
 export async function loginAndGetSession(
   request: APIRequestContext,
-  email = process.env.TEST_EMAIL ?? "test@example.com",
-  password = process.env.TEST_PASSWORD ?? "changeme"
+  email = process.env.TEST_EMAIL ?? "alice",
+  password = process.env.TEST_PASSWORD ?? "alice"
 ): Promise<{ csrf: string; personId: number | null }> {
   const res = await request.post("/api/auth/login", {
     data: { username: email, password },

--- a/hooks/use-edit-modal.ts
+++ b/hooks/use-edit-modal.ts
@@ -1,0 +1,37 @@
+"use client";
+import { useState, useEffect } from "react";
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
+
+export function useEditModal() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const actionParam = searchParams.get("action");
+  const editIdParam = searchParams.get("edit");
+
+  const adding = actionParam === "add";
+  const editingId = editIdParam ? Number(editIdParam) : null;
+
+  const [modalClosed, setModalClosed] = useState(false);
+  useEffect(() => { setModalClosed(false); }, [editingId]);
+
+  const openAdd = () => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("action", "add");
+    router.push(`${pathname}?${params.toString()}`, { scroll: false });
+  };
+
+  const openEdit = (id: number) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("edit", String(id));
+    router.push(`${pathname}?${params.toString()}`, { scroll: false });
+  };
+
+  const closeModal = () => {
+    setModalClosed(true);
+    window.history.replaceState(null, "", pathname);
+  };
+
+  return { adding, editingId, modalClosed, openAdd, openEdit, closeModal };
+}


### PR DESCRIPTION
Closes #228

## Summary
- Extract `hooks/use-edit-modal.ts`: URL-driven modal state (`?action=add` / `?edit=<id>`) shared across trips, fuel, and expenses pages
- Extract `components/list-filter-bar.tsx`: mine/all toggle + car filter + year select
- Extract `components/modal-sheet.tsx`: Radix Dialog bottom-sheet wrapper
- Fix WCAG AA contrast violations (inkMute → inkDim) in card components, dashboard, and page header
- Fix nested interactive elements in admin members page
- Switch axe-core from CDN to local node_modules (reliable in offline/CI environments)

## Test Plan
- [x] Unit tests: 411/411 passing
- [x] a11y audit: 16/16 passing (all critical/serious violations resolved)
- [x] Direct-URL edit: opening `/trips?edit=<id>` shows form; closing stays on `/trips`
- [x] Add/edit/delete flows on `/trips`, `/fuel`, `/expenses`

🤖 Generated with [Claude Code](https://claude.com/claude-code)