### PR TITLE
fix(settlement): use net payments for step-1 paid/open annotation

### DIFF
--- a/lib/__tests__/settlement.test.ts
+++ b/lib/__tests__/settlement.test.ts
@@ -60,7 +60,6 @@ describe("getSettlement", () => {
     expect(dave.s1).toBe(-90); // -(50+40)
   });
 
-
   it("S₂ for owners uses N_new", () => {
     const db = makeDb();
     seed(db);
@@ -238,7 +237,7 @@ describe("getSettlement — payment integration", () => {
   it("reports all_paid=true when all transfers are fully paid", () => {
     const db = makeDb();
     seed(db);
-    const nameToId: Record<string, number> = { "Alice": 1, "Bob": 2, "Carol": 3, "Dave": 4 };
+    const nameToId: Record<string, number> = { Alice: 1, Bob: 2, Carol: 3, Dave: 4 };
     const result0 = getSettlement(db, 2025);
     // Pay every transfer that has a payment_status
     for (const t of result0.transfers) {
@@ -270,6 +269,54 @@ describe("getSettlement — payment integration", () => {
     }
     const result1 = getSettlement(db, 2025);
     expect(result1.all_paid).toBe(true);
+  });
+
+  it("debit: overpayment + refund nets to zero open balance", () => {
+    const db = makeDb();
+    seed(db);
+    // Carol owes €180 (S1 = -180). She pays €220, co-op refunds €40 excess.
+    // Net: 220 - 40 = 180 = exactly her debt → open should be 0, no surplus.
+    insertPayment(db, { person_id: 3, date: "2026-01-01", amount: 220, note: "overpayment" });
+    insertPayment(db, { person_id: 3, date: "2026-01-15", amount: -40, note: "refund excess" });
+    const result = getSettlement(db, 2025);
+    const carolT = result.transfers.find((t) => t.step === 1 && t.from === "Carol")!;
+    expect(carolT.payment_status).not.toBeNull();
+    expect(carolT.payment_status!.paid).toBeCloseTo(180, 2);
+    expect(carolT.payment_status!.open).toBeCloseTo(0, 2);
+    expect(carolT.payment_status!.payments).toHaveLength(2);
+  });
+
+  it("credit: over-reimbursement + correction payment nets to zero open balance", () => {
+    const db = makeDb();
+    seed(db);
+    // Add Eve who pays €50 fuel for CarA (no trips) → S1(Eve) = +50, co-op owes Eve.
+    db.prepare(
+      "INSERT INTO people (id, first_name, last_name, active) VALUES (5,'Eve','Member',1)"
+    ).run();
+    db.prepare(
+      "INSERT INTO fuel_fillups (person_id, car_id, date, liters, amount, price_per_liter) VALUES (5,1,'2025-03-01',40,50,1.25)"
+    ).run();
+    // Co-op pays Eve €80 (too much by €30), Eve pays back €30.
+    // Net: -80 + 30 = -50, |net| = 50 = exactly what she was owed → open should be 0.
+    insertPayment(db, {
+      person_id: 5,
+      date: "2026-01-01",
+      amount: -80,
+      note: "reimbursement (too much)",
+    });
+    insertPayment(db, {
+      person_id: 5,
+      date: "2026-01-15",
+      amount: 30,
+      note: "Eve pays back excess",
+    });
+    const result = getSettlement(db, 2025);
+    const eveT = result.transfers.find((t) => t.step === 1 && t.to === "Eve")!;
+    expect(eveT).toBeDefined();
+    expect(eveT.payment_status).not.toBeNull();
+    expect(eveT.payment_status!.paid).toBeCloseTo(50, 2);
+    expect(eveT.payment_status!.open).toBeCloseTo(0, 2);
+    expect(eveT.payment_status!.payments).toHaveLength(2);
   });
 
   it("includes payments_by_person in the result", () => {

--- a/lib/queries/settlement.ts
+++ b/lib/queries/settlement.ts
@@ -77,9 +77,7 @@ function buildNameToId(people: PersonRow[]): Map<string, number> {
   for (const p of people) {
     const key = shortNameOf(p);
     if (map.has(key)) {
-      console.warn(
-        `[settlement] duplicate shortName "${key}" — payment annotation may be wrong`
-      );
+      console.warn(`[settlement] duplicate shortName "${key}" — payment annotation may be wrong`);
     }
     map.set(key, p.id);
   }
@@ -581,20 +579,26 @@ export function getSettlement(db: Database.Database, year: number): SettlementRe
     }
 
     if (tr.from === "co-op") {
-      // Step 1 credit (co-op → regular member): track negative payments.
+      // Step 1 credit (co-op → regular member): net of all payments (excess repaid by member reduces paid).
       const recipientId = nameToId.get(tr.to) ?? null;
       if (recipientId === null) return { ...tr, payment_status: null };
-      const personPayments = (paymentsByPerson.get(recipientId) ?? []).filter((p) => p.amount < 0);
-      const paid = round2(personPayments.reduce((s, p) => s + Math.abs(p.amount), 0));
+      const personPayments = paymentsByPerson.get(recipientId) ?? [];
+      const netPaid = round2(personPayments.reduce((s, p) => s + p.amount, 0));
+      const paid = round2(Math.abs(netPaid));
       const open = round2(Math.max(0, tr.amount - paid));
       return { ...tr, payment_status: { paid, open, payments: personPayments } };
     }
 
-    // Step 1 debit (regular member → co-op): track positive payments.
+    // Step 1 debit (regular member → co-op): net of all payments (refunds reduce paid amount).
     const payerId = nameToId.get(tr.from) ?? null;
     if (payerId === null) return { ...tr, payment_status: null };
-    const personPayments = (paymentsByPerson.get(payerId) ?? []).filter((p) => p.amount > 0);
-    const paid = round2(personPayments.reduce((s, p) => s + p.amount, 0));
+    const personPayments = paymentsByPerson.get(payerId) ?? [];
+    const paid = round2(
+      Math.max(
+        0,
+        personPayments.reduce((s, p) => s + p.amount, 0)
+      )
+    );
     const open = round2(Math.max(0, tr.amount - paid));
     return { ...tr, payment_status: { paid, open, payments: personPayments } };
   });


### PR DESCRIPTION
## Summary

- Debit transfers (member owes co-op) previously only counted positive payments. A refund/correction payment (negative amount) was silently ignored, leaving the transfer showing "teveel betaald" even after the net was correct.
- Credit transfers (co-op owes member) had the mirror problem: only negative payments were counted, so a member paying back an over-reimbursement was ignored.
- Both cases now use net of all payments — consistent with how Step 2 (owner payouts) already worked.

**Real example fixed:** Wim 2021 owed €253.31, paid €295.91, received –€42.60 refund. Net = €253.31. Settlement page now shows "Volledig betaald" instead of "+€42.60 teveel betaald".

## Test plan

- [x] `npm test -- settlement` — 22/22 pass
- [x] New test: debit overpayment + refund → paid=owed, open=0
- [x] New test: credit over-reimbursement + correction → paid=owed, open=0
- [ ] Verify Wim 2021 on https://autodelen.bluette.be/admin/settlement?year=2021 shows "Volledig betaald"