### PR TITLE
chore(tsconfig): exclude docs/ from TypeScript compilation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "docs"]
 }


### PR DESCRIPTION
## Summary

- Adds `docs` to `tsconfig.json` exclude list so prototype/spec files in `docs/` are not type-checked during the main build.

## Test plan

- [x] `npm run build` completes without TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)