### PR TITLE
test(auth): add route-level tests for login, logout, cloak, uncloak, profile PATCH

### DIFF
--- a/app/api/auth/cloak/route.test.ts
+++ b/app/api/auth/cloak/route.test.ts
@@ -1,0 +1,99 @@
+// app/api/auth/cloak/route.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { POST } from "./route";
+
+vi.mock("@/lib/env", () => ({
+  env: { SESSION_PASSWORD: "test-password-32-chars-minimum!!", NODE_ENV: "test" },
+}));
+
+const mockSession: Record<string, unknown> = {
+  authenticated: true,
+  isAdmin: true,
+  cloakedAs: undefined,
+  save: vi.fn(),
+};
+
+vi.mock("iron-session", () => ({
+  getIronSession: vi.fn(async () => mockSession),
+}));
+
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
+const mockGetPersonById = vi.fn();
+vi.mock("@/lib/queries/people", () => ({
+  getPersonById: (...args: unknown[]) => mockGetPersonById(...args),
+  shortNameOf: (p: { first_name?: string }) => p.first_name ?? "Person",
+}));
+
+function makeReq(body: unknown) {
+  return new Request("http://localhost/api/auth/cloak", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSession.authenticated = true;
+  mockSession.isAdmin = true;
+  mockSession.cloakedAs = undefined;
+  mockSession.save = vi.fn();
+  mockGetPersonById.mockReturnValue({ id: 5, first_name: "Alice", active: 1, is_admin: 0 });
+});
+
+describe("POST /api/auth/cloak", () => {
+  it("sets cloakedAs and returns 200 for admin with valid target", async () => {
+    const res = await POST(makeReq({ personId: 5 }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(mockSession.cloakedAs).toMatchObject({ personId: 5, shortName: "Alice" });
+    expect(mockSession.save).toHaveBeenCalledOnce();
+  });
+
+  it("returns 403 when not admin", async () => {
+    mockSession.isAdmin = false;
+    const res = await POST(makeReq({ personId: 5 }));
+    expect(res.status).toBe(403);
+    expect(mockSession.save).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when not authenticated", async () => {
+    mockSession.authenticated = false;
+    mockSession.isAdmin = false;
+    const res = await POST(makeReq({ personId: 5 }));
+    expect(res.status).toBe(403);
+    expect(mockSession.save).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for missing personId", async () => {
+    const res = await POST(makeReq({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for non-numeric personId", async () => {
+    const res = await POST(makeReq({ personId: "five" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    const req = new Request("http://localhost/api/auth/cloak", {
+      method: "POST",
+      body: "not-json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when person not found", async () => {
+    mockGetPersonById.mockReturnValue(undefined);
+    const res = await POST(makeReq({ personId: 99 }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for inactive person", async () => {
+    mockGetPersonById.mockReturnValue({ id: 5, first_name: "Alice", active: 0, is_admin: 0 });
+    const res = await POST(makeReq({ personId: 5 }));
+    expect(res.status).toBe(404);
+  });
+});

--- a/app/api/auth/login/route.test.ts
+++ b/app/api/auth/login/route.test.ts
@@ -1,0 +1,113 @@
+// app/api/auth/login/route.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { POST } from "./route";
+
+const mockSession = {
+  authenticated: false as boolean,
+  personId: undefined as number | undefined,
+  shortName: undefined as string | undefined,
+  isAdmin: false,
+  save: vi.fn(),
+};
+
+vi.mock("iron-session", () => ({
+  getIronSession: vi.fn(async () => mockSession),
+}));
+
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
+const mockGetPersonByUsername = vi.fn();
+vi.mock("@/lib/queries/people", () => ({
+  getPersonByUsername: (...args: unknown[]) => mockGetPersonByUsername(...args),
+  isOwner: vi.fn(() => false),
+  shortNameOf: (p: { first_name?: string }) => p.first_name ?? "Person",
+}));
+
+const mockVerifyCredentials = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  verifyCredentials: (...args: unknown[]) => mockVerifyCredentials(...args),
+}));
+
+vi.mock("@/lib/env", () => ({
+  env: {
+    SESSION_PASSWORD: "test-password-32-chars-minimum!!",
+    NODE_ENV: "test",
+    AUTH_USERNAME: undefined,
+    AUTH_PASSWORD_HASH: undefined,
+  },
+}));
+
+function makeReq(body: unknown) {
+  return new Request("http://localhost/api/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const alicePerson = {
+  id: 1,
+  first_name: "Alice",
+  last_name: "",
+  username: "alice",
+  password_hash: "hashed",
+  is_admin: 0,
+  active: 1,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSession.authenticated = false;
+  mockSession.personId = undefined;
+  mockSession.shortName = undefined;
+  mockSession.isAdmin = false;
+  mockSession.save = vi.fn();
+  mockGetPersonByUsername.mockReturnValue(alicePerson);
+  mockVerifyCredentials.mockResolvedValue(true);
+});
+
+describe("POST /api/auth/login", () => {
+  it("returns 200 and saves session on valid credentials", async () => {
+    const res = await POST(makeReq({ username: "alice", password: "correct" }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(mockSession.authenticated).toBe(true);
+    expect(mockSession.personId).toBe(1);
+    expect(mockSession.save).toHaveBeenCalledOnce();
+  });
+
+  it("returns 401 on wrong password", async () => {
+    mockVerifyCredentials.mockResolvedValue(false);
+    const res = await POST(makeReq({ username: "alice", password: "wrong" }));
+    expect(res.status).toBe(401);
+    expect(await res.json()).toMatchObject({ error: "invalid_credentials" });
+    expect(mockSession.save).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when person not found", async () => {
+    mockGetPersonByUsername.mockReturnValue(undefined);
+    const res = await POST(makeReq({ username: "nobody", password: "pw" }));
+    expect(res.status).toBe(401);
+    expect(mockSession.save).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for invalid JSON body", async () => {
+    const req = new Request("http://localhost/api/auth/login", {
+      method: "POST",
+      body: "not-json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when username or password are not strings", async () => {
+    const res = await POST(makeReq({ username: 123, password: true }));
+    expect(res.status).toBe(401);
+  });
+
+  it("stores isAdmin=true when person has is_admin=1", async () => {
+    mockGetPersonByUsername.mockReturnValue({ ...alicePerson, is_admin: 1 });
+    await POST(makeReq({ username: "alice", password: "correct" }));
+    expect(mockSession.isAdmin).toBe(true);
+  });
+});

--- a/app/api/auth/logout/route.test.ts
+++ b/app/api/auth/logout/route.test.ts
@@ -1,0 +1,42 @@
+// app/api/auth/logout/route.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { POST } from "./route";
+
+vi.mock("@/lib/env", () => ({
+  env: { SESSION_PASSWORD: "test-password-32-chars-minimum!!", NODE_ENV: "test" },
+}));
+
+const mockSession = {
+  authenticated: true,
+  save: vi.fn(),
+  destroy: vi.fn(),
+};
+
+vi.mock("iron-session", () => ({
+  getIronSession: vi.fn(async () => mockSession),
+}));
+
+function makeReq() {
+  return new Request("http://localhost/api/auth/logout", { method: "POST" });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSession.authenticated = true;
+});
+
+describe("POST /api/auth/logout", () => {
+  it("destroys session and returns 200 when authenticated", async () => {
+    const res = await POST(makeReq());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(mockSession.destroy).toHaveBeenCalledOnce();
+  });
+
+  it("returns 200 but skips destroy when not authenticated", async () => {
+    mockSession.authenticated = false;
+    const res = await POST(makeReq());
+    expect(res.status).toBe(200);
+    expect(mockSession.destroy).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/auth/uncloak/route.test.ts
+++ b/app/api/auth/uncloak/route.test.ts
@@ -1,0 +1,46 @@
+// app/api/auth/uncloak/route.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { POST } from "./route";
+
+vi.mock("@/lib/env", () => ({
+  env: { SESSION_PASSWORD: "test-password-32-chars-minimum!!", NODE_ENV: "test" },
+}));
+
+const mockSession: Record<string, unknown> = {
+  authenticated: true,
+  cloakedAs: { personId: 2, shortName: "Bob", isAdmin: false },
+  save: vi.fn(),
+};
+
+vi.mock("iron-session", () => ({
+  getIronSession: vi.fn(async () => mockSession),
+}));
+
+function makeReq() {
+  return new Request("http://localhost/api/auth/uncloak", { method: "POST" });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSession.authenticated = true;
+  mockSession.cloakedAs = { personId: 2, shortName: "Bob", isAdmin: false };
+  mockSession.save = vi.fn();
+});
+
+describe("POST /api/auth/uncloak", () => {
+  it("clears cloakedAs and saves session when authenticated", async () => {
+    const res = await POST(makeReq());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(mockSession.cloakedAs).toBeUndefined();
+    expect(mockSession.save).toHaveBeenCalledOnce();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockSession.authenticated = false;
+    const res = await POST(makeReq());
+    expect(res.status).toBe(401);
+    expect(await res.json()).toMatchObject({ error: "unauthenticated" });
+    expect(mockSession.save).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/people/[id]/profile/route.test.ts
+++ b/app/api/people/[id]/profile/route.test.ts
@@ -1,0 +1,137 @@
+// app/api/people/[id]/profile/route.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PATCH } from "./route";
+
+vi.mock("@/lib/env", () => ({
+  env: { SESSION_PASSWORD: "test-password-32-chars-minimum!!", NODE_ENV: "test" },
+}));
+
+const CSRF = "test-csrf-token";
+
+const mockSession = {
+  authenticated: true,
+  personId: 1,
+  isAdmin: false,
+  save: vi.fn(),
+};
+
+vi.mock("iron-session", () => ({
+  getIronSession: vi.fn(async () => mockSession),
+}));
+
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
+const mockGetPersonById = vi.fn();
+const mockUpdatePerson = vi.fn();
+vi.mock("@/lib/queries/people", () => ({
+  getPersonById: (...args: unknown[]) => mockGetPersonById(...args),
+  updatePerson: (...args: unknown[]) => mockUpdatePerson(...args),
+}));
+
+const existingPerson = {
+  id: 1,
+  first_name: "Alice",
+  last_name: "",
+  username: "alice",
+  bank_account: "",
+  email: null,
+  theme_preference: "mono" as const,
+  is_admin: 0,
+  active: 1,
+  discount: 0,
+  discount_long: 0,
+  updated_at: "",
+};
+
+function makeCtx(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+function makeReq(body: unknown, method = "PATCH") {
+  return new Request(`http://localhost/api/people/1/profile`, {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      Cookie: `csrf-token=${CSRF}`,
+      "x-csrf-token": CSRF,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+const validBody = { first_name: "Alice", last_name: "", bank_account: "" };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSession.authenticated = true;
+  mockSession.personId = 1;
+  mockSession.isAdmin = false;
+  mockGetPersonById.mockReturnValue(existingPerson);
+  mockUpdatePerson.mockReturnValue(undefined);
+});
+
+describe("PATCH /api/people/[id]/profile", () => {
+  it("allows person to update their own profile", async () => {
+    const res = await PATCH(makeReq(validBody), makeCtx("1"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(mockUpdatePerson).toHaveBeenCalledOnce();
+  });
+
+  it("allows admin to update any person's profile", async () => {
+    mockSession.personId = 99;
+    mockSession.isAdmin = true;
+    const res = await PATCH(makeReq(validBody), makeCtx("1"));
+    expect(res.status).toBe(200);
+    expect(mockUpdatePerson).toHaveBeenCalledOnce();
+  });
+
+  it("returns 403 when non-admin edits another person", async () => {
+    mockSession.personId = 2;
+    mockSession.isAdmin = false;
+    const res = await PATCH(makeReq(validBody), makeCtx("1"));
+    expect(res.status).toBe(403);
+    expect(mockUpdatePerson).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when unauthenticated", async () => {
+    mockSession.authenticated = false;
+    mockSession.personId = undefined as unknown as number;
+    const res = await PATCH(makeReq(validBody), makeCtx("1"));
+    expect(res.status).toBe(403);
+    expect(mockUpdatePerson).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when person does not exist", async () => {
+    mockGetPersonById.mockReturnValue(undefined);
+    const res = await PATCH(makeReq(validBody), makeCtx("1"));
+    expect(res.status).toBe(404);
+    expect(mockUpdatePerson).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when CSRF token is missing", async () => {
+    const req = new Request("http://localhost/api/people/1/profile", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(validBody),
+    });
+    const res = await PATCH(req, makeCtx("1"));
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ error: "invalid_csrf" });
+  });
+
+  it("returns 400 for missing required first_name", async () => {
+    const res = await PATCH(makeReq({ last_name: "X" }), makeCtx("1"));
+    expect(res.status).toBe(400);
+  });
+
+  it("persists theme_preference update", async () => {
+    const res = await PATCH(
+      makeReq({ ...validBody, theme_preference: "paper" }),
+      makeCtx("1")
+    );
+    expect(res.status).toBe(200);
+    const [, , data] = mockUpdatePerson.mock.calls[0];
+    expect(data.theme_preference).toBe("paper");
+  });
+});


### PR DESCRIPTION
## Summary

Adds 26 unit tests across 5 auth-related route handlers that had zero test coverage:

| File | Tests | What's covered |
|---|---|---|
| `app/api/auth/login/route.test.ts` | 6 | valid creds → session saved; wrong password → 401; unknown user → 401; bad JSON → 401; non-string fields → 401; is_admin flag stored |
| `app/api/auth/logout/route.test.ts` | 2 | authenticated → session.destroy() called; unauthenticated → destroy skipped |
| `app/api/auth/cloak/route.test.ts` | 8 | admin + valid target → cloakedAs set; non-admin → 403; unauthenticated → 403; missing personId → 400; non-numeric personId → 400; bad JSON → 400; person not found → 404; inactive person → 404 |
| `app/api/auth/uncloak/route.test.ts` | 2 | authenticated → cloakedAs cleared + session saved; unauthenticated → 401 |
| `app/api/people/[id]/profile/route.test.ts` | 8 | own profile → 200; admin edits other → 200; non-admin edits other → 403; unauthenticated → 403; person not found → 404; missing CSRF → 403; missing first_name → 400; theme_preference persisted |

## Notes

- All tests mock `iron-session` to control session state without real cookies
- All tests mock `@/lib/env` to satisfy `SESSION_PASSWORD` validation at import time
- Cloak/uncloak/profile tests mock `@/lib/db` + `@/lib/queries/people`
- Login tests mock `@/lib/auth` (verifyCredentials) for fast, bcrypt-free assertions

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)