### PR TITLE
fix(calendar): run delta sync on every renew call, not only on channel rotation

### DIFF
--- a/lib/__tests__/calendar_renew.test.ts
+++ b/lib/__tests__/calendar_renew.test.ts
@@ -37,7 +37,7 @@ describe("handleCalendarRenew", () => {
     expect(calMock.watchEvents).not.toHaveBeenCalled();
   });
 
-  it("returns skipped:not_due when channel expires in >5 days", async () => {
+  it("returns skipped:not_due but still runs delta sync when channel expires in >5 days", async () => {
     const db = makeDb();
     setSetting(db, "google_calendar_id", "cal-id");
     setSetting(db, "google_oauth_refresh_token", "rt");
@@ -49,6 +49,35 @@ describe("handleCalendarRenew", () => {
     const result = await handleCalendarRenew(db, "https://example.com");
     expect(result).toEqual({ ok: true, skipped: "not_due" });
     expect(calMock.watchEvents).not.toHaveBeenCalled();
+    expect(calMock.listEventsDelta).toHaveBeenCalledWith(expect.anything(), "cal-id", "tok");
+    const row = db
+      .prepare("SELECT sync_token FROM calendar_sync_state WHERE id = 1")
+      .get() as { sync_token: string };
+    expect(row.sync_token).toBe("new-tok");
+  });
+
+  it("recovers from 410 in not_due delta sync via full re-sync", async () => {
+    const db = makeDb();
+    setSetting(db, "google_calendar_id", "cal-id");
+    setSetting(db, "google_oauth_refresh_token", "rt");
+    const future = new Date(Date.now() + 6 * 24 * 60 * 60 * 1000).toISOString();
+    db.prepare(
+      "INSERT INTO calendar_sync_state (id, channel_id, resource_id, expiration_at, sync_token) VALUES (1, 'ch', 'res', ?, 'expired-tok')"
+    ).run(future);
+
+    vi.mocked(calMock.listEventsDelta)
+      .mockRejectedValueOnce(Object.assign(new Error("Gone"), { code: 410 }))
+      .mockResolvedValueOnce({ items: [], nextSyncToken: "fresh-tok" });
+
+    const result = await handleCalendarRenew(db, "https://example.com");
+    expect(result).toEqual({ ok: true, skipped: "not_due" });
+    // First call with stale token, second without (full re-sync)
+    expect(calMock.listEventsDelta).toHaveBeenCalledTimes(2);
+    expect(calMock.listEventsDelta).toHaveBeenLastCalledWith(expect.anything(), "cal-id");
+    const row = db
+      .prepare("SELECT sync_token FROM calendar_sync_state WHERE id = 1")
+      .get() as { sync_token: string };
+    expect(row.sync_token).toBe("fresh-tok");
   });
 
   it("renews channel when it expires in <5 days", async () => {

--- a/lib/calendar-renew.ts
+++ b/lib/calendar-renew.ts
@@ -35,6 +35,25 @@ export async function handleCalendarRenew(
     const expiresMs = new Date(stateRow.expiration_at).getTime();
     const fiveDaysMs = 5 * 24 * 60 * 60 * 1000;
     if (!isNaN(expiresMs) && expiresMs - Date.now() > fiveDaysMs) {
+      // Channel healthy — still run a delta sync to recover any missed webhook notifications
+      try {
+        const { items, nextSyncToken } = await listEventsDelta(
+          client,
+          calendarId,
+          stateRow.sync_token
+        );
+        await processCalendarDelta(db, client, calendarId, items);
+        db.prepare("UPDATE calendar_sync_state SET sync_token=? WHERE id=1").run(nextSyncToken);
+      } catch (e: unknown) {
+        const code = (e as { code?: number })?.code;
+        if (code === 410) {
+          const { items, nextSyncToken } = await listEventsDelta(client, calendarId);
+          await processCalendarDelta(db, client, calendarId, items);
+          db.prepare("UPDATE calendar_sync_state SET sync_token=? WHERE id=1").run(nextSyncToken);
+        } else {
+          console.error("[calendar-renew] delta sync failed", e);
+        }
+      }
       return { ok: true, skipped: "not_due" };
     }
     try {


### PR DESCRIPTION
## Summary

- `handleCalendarRenew` was returning early (`skipped: not_due`) without running a delta sync when the push channel was healthy (>5 days until expiry)
- A single dropped webhook notification had no recovery path — the missed RSVP update would only be picked up when the channel rotated (~30 days later)
- Fix: always run `listEventsDelta` + `processCalendarDelta` in the `not_due` path; channel renewal (`watchEvents`) still only runs inside the 5-day window
- Also set up the VPS crontab (`0 * * * *`) which was never configured despite being documented

## Root cause

Two independent gaps:
1. **No catch-up on healthy channels** — the `not_due` early return skipped delta sync entirely
2. **No cron job** — the VPS crontab was never set up, so even the 30-day renewal would have failed

## Test plan
- [x] All 443 unit tests pass
- [x] TypeScript: clean
- [x] New tests: `not_due` path now asserts `listEventsDelta` is called and `sync_token` is updated; added 410 recovery test for that path
- [x] VPS crontab verified: `0 * * * *` calls `/api/admin/calendar-renew`

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)