### PR TITLE
feat(settlement): show already-paid amount in settlement message

### DIFF
--- a/app/admin/settlement/page.tsx
+++ b/app/admin/settlement/page.tsx
@@ -13,6 +13,7 @@ import { apiFetch } from "@/lib/api/client";
 import { Card, Row, Perf } from "../_shared";
 import type { MemberStatement, AnnotatedTransfer } from "@/types";
 import { fullNameOf } from "@/lib/person-utils";
+import { buildSettlementMessage, buildSettlementLines, type SettlementLine } from "@/lib/settlement-message";
 
 function fmtL(liters: number): string {
   return liters.toLocaleString("nl-BE", { minimumFractionDigits: 1, maximumFractionDigits: 1 });
@@ -438,6 +439,110 @@ function CarSectionHeader({ label, saldo }: { label: string; saldo: number }) {
   );
 }
 
+function renderLineJsx(line: SettlementLine, key: number): React.ReactNode {
+  switch (line.kind) {
+    case "section_break":
+      return (
+        <div
+          key={key}
+          style={{ marginTop: 14, borderTop: `1px dashed ${paper.paperDark}`, paddingTop: 10 }}
+        />
+      );
+    case "car_header":
+      return (
+        <CarSectionHeader
+          key={key}
+          label={line.label}
+          saldo={line.sign === "+" ? line.amount : -line.amount}
+        />
+      );
+    case "row":
+      return (
+        <BreakdownCarRow
+          key={key}
+          car={line.label}
+          detail={null}
+          amount={`${line.sign} ${fmtMoney(line.amount)}`}
+          amountColor={line.sign === "−" ? paper.accent : paper.green}
+        />
+      );
+    case "row_zero":
+      return (
+        <BreakdownCarRow
+          key={key}
+          car={line.label}
+          detail={null}
+          amount={fmtMoney(0)}
+          amountColor={paper.inkDim}
+        />
+      );
+    case "note":
+      return (
+        <div
+          key={key}
+          style={{
+            fontFamily: fontMono,
+            fontSize: 8,
+            color: paper.inkDim,
+            paddingLeft: 16,
+            marginTop: 4,
+            fontStyle: "italic",
+          }}
+        >
+          {line.text}
+        </div>
+      );
+    case "separator":
+      return (
+        <div
+          key={key}
+          style={{ borderTop: `1px dashed ${paper.paperDark}`, marginTop: 10, paddingTop: 8 }}
+        />
+      );
+    case "summary": {
+      const signed = line.sign === "+" ? line.amount : -line.amount;
+      return (
+        <div
+          key={key}
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "baseline",
+            marginTop: line.emphasis ? 0 : 4,
+          }}
+        >
+          <span
+            style={{
+              fontFamily: fontMono,
+              fontSize: 9,
+              letterSpacing: 1.5,
+              textTransform: "uppercase" as const,
+              color: paper.inkDim,
+              fontWeight: line.emphasis ? 700 : 400,
+            }}
+          >
+            {line.label}
+          </span>
+          <span
+            style={{
+              fontFamily: fontMono,
+              fontSize: line.emphasis ? 14 : 10,
+              fontWeight: line.emphasis ? 700 : 400,
+              color: amtColor(signed),
+            }}
+          >
+            {signPrefix(signed)}
+            {fmtMoney(signed)}
+          </span>
+        </div>
+      );
+    }
+    case "instruction_pay":
+    case "instruction_receive":
+      return null;
+  }
+}
+
 function MemberCard({
   m,
   year,
@@ -447,6 +552,7 @@ function MemberCard({
   crossRows,
   settlementTransfer,
   showAll,
+  alreadyPaid,
 }: {
   m: MemberStatement;
   year: number;
@@ -456,6 +562,7 @@ function MemberCard({
   crossRows: { car_short: string; row: import("@/types").CarParticipantRow }[];
   settlementTransfer: AnnotatedTransfer | undefined;
   showAll: boolean;
+  alreadyPaid: number;
 }) {
   const t = useT();
   const [open, setOpen] = useState(false);
@@ -483,134 +590,20 @@ function MemberCard({
   const isSlim = !showAll && exactMatch;
 
   const copyMsg = () => {
-    const iban =
-      bankAccount || "(rekeningnummer niet ingesteld — stel in via Admin → Instellingen)";
-    const W = 40;
-    const WC = 32;
-    const e = (n: number) => `€ ${n.toFixed(2).replace(".", ",").padStart(6)}`;
-    const row = (left: string, sign: "+" | "−", n: number, w = W) => {
-      const right = `${sign} ${e(n)}`;
-      return left + " ".repeat(Math.max(1, w - left.length - right.length)) + right;
-    };
-
-    const sections: string[] = [];
-
-    if (m.is_owner) {
-      for (const era of m.car_eras) {
-        const nStar = era.n_c_star ?? 0;
-        const contribs = era.member_contributions ?? [];
-        if (Math.abs(nStar) < 0.005 && contribs.length === 0) continue;
-        const lines: string[] = [
-          row(
-            `${t("settlement.section_own_car")} — ${era.car_short}`,
-            nStar >= 0 ? "+" : "−",
-            Math.abs(nStar)
-          ),
-        ];
-        for (const c of contribs) {
-          const detail =
-            c.trip_km > 0
-              ? ` (${c.trip_km} km${c.fuel_liters > 0.05 ? `, ${fmtL(c.fuel_liters)} L` : ""}${c.expense_amount > 0 ? `, € ${c.expense_amount.toFixed(2).replace(".", ",")}` : ""})`
-              : "";
-          if (c.contribution === 0) {
-            const label = `  ${c.person_name}${detail}`;
-            lines.push(label + " ".repeat(Math.max(1, W - label.length - 7)) + `€  0,00`);
-          } else {
-            lines.push(
-              row(
-                `  ${c.person_name}${detail}`,
-                c.contribution >= 0 ? "+" : "−",
-                Math.abs(c.contribution),
-                WC
-              )
-            );
-          }
-        }
-        sections.push(lines.join("\n"));
-      }
-      if (crossRows.length > 0) {
-        const lines: string[] = [];
-        for (const { car_short, row: r } of crossRows) {
-          const parts: string[] = [];
-          if (r.trip_km > 0) parts.push(`${r.trip_km} km`);
-          if (r.fuel_liters > 0.05) parts.push(`${fmtL(r.fuel_liters)} L`);
-          const saldo = -r.balance;
-          lines.push(
-            row(
-              `${car_short}${parts.length ? ` (${parts.join(", ")})` : ""}`,
-              saldo >= 0 ? "+" : "−",
-              Math.abs(saldo)
-            )
-          );
-        }
-        sections.push(lines.join("\n"));
-      }
-    } else {
-      // Group by car, then type — mirrors the card structure
-      for (const era of m.car_eras) {
-        if (era.trip_km === 0 && era.fuel_liters === 0 && era.expense_amount === 0) continue;
-        const sec = [row(era.car_short, era.balance >= 0 ? "+" : "−", Math.abs(era.balance))];
-        if (era.trip_km > 0)
-          sec.push(row(`  ${t("page.trips")} (${era.trip_km} km)`, "−", era.trip_amount, WC));
-        const hasFuelStar = (era.fuel_settled_liters ?? 0) > 0.05;
-        const hasExpStar = (era.expense_settled_amount ?? 0) > 0.005;
-        if (era.fuel_liters > 0)
-          sec.push(
-            row(
-              `  ${t("settlement.breakdown_fuel")} (${fmtL(era.fuel_liters)} L)${hasFuelStar ? " (*)" : ""}`,
-              "+",
-              era.fuel_amount,
-              WC
-            )
-          );
-        if (era.expense_amount > 0)
-          sec.push(
-            row(
-              `  ${t("settlement.breakdown_costs")}${hasExpStar ? (hasFuelStar ? " (**)" : " (*)") : ""}`,
-              "+",
-              era.expense_amount,
-              WC
-            )
-          );
-        if (hasFuelStar)
-          sec.push(
-            `  (*) ${era.fuel_settled_count} tankbeurt${(era.fuel_settled_count ?? 0) !== 1 ? "en" : ""} (${fmtL(era.fuel_settled_liters ?? 0)} L) buiten afrekening`
-          );
-        if (hasExpStar) {
-          const prefix = hasFuelStar ? "(**)" : "(*)";
-          sec.push(
-            `  ${prefix} ${era.expense_settled_count} kost${(era.expense_settled_count ?? 0) !== 1 ? "en" : ""} buiten afrekening`
-          );
-        }
-        sections.push(sec.join("\n"));
-      }
-    }
-
-    const separator = "─".repeat(W);
-    const lines = [
-      "```",
-      `Beste ${personFullName},`,
-      m.is_owner
-        ? `Jouw eigenaarspayout voor ${year}:`
-        : `Jouw aandeel in de jaarafrekening ${year}:`,
-      ...(sections.length > 0 ? [sections.join("\n")] : []),
-      separator,
-      row(`Saldo`, net >= 0 ? "+" : "−", Math.abs(net)),
-      ``,
-      ...(net > 0
-        ? [
-            personBankAccount
-              ? `Coöp schrijft ${e(Math.abs(net))} over naar ${personBankAccount}.`
-              : `Coöp schrijft ${e(Math.abs(net))} over naar jou.`,
-          ]
-        : net < 0
-          ? [`Gelieve ${e(Math.abs(net))} over te schrijven naar ${iban}.`]
-          : []),
-      `Je overzicht: ${typeof window !== "undefined" ? window.location.origin : ""}`,
-      "```",
-    ];
-
-    navigator.clipboard.writeText(lines.join("\n"));
+    const text = buildSettlementMessage({
+      m,
+      year,
+      bankAccount,
+      personBankAccount,
+      personFullName,
+      crossRows,
+      alreadyPaid,
+      t: (key: string) => t(key as Parameters<typeof t>[0]),
+    }).replace(
+      "Je overzicht: ",
+      `Je overzicht: ${typeof window !== "undefined" ? window.location.origin : ""}`
+    );
+    navigator.clipboard.writeText(text);
     setMsgCopied(true);
     setTimeout(() => setMsgCopied(false), 2000);
   };
@@ -708,190 +701,15 @@ function MemberCard({
 
       {open && (
         <div style={{ borderTop: `1px dashed ${paper.paperDark}`, padding: "10px 14px 14px" }}>
-          {/* Non-owner: per-car breakdown */}
-          {!m.is_owner &&
-            m.car_eras.map((era, i) => (
-              <div key={i} style={{ marginTop: i === 0 ? 0 : 14 }}>
-                <CarSectionHeader label={era.car_short} saldo={era.balance} />
-                {era.trip_km > 0 && (
-                  <BreakdownCarRow
-                    car={`${t("page.trips")} (${era.trip_km} km)`}
-                    detail={null}
-                    amount={`− ${fmtMoney(era.trip_amount)}`}
-                    amountColor={paper.accent}
-                  />
-                )}
-                {era.fuel_liters > 0 && (
-                  <BreakdownCarRow
-                    car={`${t("settlement.breakdown_fuel")} (${fmtL(era.fuel_liters)} L${(era.fuel_settled_liters ?? 0) > 0.05 ? " (*)" : ""})`}
-                    detail={null}
-                    amount={`+ ${fmtMoney(era.fuel_amount)}`}
-                    amountColor={paper.green}
-                  />
-                )}
-                {era.expense_amount > 0 && (
-                  <BreakdownCarRow
-                    car={`${t("settlement.breakdown_costs")}${(era.expense_settled_amount ?? 0) > 0.005 ? ((era.fuel_settled_liters ?? 0) > 0.05 ? " (**)" : " (*)") : ""}`}
-                    detail={null}
-                    amount={`+ ${fmtMoney(era.expense_amount)}`}
-                    amountColor={paper.green}
-                  />
-                )}
-                <SettledNote
-                  fuelCount={era.fuel_settled_count ?? 0}
-                  fuelLiters={era.fuel_settled_liters ?? 0}
-                  expCount={era.expense_settled_count ?? 0}
-                  expAmt={era.expense_settled_amount ?? 0}
-                />
-              </div>
-            ))}
-
-          {/* EIGEN WAGEN section — owners only, shown first */}
-          {m.is_owner &&
-            m.car_eras.map((era, i) => {
-              const nStar = era.n_c_star ?? 0;
-              const contribs = era.member_contributions ?? [];
-              if (Math.abs(nStar) < 0.005 && contribs.length === 0) return null;
-              return (
-                <div
-                  key={i}
-                  style={{
-                    marginTop: i > 0 ? 14 : 0,
-                    borderTop: i > 0 ? `1px dashed ${paper.paperDark}` : undefined,
-                    paddingTop: i > 0 ? 10 : 0,
-                  }}
-                >
-                  <CarSectionHeader
-                    label={`${t("settlement.section_own_car")} — ${era.car_short}`}
-                    saldo={nStar}
-                  />
-                  {contribs.map((contrib, j) => {
-                    const detail = fmtDetail(
-                      contrib.trip_km,
-                      contrib.fuel_liters,
-                      contrib.expense_amount,
-                      contrib.fuel_settled_liters,
-                      contrib.expense_settled_amount
-                    );
-                    const isOwnRow = contrib.person_name === m.person_name;
-                    return (
-                      <div
-                        key={j}
-                        style={{
-                          display: "flex",
-                          justifyContent: "space-between",
-                          alignItems: "baseline",
-                          paddingLeft: 16,
-                          marginTop: 2,
-                        }}
-                      >
-                        <span style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkDim }}>
-                          {contrib.person_name}
-                          {detail ? ` ${detail}` : ""}
-                        </span>
-                        <span
-                          style={{
-                            fontFamily: fontMono,
-                            fontSize: 10,
-                            color: isOwnRow ? paper.inkDim : amtColor(contrib.contribution),
-                            paddingLeft: 12,
-                          }}
-                        >
-                          {isOwnRow
-                            ? fmtMoney(0)
-                            : `${signPrefix(contrib.contribution)}${fmtMoney(contrib.contribution)}`}
-                        </span>
-                      </div>
-                    );
-                  })}
-                  <SettledNote
-                    fuelCount={contribs.reduce((s, c) => s + (c.fuel_settled_count ?? 0), 0)}
-                    fuelLiters={contribs.reduce((s, c) => s + (c.fuel_settled_liters ?? 0), 0)}
-                    expCount={contribs.reduce((s, c) => s + (c.expense_settled_count ?? 0), 0)}
-                    expAmt={contribs.reduce((s, c) => s + (c.expense_settled_amount ?? 0), 0)}
-                  />
-                </div>
-              );
-            })}
-
-          {/* Cross-car sections — owners who drove other owners' cars */}
-          {m.is_owner && crossRows.length > 0 && (
-            <div
-              style={{
-                marginTop: 14,
-                borderTop: `1px dashed ${paper.paperDark}`,
-                paddingTop: 10,
-              }}
-            >
-              {crossRows.map((item, i) => {
-                const crossSaldo = -item.row.balance;
-                return (
-                  <div key={i} style={{ marginTop: i === 0 ? 0 : 14 }}>
-                    <CarSectionHeader label={item.car_short} saldo={crossSaldo} />
-                    {item.row.trip_km > 0 && (
-                      <BreakdownCarRow
-                        car={`ritten (${item.row.trip_km} km)`}
-                        detail={null}
-                        amount={`− ${fmtMoney(item.row.trip_amount)}`}
-                        amountColor={paper.accent}
-                      />
-                    )}
-                    {item.row.fuel_liters > 0 && (
-                      <BreakdownCarRow
-                        car={`brandstof (${fmtL(item.row.fuel_liters)} L)${item.row.fuel_settled_liters > 0.05 ? " (*)" : ""}`}
-                        detail={null}
-                        amount={`+ ${fmtMoney(item.row.fuel_amount)}`}
-                        amountColor={paper.green}
-                      />
-                    )}
-                    {item.row.expense_amount > 0 && (
-                      <BreakdownCarRow
-                        car={`kosten${item.row.expense_settled_amount > 0.005 ? (item.row.fuel_settled_liters > 0.05 ? " (**)" : " (*)") : ""}`}
-                        detail={null}
-                        amount={`+ ${fmtMoney(item.row.expense_amount)}`}
-                        amountColor={paper.green}
-                      />
-                    )}
-                    <SettledNote
-                      fuelCount={item.row.fuel_settled_count}
-                      fuelLiters={item.row.fuel_settled_liters}
-                      expCount={item.row.expense_settled_count}
-                      expAmt={item.row.expense_settled_amount}
-                    />
-                  </div>
-                );
-              })}
-            </div>
-          )}
-
-          {/* SALDO */}
-          <div
-            style={{
-              display: "flex",
-              justifyContent: "space-between",
-              alignItems: "baseline",
-              marginTop: 10,
-              paddingTop: 8,
-              borderTop: `1px dashed ${paper.paperDark}`,
-            }}
-          >
-            <span
-              style={{
-                fontFamily: fontMono,
-                fontSize: 9,
-                letterSpacing: 1.5,
-                textTransform: "uppercase" as const,
-                color: paper.inkDim,
-                fontWeight: 700,
-              }}
-            >
-              Saldo
-            </span>
-            <span style={{ fontFamily: fontMono, fontSize: 14, fontWeight: 700, color: netColor }}>
-              {signPrefix(net)}
-              {fmtMoney(net)}
-            </span>
-          </div>
+          {buildSettlementLines({
+            m,
+            year,
+            bankAccount,
+            personBankAccount,
+            crossRows,
+            alreadyPaid,
+            t: (key: string) => t(key as Parameters<typeof t>[0]),
+          }).map((line, i) => renderLineJsx(line, i))}
 
           {/* Transfer direction */}
           {Math.abs(net) > 0.005 && bankAccount && (
@@ -1286,6 +1104,7 @@ function AdminSettlementPageContent() {
                         tr.payment_status !== null
                     )}
                     showAll={showAll}
+                    alreadyPaid={data.payments_by_person[m.person_id] ?? 0}
                   />
                 ))}
 

--- a/lib/__tests__/queries.test.ts
+++ b/lib/__tests__/queries.test.ts
@@ -355,13 +355,13 @@ describe("getDashboard", () => {
 
     insertFuelFillup(db, {
       person_id: memberId, car_id: cid, date: "2026-01-10",
-      amount: 40, liters: 25, price_per_liter: null, full_tank: 0,
+      amount: 40, liters: 25, full_tank: 0,
       odometer: null, receipt: null, location: null, gps_coords: null,
       settled_outside: 1,
     });
     insertFuelFillup(db, {
       person_id: memberId, car_id: cid, date: "2026-01-11",
-      amount: 20, liters: 12, price_per_liter: null, full_tank: 0,
+      amount: 20, liters: 12, full_tank: 0,
       odometer: null, receipt: null, location: null, gps_coords: null,
       settled_outside: 0,
     });
@@ -390,7 +390,7 @@ describe("getDashboard", () => {
     });
     insertFuelFillup(db, {
       person_id: ownerId, car_id: cid2, date: "2026-02-01",
-      amount: 50, liters: 30, price_per_liter: null, full_tank: 0,
+      amount: 50, liters: 30, full_tank: 0,
       odometer: null, receipt: null, location: null, gps_coords: null,
       settled_outside: 1,
     });
@@ -427,7 +427,6 @@ describe("getDashboard", () => {
       date: "2026-01-10",
       amount: 50,
       liters: 30,
-      price_per_liter: null,
       full_tank: 0,
       odometer: null,
       receipt: null,
@@ -442,7 +441,6 @@ describe("getDashboard", () => {
       date: "2026-01-10",
       amount: 20,
       liters: 12,
-      price_per_liter: null,
       full_tank: 0,
       odometer: null,
       receipt: null,

--- a/lib/__tests__/settlement_lines.test.ts
+++ b/lib/__tests__/settlement_lines.test.ts
@@ -1,0 +1,282 @@
+// lib/__tests__/settlement_lines.test.ts
+import { describe, it, expect } from "vitest";
+import { buildSettlementLines } from "../settlement-lines";
+import type { SettlementLine } from "../settlement-lines";
+import type { MemberStatement } from "@/types";
+
+const mockT = (key: string): string => {
+  const map: Record<string, string> = {
+    "settlement.section_own_car": "Eigen wagen",
+    "page.trips": "Ritten",
+    "settlement.breakdown_fuel": "Brandstof",
+    "settlement.breakdown_costs": "Kosten",
+  };
+  return map[key] ?? key;
+};
+
+const kinds = (lines: SettlementLine[]) => lines.map((l) => l.kind);
+
+const nonOwner: MemberStatement = {
+  person_id: 3,
+  person_name: "Alice",
+  is_owner: false,
+  s1: -148.01,
+  car_eras: [
+    {
+      car_name: "Car A",
+      car_short: "CA",
+      owner_name: "Bob",
+      owner_from: "2020-01-01",
+      owner_to: null,
+      balance: -148.01,
+      trip_km: 500,
+      trip_amount: 100,
+      fuel_liters: 20,
+      fuel_amount: 48.01,
+      expense_amount: 0,
+    },
+  ],
+};
+
+describe("buildSettlementLines — non-owner, no payments", () => {
+  const lines = () =>
+    buildSettlementLines({
+      m: nonOwner,
+      year: 2024,
+      bankAccount: "BE00 0000 0000 0000",
+      personBankAccount: "",
+      crossRows: [],
+      alreadyPaid: 0,
+      t: mockT,
+    });
+
+  it("produces car_header → row(trips) → row(fuel) → separator → summary(Saldo) → instruction_pay", () => {
+    expect(kinds(lines())).toEqual([
+      "car_header",
+      "row",
+      "row",
+      "separator",
+      "summary",
+      "instruction_pay",
+    ]);
+  });
+
+  it("car_header has correct label, sign, amount", () => {
+    const header = lines().find((l) => l.kind === "car_header") as Extract<SettlementLine, { kind: "car_header" }>;
+    expect(header.label).toBe("CA");
+    expect(header.sign).toBe("−");
+    expect(header.amount).toBeCloseTo(148.01, 2);
+  });
+
+  it("trip row has correct label and sign", () => {
+    const row = lines().find((l) => l.kind === "row") as Extract<SettlementLine, { kind: "row" }>;
+    expect(row.label).toContain("Ritten");
+    expect(row.label).toContain("500 km");
+    expect(row.sign).toBe("−");
+    expect(row.amount).toBeCloseTo(100, 2);
+  });
+
+  it("summary label is 'Saldo' when no payments", () => {
+    const s = lines().find((l) => l.kind === "summary") as Extract<SettlementLine, { kind: "summary" }>;
+    expect(s.label).toBe("Saldo");
+    expect(s.sign).toBe("−");
+    expect(s.amount).toBeCloseTo(148.01, 2);
+  });
+
+  it("no instruction line when person has no balance direction to settle", () => {
+    // balance < 0 → person owes co-op → instruction_pay with iban
+    const inst = lines().find((l) => l.kind === "instruction_pay") as Extract<SettlementLine, { kind: "instruction_pay" }> | undefined;
+    expect(inst).toBeDefined();
+    expect(inst!.iban).toBe("BE00 0000 0000 0000");
+    expect(inst!.amount).toBeCloseTo(148.01, 2);
+  });
+});
+
+describe("buildSettlementLines — non-owner, with partial payment", () => {
+  const lines = () =>
+    buildSettlementLines({
+      m: nonOwner,
+      year: 2024,
+      bankAccount: "BE00 0000 0000 0000",
+      personBankAccount: "",
+      crossRows: [],
+      alreadyPaid: 50,
+      t: mockT,
+    });
+
+  it("produces car_header → row → row → separator → summary(Bruto) → summary(Al betaald) → separator → summary(Nog te betalen)", () => {
+    expect(kinds(lines())).toEqual([
+      "car_header",
+      "row",
+      "row",
+      "separator",
+      "summary",  // Bruto saldo
+      "summary",  // Al betaald
+      "separator",
+      "summary",  // Nog te betalen
+      "instruction_pay",
+    ]);
+  });
+
+  it("first summary is 'Bruto saldo'", () => {
+    const summaries = lines().filter((l) => l.kind === "summary") as Extract<SettlementLine, { kind: "summary" }>[];
+    expect(summaries[0].label).toBe("Bruto saldo");
+    expect(summaries[0].amount).toBeCloseTo(148.01, 2);
+  });
+
+  it("second summary is 'Al betaald'", () => {
+    const summaries = lines().filter((l) => l.kind === "summary") as Extract<SettlementLine, { kind: "summary" }>[];
+    expect(summaries[1].label).toBe("Al betaald");
+    expect(summaries[1].amount).toBeCloseTo(50, 2);
+  });
+
+  it("final summary is 'Nog te betalen' with remaining amount", () => {
+    const summaries = lines().filter((l) => l.kind === "summary") as Extract<SettlementLine, { kind: "summary" }>[];
+    expect(summaries[2].label).toBe("Nog te betalen");
+    expect(summaries[2].amount).toBeCloseTo(98.01, 2);
+    expect(summaries[2].emphasis).toBe(true);
+  });
+});
+
+describe("buildSettlementLines — non-owner, net > 0 with payments", () => {
+  it("instruction_receive when remaining > 0", () => {
+    const lines = buildSettlementLines({
+      m: { ...nonOwner, s1: 2.19 },
+      year: 2025,
+      bankAccount: "BE00 0000 0000 0000",
+      personBankAccount: "BE00 0000 0000 0004",
+      crossRows: [],
+      alreadyPaid: -2,  // raw sum: 22 + (-24)
+      t: mockT,
+    });
+    const inst = lines.find((l) => l.kind === "instruction_receive") as Extract<SettlementLine, { kind: "instruction_receive" }> | undefined;
+    expect(inst).toBeDefined();
+    expect(inst!.amount).toBeCloseTo(0.19, 2);
+    expect(inst!.bankAccount).toBe("BE00 0000 0000 0004");
+  });
+
+  it("final summary is 'Nog te ontvangen' when co-op still owes", () => {
+    const lines = buildSettlementLines({
+      m: { ...nonOwner, s1: 2.19 },
+      year: 2025,
+      bankAccount: "BE00 0000 0000 0000",
+      personBankAccount: "",
+      crossRows: [],
+      alreadyPaid: -2,
+      t: mockT,
+    });
+    const summaries = lines.filter((l) => l.kind === "summary") as Extract<SettlementLine, { kind: "summary" }>[];
+    expect(summaries.at(-1)!.label).toBe("Nog te ontvangen");
+  });
+});
+
+describe("buildSettlementLines — two car eras → section_break between them", () => {
+  it("inserts section_break between car sections", () => {
+    const twoCarMember: MemberStatement = {
+      ...nonOwner,
+      car_eras: [
+        { ...nonOwner.car_eras[0], car_short: "CA" },
+        { ...nonOwner.car_eras[0], car_short: "CB", balance: -80, trip_km: 400, trip_amount: 80, fuel_liters: 0, fuel_amount: 0 },
+      ],
+    };
+    const lines = buildSettlementLines({
+      m: twoCarMember,
+      year: 2024,
+      bankAccount: "",
+      personBankAccount: "",
+      crossRows: [],
+      alreadyPaid: 0,
+      t: mockT,
+    });
+    expect(kinds(lines)).toContain("section_break");
+    // section_break appears between the two car_headers
+    const breakIdx = lines.findIndex((l) => l.kind === "section_break");
+    expect(lines[breakIdx - 1].kind).not.toBe("car_header");  // after some rows
+    expect(lines[breakIdx + 1].kind).toBe("car_header");      // before next header
+  });
+});
+
+describe("buildSettlementLines — settled-outside notes", () => {
+  it("emits note line when fuel_settled_liters > 0", () => {
+    const member: MemberStatement = {
+      ...nonOwner,
+      car_eras: [{
+        ...nonOwner.car_eras[0],
+        fuel_settled_liters: 10,
+        fuel_settled_count: 1,
+      }],
+    };
+    const lines = buildSettlementLines({
+      m: member,
+      year: 2024,
+      bankAccount: "",
+      personBankAccount: "",
+      crossRows: [],
+      alreadyPaid: 0,
+      t: mockT,
+    });
+    const note = lines.find((l) => l.kind === "note") as Extract<SettlementLine, { kind: "note" }> | undefined;
+    expect(note).toBeDefined();
+    expect(note!.text).toContain("(*)");
+    expect(note!.text).toContain("buiten afrekening");
+  });
+});
+
+describe("buildSettlementLines — owner, own car section", () => {
+  const owner: MemberStatement = {
+    person_id: 1,
+    person_name: "Alice",
+    is_owner: true,
+    s2: 150,
+    s1_cross: 0,
+    net: 150,
+    car_eras: [
+      {
+        car_name: "Car A",
+        car_short: "CA",
+        owner_name: "Alice",
+        owner_from: "2020-01-01",
+        owner_to: null,
+        balance: 150,
+        trip_km: 0,
+        trip_amount: 0,
+        fuel_liters: 0,
+        fuel_amount: 0,
+        expense_amount: 0,
+        n_c_star: 150,
+        member_contributions: [
+          { person_name: "Bob", trip_km: 500, fuel_liters: 10, expense_amount: 0, contribution: 150, fuel_settled_count: 0, fuel_settled_liters: 0, expense_settled_count: 0, expense_settled_amount: 0 },
+        ],
+      },
+    ],
+  };
+
+  it("produces car_header with 'Eigen wagen — CA' label", () => {
+    const lines = buildSettlementLines({
+      m: owner,
+      year: 2024,
+      bankAccount: "",
+      personBankAccount: "",
+      crossRows: [],
+      alreadyPaid: 0,
+      t: mockT,
+    });
+    const header = lines.find((l) => l.kind === "car_header") as Extract<SettlementLine, { kind: "car_header" }>;
+    expect(header.label).toBe("Eigen wagen — CA");
+  });
+
+  it("produces row for each member contribution", () => {
+    const lines = buildSettlementLines({
+      m: owner,
+      year: 2024,
+      bankAccount: "",
+      personBankAccount: "",
+      crossRows: [],
+      alreadyPaid: 0,
+      t: mockT,
+    });
+    const rows = lines.filter((l) => l.kind === "row") as Extract<SettlementLine, { kind: "row" }>[];
+    expect(rows.length).toBe(1);
+    expect(rows[0].label).toContain("Bob");
+  });
+});

--- a/lib/__tests__/settlement_message.test.ts
+++ b/lib/__tests__/settlement_message.test.ts
@@ -1,0 +1,161 @@
+// lib/__tests__/settlement_message.test.ts
+import { describe, it, expect } from "vitest";
+import { buildSettlementMessage } from "../settlement-message";
+import type { MemberStatement } from "@/types";
+
+const mockT = (key: string): string => {
+  const map: Record<string, string> = {
+    "settlement.section_own_car": "Eigen wagen",
+    "page.trips": "Ritten",
+    "settlement.breakdown_fuel": "Brandstof",
+    "settlement.breakdown_costs": "Kosten",
+  };
+  return map[key] ?? key;
+};
+
+const nonOwner: MemberStatement = {
+  person_id: 3,
+  person_name: "Alice",
+  is_owner: false,
+  s1: -148.01,
+  car_eras: [
+    {
+      car_name: "Car A",
+      car_short: "CA",
+      owner_name: "Bob",
+      owner_from: "2020-01-01",
+      owner_to: null,
+      balance: -148.01,
+      trip_km: 500,
+      trip_amount: 100,
+      fuel_liters: 20,
+      fuel_amount: 25,
+      expense_amount: 0,
+    },
+  ],
+};
+
+describe("buildSettlementMessage — no payments", () => {
+  it("contains 'Saldo' when alreadyPaid is 0", () => {
+    const msg = buildSettlementMessage({
+      m: nonOwner,
+      year: 2024,
+      bankAccount: "BE00 0000 0000 0000",
+      personBankAccount: "",
+      personFullName: "Alice",
+      crossRows: [],
+      alreadyPaid: 0,
+      t: mockT,
+    });
+    expect(msg).toContain("Saldo");
+    expect(msg).not.toContain("Bruto saldo");
+    expect(msg).not.toContain("Al betaald");
+  });
+});
+
+describe("buildSettlementMessage — with partial payment", () => {
+  it("shows Bruto saldo, Al betaald when alreadyPaid > 0", () => {
+    const msg = buildSettlementMessage({
+      m: nonOwner,
+      year: 2024,
+      bankAccount: "BE00 0000 0000 0000",
+      personBankAccount: "",
+      personFullName: "Alice",
+      crossRows: [],
+      alreadyPaid: 50,
+      t: mockT,
+    });
+    expect(msg).toContain("Bruto saldo");
+    expect(msg).toContain("Al betaald");
+  });
+
+  it("remaining amount = |net| - alreadyPaid when still underpaid", () => {
+    // net = -148.01, paid = 50 → still owe 98.01
+    const msg = buildSettlementMessage({
+      m: nonOwner,
+      year: 2024,
+      bankAccount: "BE00 0000 0000 0000",
+      personBankAccount: "",
+      personFullName: "Alice",
+      crossRows: [],
+      alreadyPaid: 50,
+      t: mockT,
+    });
+    expect(msg).toContain("98,01");
+    expect(msg).toContain("Gelieve");
+  });
+
+  it("shows co-op owes back when overpaid", () => {
+    // net = -100, paid = 150 → co-op owes back 50
+    const msg = buildSettlementMessage({
+      m: { ...nonOwner, s1: -100 },
+      year: 2024,
+      bankAccount: "BE00 0000 0000 0000",
+      personBankAccount: "",
+      personFullName: "Alice",
+      crossRows: [],
+      alreadyPaid: 150,
+      t: mockT,
+    });
+    expect(msg).toContain("50,00");
+    expect(msg).toContain("Coöp schrijft");
+  });
+
+  it("net > 0: co-op already paid person partially — remaining = net - paid", () => {
+    // net = +2.19 (co-op owes person), co-op already paid 21 → overpaid by 18.81 → person owes back
+    const msg = buildSettlementMessage({
+      m: { ...nonOwner, s1: 2.19 },
+      year: 2025,
+      bankAccount: "BE00 0000 0000 0000",
+      personBankAccount: "",
+      personFullName: "Bob",
+      crossRows: [],
+      alreadyPaid: 21,
+      t: mockT,
+    });
+    expect(msg).toContain("Bruto saldo");
+    expect(msg).toContain("Al betaald");
+    // remaining = 2.19 - 21 = -18.81 → Bob owes co-op €18.81
+    expect(msg).toContain("18,81");
+    expect(msg).toContain("Gelieve");
+    expect(msg).not.toContain("Coöp schrijft");
+  });
+
+  it("net > 0: negative alreadyPaid (netted payments) treated as absolute value", () => {
+    // net = +2.19, payments_by_person = 22 + (−24) = −2 → effective paid = 2
+    // remaining = 2.19 − 2 = 0.19 → co-op still owes 0.19
+    const msg = buildSettlementMessage({
+      m: { ...nonOwner, s1: 2.19 },
+      year: 2025,
+      bankAccount: "BE00 0000 0000 0000",
+      personBankAccount: "BE00 0000 0000 0004",
+      personFullName: "Bob",
+      crossRows: [],
+      alreadyPaid: -2,
+      t: mockT,
+    });
+    expect(msg).toContain("Bruto saldo");
+    expect(msg).toContain("Al betaald");
+    expect(msg).toContain("0,19");
+    expect(msg).toContain("Coöp schrijft");
+    expect(msg).not.toContain("4,19");
+  });
+
+  it("shows fully settled when exactly paid", () => {
+    // net = -148.01, paid = 148.01 → nothing left
+    const msg = buildSettlementMessage({
+      m: nonOwner,
+      year: 2024,
+      bankAccount: "BE00 0000 0000 0000",
+      personBankAccount: "",
+      personFullName: "Alice",
+      crossRows: [],
+      alreadyPaid: 148.01,
+      t: mockT,
+    });
+    expect(msg).toContain("Bruto saldo");
+    expect(msg).toContain("Al betaald");
+    expect(msg).not.toContain("Gelieve");
+    expect(msg).not.toContain("Coöp schrijft");
+  });
+});

--- a/lib/settlement-lines.ts
+++ b/lib/settlement-lines.ts
@@ -1,0 +1,217 @@
+import type { MemberStatement, CarParticipantRow } from "@/types";
+
+function fmtL(liters: number): string {
+  return liters.toLocaleString("nl-BE", { minimumFractionDigits: 1, maximumFractionDigits: 1 });
+}
+
+export type SettlementLine =
+  | { kind: "section_break" }
+  | { kind: "car_header"; label: string; sign: "+" | "−"; amount: number }
+  | { kind: "row"; label: string; sign: "+" | "−"; amount: number }
+  | { kind: "row_zero"; label: string }
+  | { kind: "note"; text: string }
+  | { kind: "separator" }
+  | { kind: "summary"; label: string; sign: "+" | "−"; amount: number; emphasis?: boolean }
+  | { kind: "instruction_pay"; amount: number; iban: string }
+  | { kind: "instruction_receive"; amount: number; bankAccount: string };
+
+export interface BuildSettlementLinesParams {
+  m: MemberStatement;
+  year: number;
+  bankAccount: string;
+  personBankAccount: string;
+  crossRows: { car_short: string; row: CarParticipantRow }[];
+  alreadyPaid: number;
+  t: (key: string) => string;
+}
+
+export function buildSettlementLines({
+  m,
+  bankAccount,
+  personBankAccount,
+  crossRows,
+  alreadyPaid,
+  t,
+}: BuildSettlementLinesParams): SettlementLine[] {
+  const lines: SettlementLine[] = [];
+  const net = m.is_owner ? (m.net ?? 0) : (m.s1 ?? 0);
+
+  if (m.is_owner) {
+    let first = true;
+    for (const era of m.car_eras) {
+      const nStar = era.n_c_star ?? 0;
+      const contribs = era.member_contributions ?? [];
+      if (Math.abs(nStar) < 0.005 && contribs.length === 0) continue;
+      if (!first) lines.push({ kind: "section_break" });
+      first = false;
+      lines.push({
+        kind: "car_header",
+        label: `${t("settlement.section_own_car")} — ${era.car_short}`,
+        sign: nStar >= 0 ? "+" : "−",
+        amount: Math.abs(nStar),
+      });
+      for (const c of contribs) {
+        const detail =
+          c.trip_km > 0
+            ? ` (${c.trip_km} km${c.fuel_liters > 0.05 ? `, ${fmtL(c.fuel_liters)} L` : ""}${c.expense_amount > 0 ? `, € ${c.expense_amount.toFixed(2).replace(".", ",")}` : ""})`
+            : "";
+        if (c.contribution === 0) {
+          lines.push({ kind: "row_zero", label: `${c.person_name}${detail}` });
+        } else {
+          lines.push({
+            kind: "row",
+            label: `${c.person_name}${detail}`,
+            sign: c.contribution >= 0 ? "+" : "−",
+            amount: Math.abs(c.contribution),
+          });
+        }
+      }
+      const fuelCount = contribs.reduce((s, c) => s + (c.fuel_settled_count ?? 0), 0);
+      const fuelLiters = contribs.reduce((s, c) => s + (c.fuel_settled_liters ?? 0), 0);
+      const expCount = contribs.reduce((s, c) => s + (c.expense_settled_count ?? 0), 0);
+      const expAmt = contribs.reduce((s, c) => s + (c.expense_settled_amount ?? 0), 0);
+      if (fuelLiters > 0.05) {
+        lines.push({
+          kind: "note",
+          text: `(*) ${fuelCount} tankbeurt${fuelCount !== 1 ? "en" : ""} (${fmtL(fuelLiters)} L) buiten afrekening`,
+        });
+      }
+      if (expAmt > 0.005) {
+        const prefix = fuelLiters > 0.05 ? "(**)" : "(*)";
+        lines.push({
+          kind: "note",
+          text: `${prefix} ${expCount} kost${expCount !== 1 ? "en" : ""} (€ ${expAmt.toFixed(2).replace(".", ",")}) buiten afrekening`,
+        });
+      }
+    }
+    if (crossRows.length > 0) {
+      if (!first) lines.push({ kind: "section_break" });
+      for (const { car_short, row: r } of crossRows) {
+        const saldo = -r.balance;
+        lines.push({
+          kind: "car_header",
+          label: car_short,
+          sign: saldo >= 0 ? "+" : "−",
+          amount: Math.abs(saldo),
+        });
+        if (r.trip_km > 0) {
+          lines.push({ kind: "row", label: `ritten (${r.trip_km} km)`, sign: "−", amount: r.trip_amount });
+        }
+        if (r.fuel_liters > 0.05) {
+          const hasFuelStar = r.fuel_settled_liters > 0.05;
+          lines.push({
+            kind: "row",
+            label: `brandstof (${fmtL(r.fuel_liters)} L)${hasFuelStar ? " (*)" : ""}`,
+            sign: "+",
+            amount: r.fuel_amount,
+          });
+        }
+        if (r.expense_amount > 0.005) {
+          const hasFuelStar = r.fuel_settled_liters > 0.05;
+          const hasExpStar = r.expense_settled_amount > 0.005;
+          lines.push({
+            kind: "row",
+            label: `kosten${hasExpStar ? (hasFuelStar ? " (**)" : " (*)") : ""}`,
+            sign: "+",
+            amount: r.expense_amount,
+          });
+        }
+        if (r.fuel_settled_liters > 0.05) {
+          lines.push({
+            kind: "note",
+            text: `(*) ${r.fuel_settled_count} tankbeurt${r.fuel_settled_count !== 1 ? "en" : ""} (${fmtL(r.fuel_settled_liters)} L) buiten afrekening`,
+          });
+        }
+        if (r.expense_settled_amount > 0.005) {
+          const prefix = r.fuel_settled_liters > 0.05 ? "(**)" : "(*)";
+          lines.push({
+            kind: "note",
+            text: `${prefix} ${r.expense_settled_count} kost${r.expense_settled_count !== 1 ? "en" : ""} (€ ${r.expense_settled_amount.toFixed(2).replace(".", ",")}) buiten afrekening`,
+          });
+        }
+      }
+    }
+  } else {
+    let first = true;
+    for (const era of m.car_eras) {
+      if (era.trip_km === 0 && era.fuel_liters === 0 && era.expense_amount === 0) continue;
+      if (!first) lines.push({ kind: "section_break" });
+      first = false;
+      lines.push({
+        kind: "car_header",
+        label: era.car_short,
+        sign: era.balance >= 0 ? "+" : "−",
+        amount: Math.abs(era.balance),
+      });
+      if (era.trip_km > 0) {
+        lines.push({ kind: "row", label: `${t("page.trips")} (${era.trip_km} km)`, sign: "−", amount: era.trip_amount });
+      }
+      const hasFuelStar = (era.fuel_settled_liters ?? 0) > 0.05;
+      const hasExpStar = (era.expense_settled_amount ?? 0) > 0.005;
+      if (era.fuel_liters > 0) {
+        lines.push({
+          kind: "row",
+          label: `${t("settlement.breakdown_fuel")} (${fmtL(era.fuel_liters)} L)${hasFuelStar ? " (*)" : ""}`,
+          sign: "+",
+          amount: era.fuel_amount,
+        });
+      }
+      if (era.expense_amount > 0) {
+        lines.push({
+          kind: "row",
+          label: `${t("settlement.breakdown_costs")}${hasExpStar ? (hasFuelStar ? " (**)" : " (*)") : ""}`,
+          sign: "+",
+          amount: era.expense_amount,
+        });
+      }
+      if (hasFuelStar) {
+        lines.push({
+          kind: "note",
+          text: `(*) ${era.fuel_settled_count} tankbeurt${(era.fuel_settled_count ?? 0) !== 1 ? "en" : ""} (${fmtL(era.fuel_settled_liters ?? 0)} L) buiten afrekening`,
+        });
+      }
+      if (hasExpStar) {
+        const prefix = hasFuelStar ? "(**)" : "(*)";
+        lines.push({
+          kind: "note",
+          text: `${prefix} ${era.expense_settled_count} kost${(era.expense_settled_count ?? 0) !== 1 ? "en" : ""} (€ ${(era.expense_settled_amount ?? 0).toFixed(2).replace(".", ",")}) buiten afrekening`,
+        });
+      }
+    }
+  }
+
+  // Summary
+  lines.push({ kind: "separator" });
+  const paid = Math.abs(alreadyPaid) > 0.005 ? Math.abs(alreadyPaid) : 0;
+  const remaining = net > 0 ? net - paid : net + paid;
+
+  if (paid > 0.005) {
+    lines.push({ kind: "summary", label: "Bruto saldo", sign: net >= 0 ? "+" : "−", amount: Math.abs(net) });
+    lines.push({ kind: "summary", label: "Al betaald", sign: "+", amount: paid });
+    lines.push({ kind: "separator" });
+  }
+
+  const finalLabel =
+    paid > 0.005
+      ? remaining >= 0
+        ? "Nog te ontvangen"
+        : "Nog te betalen"
+      : "Saldo";
+  lines.push({
+    kind: "summary",
+    label: finalLabel,
+    sign: remaining >= 0 ? "+" : "−",
+    amount: Math.abs(remaining),
+    emphasis: true,
+  });
+
+  // Payment instruction
+  const iban = bankAccount || "(rekeningnummer niet ingesteld — stel in via Admin → Instellingen)";
+  if (remaining > 0.005) {
+    lines.push({ kind: "instruction_receive", amount: remaining, bankAccount: personBankAccount });
+  } else if (remaining < -0.005) {
+    lines.push({ kind: "instruction_pay", amount: Math.abs(remaining), iban });
+  }
+
+  return lines;
+}

--- a/lib/settlement-message.ts
+++ b/lib/settlement-message.ts
@@ -1,0 +1,90 @@
+import type { MemberStatement, CarParticipantRow } from "@/types";
+import { buildSettlementLines, type SettlementLine } from "./settlement-lines";
+
+export type { SettlementLine };
+export { buildSettlementLines };
+
+export interface SettlementMessageParams {
+  m: MemberStatement;
+  year: number;
+  bankAccount: string;
+  personBankAccount: string;
+  personFullName: string;
+  crossRows: { car_short: string; row: CarParticipantRow }[];
+  alreadyPaid: number;
+  t: (key: string) => string;
+}
+
+const W = 40;
+const WC = 32;
+
+function e(n: number): string {
+  return `€ ${n.toFixed(2).replace(".", ",").padStart(6)}`;
+}
+
+function row(left: string, sign: "+" | "−", n: number, w = W): string {
+  const right = `${sign} ${e(n)}`;
+  return left + " ".repeat(Math.max(1, w - left.length - right.length)) + right;
+}
+
+export function renderLinesToText(lines: SettlementLine[]): string {
+  const result: string[] = [];
+  for (const line of lines) {
+    switch (line.kind) {
+      case "section_break":
+        // sections in text are contiguous — no blank line between car sections
+        break;
+      case "car_header":
+        result.push(row(line.label, line.sign, line.amount, W));
+        break;
+      case "row":
+        result.push(row(`  ${line.label}`, line.sign, line.amount, WC));
+        break;
+      case "row_zero": {
+        const label = `  ${line.label}`;
+        result.push(label + " ".repeat(Math.max(1, W - label.length - 7)) + `€  0,00`);
+        break;
+      }
+      case "note":
+        result.push(`  ${line.text}`);
+        break;
+      case "separator":
+        result.push("─".repeat(W));
+        break;
+      case "summary":
+        result.push(row(line.label, line.sign, line.amount, W));
+        break;
+      case "instruction_pay":
+        result.push(``, `Gelieve ${e(line.amount)} over te schrijven naar ${line.iban}.`);
+        break;
+      case "instruction_receive":
+        result.push(
+          ``,
+          line.bankAccount
+            ? `Coöp schrijft ${e(line.amount)} over naar ${line.bankAccount}.`
+            : `Coöp schrijft ${e(line.amount)} over naar jou.`
+        );
+        break;
+    }
+  }
+  return result.join("\n");
+}
+
+export function buildSettlementMessage({
+  m,
+  year,
+  bankAccount,
+  personBankAccount,
+  personFullName,
+  crossRows,
+  alreadyPaid,
+  t,
+}: SettlementMessageParams): string {
+  const lines = buildSettlementLines({ m, year, bankAccount, personBankAccount, crossRows, alreadyPaid, t });
+  const body = renderLinesToText(lines);
+  const header = [
+    `Beste ${personFullName},`,
+    m.is_owner ? `Jouw eigenaarspayout voor ${year}:` : `Jouw aandeel in de jaarafrekening ${year}:`,
+  ].join("\n");
+  return ["```", header, body, `Je overzicht: `, "```"].join("\n");
+}


### PR DESCRIPTION
## Summary

- Adds **Bruto saldo / Al betaald / Nog te betalen|ontvangen** breakdown to the copied settlement message when payments have been recorded, matching what the payment-status card already shows
- Fixes sign bug when `payments_by_person` is a negative net sum (uses `Math.abs()` consistent with `payment_status.paid`)
- Extracts `buildSettlementLines()` as a single source of truth shared by both the card JSX renderer and the plain-text message renderer — the two cannot drift independently
- Removes spurious `price_per_liter` field from `FuelFillupInput` test objects

## Test Plan

- [ ] 442 unit tests pass (`npx vitest run`)
- [ ] 15 new tests for `buildSettlementLines()` covering non-owner, owner, section breaks, notes, payment breakdown
- [ ] 7 new tests for `buildSettlementMessage()` covering sign edge cases (negative `alreadyPaid`, overpayment, net > 0)
- [ ] Bob 2025 in demo.db: card and message both show Bruto saldo / Al betaald / Nog te ontvangen
- [ ] Member with no payments: message shows plain Saldo (unchanged)

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)