### PR TITLE
feat(auth): session revocation (#266) + self-service password reset / magic link (#267)

### DIFF
--- a/app/api/auth/forgot/route.test.ts
+++ b/app/api/auth/forgot/route.test.ts
@@ -10,14 +10,14 @@ vi.mock("@/lib/env", () => ({
 }));
 vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
 
-const mockGetPersonByEmail = vi.fn();
-const mockCreateAuthToken = vi.fn();
+const mockGetPersonByEmail = vi.fn<(...a: unknown[]) => unknown>();
+const mockCreateAuthToken = vi.fn<(...a: unknown[]) => unknown>();
 vi.mock("@/lib/queries/people", () => ({
   getPersonByEmail: (...a: unknown[]) => mockGetPersonByEmail(...a),
   createAuthToken: (...a: unknown[]) => mockCreateAuthToken(...a),
 }));
 
-const mockSendMail = vi.fn(() => Promise.resolve());
+const mockSendMail = vi.fn<(...a: unknown[]) => Promise<void>>(() => Promise.resolve());
 vi.mock("@/lib/mailer", () => ({ sendMail: (...a: unknown[]) => mockSendMail(...a) }));
 
 import { POST } from "./route";

--- a/app/api/auth/forgot/route.test.ts
+++ b/app/api/auth/forgot/route.test.ts
@@ -1,0 +1,82 @@
+// app/api/auth/forgot/route.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/env", () => ({
+  env: {
+    SESSION_PASSWORD: "test-password-32-chars-minimum!!",
+    NODE_ENV: "test",
+    NEXT_PUBLIC_BASE_URL: "http://localhost:3000",
+  },
+}));
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
+const mockGetPersonByEmail = vi.fn();
+const mockCreateAuthToken = vi.fn();
+vi.mock("@/lib/queries/people", () => ({
+  getPersonByEmail: (...a: unknown[]) => mockGetPersonByEmail(...a),
+  createAuthToken: (...a: unknown[]) => mockCreateAuthToken(...a),
+}));
+
+const mockSendMail = vi.fn(() => Promise.resolve());
+vi.mock("@/lib/mailer", () => ({ sendMail: (...a: unknown[]) => mockSendMail(...a) }));
+
+import { POST } from "./route";
+
+let ipCounter = 0;
+function req(body: unknown, ip?: string) {
+  return new Request("http://localhost/api/auth/forgot", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-forwarded-for": ip ?? `192.0.2.${++ipCounter}`,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetPersonByEmail.mockReturnValue(undefined);
+});
+
+describe("POST /api/auth/forgot", () => {
+  it("creates a reset token and sends mail when the email matches an account", async () => {
+    mockGetPersonByEmail.mockReturnValue({ id: 9 });
+    const res = await POST(req({ email: "alice@example.com" }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(mockCreateAuthToken).toHaveBeenCalledOnce();
+    expect(mockCreateAuthToken.mock.calls[0]).toEqual([
+      {},
+      9,
+      expect.any(String),
+      expect.any(String),
+      "reset",
+    ]);
+    expect(mockSendMail).toHaveBeenCalledOnce();
+  });
+
+  it("returns 200 without sending when no account matches (no enumeration)", async () => {
+    const res = await POST(req({ email: "nobody@example.com" }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(mockCreateAuthToken).not.toHaveBeenCalled();
+    expect(mockSendMail).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 even for invalid input", async () => {
+    const res = await POST(req({ email: "not-an-email" }));
+    expect(res.status).toBe(200);
+    expect(mockSendMail).not.toHaveBeenCalled();
+  });
+
+  it("rate-limits repeated requests from the same IP", async () => {
+    const ip = "192.0.2.250";
+    for (let i = 0; i < 5; i++) {
+      const res = await POST(req({ email: "x@example.com" }, ip));
+      expect(res.status).toBe(200);
+    }
+    const blocked = await POST(req({ email: "x@example.com" }, ip));
+    expect(blocked.status).toBe(429);
+  });
+});

--- a/app/api/auth/forgot/route.ts
+++ b/app/api/auth/forgot/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { randomBytes } from "crypto";
+import { getDb } from "@/lib/db";
+import { getPersonByEmail, createAuthToken } from "@/lib/queries/people";
+import { sendMail } from "@/lib/mailer";
+import { env } from "@/lib/env";
+import { checkRateLimit } from "@/lib/rate-limit";
+
+const Schema = z.object({ email: z.string().email() });
+
+/**
+ * Requests a password-reset link. Always responds 200 with no body details so
+ * the endpoint cannot be used to enumerate which emails have accounts.
+ */
+export async function POST(req: Request) {
+  const ip = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+  const rl = checkRateLimit(`${ip}:/api/auth/forgot`, { max: 5, windowMs: 15 * 60 * 1000 });
+  if (!rl.ok) {
+    return NextResponse.json(
+      { error: "too_many_requests" },
+      { status: 429, headers: { "Retry-After": String(rl.retryAfter) } }
+    );
+  }
+
+  let email: string;
+  try {
+    email = Schema.parse(await req.json()).email;
+  } catch {
+    // Bad input still returns ok — no enumeration, no validation oracle.
+    return NextResponse.json({ ok: true });
+  }
+
+  const db = getDb();
+  const person = getPersonByEmail(db, email);
+  if (person) {
+    const token = randomBytes(24).toString("hex");
+    const expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString(); // 1 hour
+    createAuthToken(db, person.id, token, expiresAt, "reset");
+    const baseUrl = env.NEXT_PUBLIC_BASE_URL ?? new URL(req.url).origin;
+    const url = `${baseUrl}/reset/${token}`;
+    await sendMail({
+      to: email,
+      subject: "Reset your CarSharing password",
+      text: `Open this link to set a new password (valid for 1 hour):\n\n${url}\n\nIf you did not request this, you can ignore this email.`,
+    });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -27,6 +27,7 @@ export async function POST(req: Request) {
   let sessionPersonId: number | undefined;
   let sessionShortName: string | undefined;
   let sessionIsAdmin = false;
+  let sessionEpoch = 0;
 
   if (person?.password_hash) {
     // DB-based per-person auth
@@ -38,6 +39,7 @@ export async function POST(req: Request) {
       sessionPersonId = person.id;
       sessionShortName = shortNameOf(person);
       sessionIsAdmin = person.is_admin === 1;
+      sessionEpoch = person.session_epoch ?? 0;
     }
   } else {
     // Env-var fallback for initial/legacy setup
@@ -74,6 +76,7 @@ export async function POST(req: Request) {
   session.personId = sessionPersonId;
   session.shortName = sessionShortName;
   session.isAdmin = sessionIsAdmin;
+  session.epoch = sessionEpoch;
   await session.save();
   return res;
 }

--- a/app/api/auth/logout-all/route.test.ts
+++ b/app/api/auth/logout-all/route.test.ts
@@ -1,0 +1,58 @@
+// app/api/auth/logout-all/route.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/env", () => ({
+  env: { SESSION_PASSWORD: "test-password-32-chars-minimum!!", NODE_ENV: "test" },
+}));
+
+const mockSession = {
+  authenticated: true,
+  personId: 5,
+  destroy: vi.fn(),
+};
+vi.mock("iron-session", () => ({ getIronSession: vi.fn(async () => mockSession) }));
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
+const mockBump = vi.fn();
+vi.mock("@/lib/queries/people", () => ({
+  bumpSessionEpoch: (...a: unknown[]) => mockBump(...a),
+}));
+
+import { POST } from "./route";
+
+const CSRF = "test-csrf-token";
+function req(withCsrf = true, withSession = true) {
+  mockSession.authenticated = withSession;
+  mockSession.personId = withSession ? 5 : (undefined as unknown as number);
+  return new Request("http://localhost/api/auth/logout-all", {
+    method: "POST",
+    headers: withCsrf ? { Cookie: `csrf-token=${CSRF}`, "x-csrf-token": CSRF } : {},
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSession.destroy = vi.fn();
+});
+
+describe("POST /api/auth/logout-all", () => {
+  it("bumps the session epoch and destroys the current session", async () => {
+    const res = await POST(req() as never);
+    expect(res.status).toBe(200);
+    expect(mockBump).toHaveBeenCalledWith({}, 5);
+    expect(mockSession.destroy).toHaveBeenCalledOnce();
+  });
+
+  it("rejects when the CSRF token is missing", async () => {
+    const res = await POST(req(false) as never);
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ error: "invalid_csrf" });
+    expect(mockBump).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unauthenticated caller", async () => {
+    const res = await POST(req(true, false) as never);
+    expect(res.status).toBe(403);
+    expect(mockBump).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/auth/logout-all/route.ts
+++ b/app/api/auth/logout-all/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { getIronSession } from "iron-session";
+import { sessionOptions, type SessionData } from "@/lib/session";
+import { getDb } from "@/lib/db";
+import { bumpSessionEpoch } from "@/lib/queries/people";
+import { validateCsrfToken } from "@/lib/csrf";
+
+/**
+ * "Log out everywhere": bumps the user's session epoch (revoking every
+ * previously issued cookie) and destroys the current session.
+ */
+export async function POST(req: NextRequest) {
+  if (!validateCsrfToken(req)) {
+    return NextResponse.json({ error: "invalid_csrf" }, { status: 403 });
+  }
+  const res = NextResponse.json({ ok: true });
+  const session = await getIronSession<SessionData>(req, res, sessionOptions);
+  if (!session.authenticated || session.personId === undefined) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+  // Revoke sessions for the real user, even while cloaking as someone else.
+  bumpSessionEpoch(getDb(), session.personId);
+  session.destroy();
+  return res;
+}

--- a/app/api/auth/magic/[token]/route.ts
+++ b/app/api/auth/magic/[token]/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import {
+  getAuthToken,
+  deleteAuthToken,
+  getSessionEpoch,
+  getPersonById,
+  shortNameOf,
+} from "@/lib/queries/people";
+import { getIronSession } from "iron-session";
+import { sessionOptions, type SessionData } from "@/lib/session";
+import { env } from "@/lib/env";
+
+/**
+ * Consumes a magic-link token (the URL emailed to the user) and establishes a
+ * session, then redirects to the app. Single-use; expired/invalid tokens are
+ * discarded and the user is sent to /login.
+ */
+export async function GET(req: Request, ctx: { params: Promise<{ token: string }> }) {
+  const { token } = await ctx.params;
+  const db = getDb();
+  const baseUrl = env.NEXT_PUBLIC_BASE_URL ?? new URL(req.url).origin;
+
+  const record = getAuthToken(db, token);
+  const invalid = !record || record.purpose !== "magic" || new Date(record.expires_at) < new Date();
+  if (invalid) {
+    if (record) deleteAuthToken(db, token);
+    return NextResponse.redirect(new URL("/login?error=magic", baseUrl));
+  }
+
+  const person = getPersonById(db, record!.person_id);
+  if (!person) {
+    deleteAuthToken(db, token);
+    return NextResponse.redirect(new URL("/login?error=magic", baseUrl));
+  }
+
+  const res = NextResponse.redirect(new URL("/", baseUrl));
+  const session = await getIronSession<SessionData>(req, res, sessionOptions);
+  session.authenticated = true;
+  session.personId = person.id;
+  session.shortName = shortNameOf(person);
+  session.isAdmin = person.is_admin === 1;
+  session.epoch = getSessionEpoch(db, person.id);
+  await session.save();
+  deleteAuthToken(db, token);
+  return res;
+}

--- a/app/api/auth/magic/route.ts
+++ b/app/api/auth/magic/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { randomBytes } from "crypto";
+import { getDb } from "@/lib/db";
+import { getPersonByEmail, createAuthToken } from "@/lib/queries/people";
+import { sendMail } from "@/lib/mailer";
+import { env } from "@/lib/env";
+import { checkRateLimit } from "@/lib/rate-limit";
+
+const Schema = z.object({ email: z.string().email() });
+
+/**
+ * Requests a passwordless magic-link sign-in. Like /forgot, always returns 200
+ * with no detail to avoid account enumeration.
+ */
+export async function POST(req: Request) {
+  const ip = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+  const rl = checkRateLimit(`${ip}:/api/auth/magic`, { max: 5, windowMs: 15 * 60 * 1000 });
+  if (!rl.ok) {
+    return NextResponse.json(
+      { error: "too_many_requests" },
+      { status: 429, headers: { "Retry-After": String(rl.retryAfter) } }
+    );
+  }
+
+  let email: string;
+  try {
+    email = Schema.parse(await req.json()).email;
+  } catch {
+    return NextResponse.json({ ok: true });
+  }
+
+  const db = getDb();
+  const person = getPersonByEmail(db, email);
+  if (person) {
+    const token = randomBytes(24).toString("hex");
+    const expiresAt = new Date(Date.now() + 15 * 60 * 1000).toISOString(); // 15 min
+    createAuthToken(db, person.id, token, expiresAt, "magic");
+    const baseUrl = env.NEXT_PUBLIC_BASE_URL ?? new URL(req.url).origin;
+    const url = `${baseUrl}/api/auth/magic/${token}`;
+    await sendMail({
+      to: email,
+      subject: "Your CarSharing sign-in link",
+      text: `Click to sign in (valid for 15 minutes):\n\n${url}\n\nIf you did not request this, you can ignore this email.`,
+    });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/auth/reset/[token]/route.test.ts
+++ b/app/api/auth/reset/[token]/route.test.ts
@@ -1,0 +1,90 @@
+// app/api/auth/reset/[token]/route.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/env", () => ({
+  env: { SESSION_PASSWORD: "test-password-32-chars-minimum!!", NODE_ENV: "test" },
+}));
+
+const mockSession = { authenticated: false, personId: 0, save: vi.fn() };
+vi.mock("iron-session", () => ({ getIronSession: vi.fn(async () => mockSession) }));
+vi.mock("@/lib/db", () => ({
+  getDb: vi.fn(() => ({ transaction: (fn: (a: unknown) => void) => (a: unknown) => fn(a) })),
+}));
+
+const mockGetAuthToken = vi.fn();
+const mockDeleteAuthToken = vi.fn();
+const mockSetPasswordHash = vi.fn();
+const mockBumpSessionEpoch = vi.fn();
+const mockGetSessionEpoch = vi.fn(() => 1);
+const mockGetPersonById = vi.fn(() => ({ id: 9, first_name: "Alice", is_admin: 0 }));
+vi.mock("@/lib/queries/people", () => ({
+  getAuthToken: (...a: unknown[]) => mockGetAuthToken(...a),
+  deleteAuthToken: (...a: unknown[]) => mockDeleteAuthToken(...a),
+  setPasswordHash: (...a: unknown[]) => mockSetPasswordHash(...a),
+  bumpSessionEpoch: (...a: unknown[]) => mockBumpSessionEpoch(...a),
+  getSessionEpoch: (...a: unknown[]) => mockGetSessionEpoch(...a),
+  getPersonById: (...a: unknown[]) => mockGetPersonById(...a),
+  shortNameOf: (p: { first_name?: string }) => p.first_name ?? "Person",
+}));
+
+import { POST } from "./route";
+
+const ctx = (token = "tok") => ({ params: Promise.resolve({ token }) });
+function req(body: unknown) {
+  return new Request("http://localhost/api/auth/reset/tok", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+const future = () => new Date(Date.now() + 60_000).toISOString();
+const past = () => new Date(Date.now() - 60_000).toISOString();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSession.authenticated = false;
+  mockSession.save = vi.fn();
+});
+
+describe("POST /api/auth/reset/[token]", () => {
+  it("rejects an unknown token", async () => {
+    mockGetAuthToken.mockReturnValue(null);
+    const res = await POST(req({ password: "supersecret" }), ctx());
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: "invalid_token" });
+  });
+
+  it("rejects a token whose purpose is not 'reset'", async () => {
+    mockGetAuthToken.mockReturnValue({ person_id: 9, expires_at: future(), purpose: "invite" });
+    const res = await POST(req({ password: "supersecret" }), ctx());
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: "invalid_token" });
+  });
+
+  it("rejects and clears an expired token", async () => {
+    mockGetAuthToken.mockReturnValue({ person_id: 9, expires_at: past(), purpose: "reset" });
+    const res = await POST(req({ password: "supersecret" }), ctx());
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: "token_expired" });
+    expect(mockDeleteAuthToken).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a too-short password", async () => {
+    mockGetAuthToken.mockReturnValue({ person_id: 9, expires_at: future(), purpose: "reset" });
+    const res = await POST(req({ password: "short" }), ctx());
+    expect(res.status).toBe(400);
+    expect(mockSetPasswordHash).not.toHaveBeenCalled();
+  });
+
+  it("sets the password, revokes old sessions, and signs the user in", async () => {
+    mockGetAuthToken.mockReturnValue({ person_id: 9, expires_at: future(), purpose: "reset" });
+    const res = await POST(req({ password: "supersecret" }), ctx());
+    expect(res.status).toBe(200);
+    expect(mockSetPasswordHash).toHaveBeenCalledOnce();
+    expect(mockBumpSessionEpoch).toHaveBeenCalledWith(expect.anything(), 9);
+    expect(mockDeleteAuthToken).toHaveBeenCalledOnce();
+    expect(mockSession.save).toHaveBeenCalledOnce();
+    expect(mockSession.authenticated).toBe(true);
+    expect(mockSession.personId).toBe(9);
+  });
+});

--- a/app/api/auth/reset/[token]/route.test.ts
+++ b/app/api/auth/reset/[token]/route.test.ts
@@ -11,12 +11,16 @@ vi.mock("@/lib/db", () => ({
   getDb: vi.fn(() => ({ transaction: (fn: (a: unknown) => void) => (a: unknown) => fn(a) })),
 }));
 
-const mockGetAuthToken = vi.fn();
-const mockDeleteAuthToken = vi.fn();
-const mockSetPasswordHash = vi.fn();
-const mockBumpSessionEpoch = vi.fn();
-const mockGetSessionEpoch = vi.fn(() => 1);
-const mockGetPersonById = vi.fn(() => ({ id: 9, first_name: "Alice", is_admin: 0 }));
+const mockGetAuthToken = vi.fn<(...a: unknown[]) => unknown>();
+const mockDeleteAuthToken = vi.fn<(...a: unknown[]) => unknown>();
+const mockSetPasswordHash = vi.fn<(...a: unknown[]) => unknown>();
+const mockBumpSessionEpoch = vi.fn<(...a: unknown[]) => unknown>();
+const mockGetSessionEpoch = vi.fn<(...a: unknown[]) => number>(() => 1);
+const mockGetPersonById = vi.fn<(...a: unknown[]) => unknown>(() => ({
+  id: 9,
+  first_name: "Alice",
+  is_admin: 0,
+}));
 vi.mock("@/lib/queries/people", () => ({
   getAuthToken: (...a: unknown[]) => mockGetAuthToken(...a),
   deleteAuthToken: (...a: unknown[]) => mockDeleteAuthToken(...a),

--- a/app/api/auth/reset/[token]/route.ts
+++ b/app/api/auth/reset/[token]/route.ts
@@ -3,30 +3,30 @@ import { z } from "zod";
 import bcrypt from "bcryptjs";
 import { getDb } from "@/lib/db";
 import {
-  getInviteToken,
-  deleteInviteToken,
+  getAuthToken,
+  deleteAuthToken,
   setPasswordHash,
-  getPersonById,
+  bumpSessionEpoch,
   getSessionEpoch,
+  getPersonById,
   shortNameOf,
 } from "@/lib/queries/people";
 import { getIronSession } from "iron-session";
 import { sessionOptions, type SessionData } from "@/lib/session";
 
-const Schema = z.object({
-  password: z.string().min(8),
-});
+const Schema = z.object({ password: z.string().min(8) });
 
+/** Completes a password reset: sets the new password and revokes old sessions. */
 export async function POST(req: Request, ctx: { params: Promise<{ token: string }> }) {
   const { token } = await ctx.params;
   const db = getDb();
 
-  const record = getInviteToken(db, token);
-  if (!record) {
+  const record = getAuthToken(db, token);
+  if (!record || record.purpose !== "reset") {
     return NextResponse.json({ error: "invalid_token" }, { status: 400 });
   }
   if (new Date(record.expires_at) < new Date()) {
-    deleteInviteToken(db, token);
+    deleteAuthToken(db, token);
     return NextResponse.json({ error: "token_expired" }, { status: 400 });
   }
 
@@ -44,7 +44,9 @@ export async function POST(req: Request, ctx: { params: Promise<{ token: string 
   const hash = await bcrypt.hash(parsed.data.password, 12);
   db.transaction((args: { personId: number; hash: string; token: string }) => {
     setPasswordHash(db, args.personId, args.hash);
-    deleteInviteToken(db, args.token);
+    // A password reset invalidates every existing session for the account.
+    bumpSessionEpoch(db, args.personId);
+    deleteAuthToken(db, args.token);
   })({ personId: record.person_id, hash, token });
 
   const person = getPersonById(db, record.person_id);

--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -2,17 +2,27 @@ import { NextResponse } from "next/server";
 import { getIronSession } from "iron-session";
 import { sessionOptions, type SessionData } from "@/lib/session";
 import { getDb } from "@/lib/db";
-import { isOwner, shortNameOf } from "@/lib/queries/people";
+import { isOwner, shortNameOf, getSessionEpoch } from "@/lib/queries/people";
 import { generateCsrfToken } from "@/lib/csrf";
 
-function getPersonFields(personId: number): { shortName: string | null; themePreference: 'paper' | 'mono' | null } {
+function getPersonFields(personId: number): {
+  shortName: string | null;
+  themePreference: "paper" | "mono" | null;
+} {
   const row = getDb()
     .prepare("SELECT first_name, last_name, username, theme_preference FROM people WHERE id = ?")
-    .get(personId) as { first_name: string; last_name: string; username: string | null; theme_preference: string | null } | undefined;
+    .get(personId) as
+    | {
+        first_name: string;
+        last_name: string;
+        username: string | null;
+        theme_preference: string | null;
+      }
+    | undefined;
   if (!row) return { shortName: null, themePreference: null };
   return {
     shortName: shortNameOf(row) || null,
-    themePreference: (row.theme_preference === 'mono' ? 'mono' : 'paper') as 'paper' | 'mono',
+    themePreference: (row.theme_preference === "mono" ? "mono" : "paper") as "paper" | "mono",
   };
 }
 
@@ -31,6 +41,15 @@ export async function GET(req: Request) {
   const session = await getIronSession<SessionData>(req, res, sessionOptions);
   if (!session.authenticated) {
     return withCsrfCookie(NextResponse.json(null));
+  }
+
+  // Honour server-side session revocation ("log out everywhere"): if this
+  // cookie's epoch is stale, destroy it and report as logged out.
+  if (session.epoch !== undefined && session.personId !== undefined) {
+    if (getSessionEpoch(getDb(), session.personId) !== session.epoch) {
+      session.destroy();
+      return withCsrfCookie(NextResponse.json(null));
+    }
   }
 
   const cloaked = session.cloakedAs;
@@ -57,7 +76,9 @@ export async function GET(req: Request) {
     owner = isOwner(getDb(), session.personId);
   }
 
-  const fields = session.personId ? getPersonFields(session.personId) : { shortName: session.shortName ?? null, themePreference: null };
+  const fields = session.personId
+    ? getPersonFields(session.personId)
+    : { shortName: session.shortName ?? null, themePreference: null };
   return withCsrfCookie(
     NextResponse.json({
       personId: session.personId ?? null,

--- a/app/forgot/page.tsx
+++ b/app/forgot/page.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useT } from "@/components/locale-provider";
+import { paper, fontMono, fontSerif } from "@/lib/paper-theme";
+
+export default function ForgotPasswordPage() {
+  const t = useT();
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [sent, setSent] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const submit = async (endpoint: "/api/auth/forgot" | "/api/auth/magic") => {
+    setError(null);
+    setLoading(true);
+    try {
+      // These endpoints always return 200 (no account enumeration); show the
+      // same confirmation regardless of whether the email matched an account.
+      await fetch(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      setSent(true);
+    } catch {
+      setError(t("auth.forgot_error"));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        minHeight: "100dvh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: paper.paperDeep,
+        padding: "16px",
+      }}
+    >
+      <div style={{ width: "100%", maxWidth: 380 }}>
+        <div style={{ textAlign: "center", marginBottom: 28 }}>
+          <h1
+            style={{
+              fontFamily: fontSerif,
+              fontSize: 26,
+              fontWeight: 700,
+              color: paper.ink,
+              margin: 0,
+              lineHeight: 1.2,
+            }}
+          >
+            {t("auth.forgot_title")}
+          </h1>
+          <p
+            style={{
+              fontFamily: fontMono,
+              fontSize: 11,
+              color: paper.inkDim,
+              marginTop: 8,
+              letterSpacing: 0.5,
+            }}
+          >
+            {t("auth.forgot_subtitle")}
+          </p>
+        </div>
+
+        <div
+          style={{
+            background: paper.paper,
+            padding: "32px 28px",
+            boxShadow: "0 1px 2px rgba(0,0,0,0.05), 0 4px 16px rgba(0,0,0,0.06)",
+          }}
+        >
+          {sent ? (
+            <p
+              role="status"
+              style={{ fontFamily: fontMono, fontSize: 12, color: paper.ink, lineHeight: 1.6 }}
+            >
+              {t("auth.forgot_sent")}
+            </p>
+          ) : (
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                submit("/api/auth/forgot");
+              }}
+            >
+              <div style={{ marginBottom: 20 }}>
+                <label htmlFor="forgot-email" style={labelStyle}>
+                  {t("auth.email")}
+                </label>
+                <input
+                  id="forgot-email"
+                  type="email"
+                  autoComplete="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
+                  autoFocus
+                  style={inputStyle}
+                />
+              </div>
+              {error && (
+                <p
+                  style={{ fontFamily: fontMono, fontSize: 11, color: "#c0392b", marginBottom: 16 }}
+                >
+                  {error}
+                </p>
+              )}
+              <button
+                type="submit"
+                disabled={loading || !email}
+                style={primaryButtonStyle(loading)}
+              >
+                {t("auth.send_reset_link")}
+              </button>
+              <button
+                type="button"
+                disabled={loading || !email}
+                onClick={() => submit("/api/auth/magic")}
+                style={secondaryButtonStyle}
+              >
+                {t("auth.send_magic_link")}
+              </button>
+            </form>
+          )}
+
+          <button
+            type="button"
+            onClick={() => router.push("/login")}
+            style={{
+              display: "block",
+              width: "100%",
+              marginTop: 20,
+              background: "none",
+              border: "none",
+              fontFamily: fontMono,
+              fontSize: 11,
+              color: paper.inkDim,
+              cursor: "pointer",
+            }}
+          >
+            {t("auth.back_to_login")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const labelStyle: React.CSSProperties = {
+  display: "block",
+  fontFamily: fontMono,
+  fontSize: 10,
+  letterSpacing: 1.5,
+  textTransform: "uppercase",
+  color: paper.inkDim,
+  marginBottom: 6,
+};
+
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  padding: "10px 12px",
+  border: "1px solid " + paper.paperDark,
+  background: paper.paperDeep,
+  fontFamily: fontMono,
+  fontSize: 13,
+  color: paper.ink,
+  outline: "none",
+  appearance: "none",
+  boxSizing: "border-box",
+};
+
+const primaryButtonStyle = (loading: boolean): React.CSSProperties => ({
+  width: "100%",
+  background: loading ? paper.inkDim : paper.ink,
+  color: paper.paper,
+  fontFamily: fontMono,
+  fontSize: 10,
+  letterSpacing: 2,
+  textTransform: "uppercase",
+  padding: "14px",
+  border: "none",
+  cursor: loading ? "not-allowed" : "pointer",
+});
+
+const secondaryButtonStyle: React.CSSProperties = {
+  width: "100%",
+  background: "transparent",
+  color: paper.ink,
+  fontFamily: fontMono,
+  fontSize: 10,
+  letterSpacing: 2,
+  textTransform: "uppercase",
+  padding: "13px",
+  marginTop: 12,
+  border: `1.5px solid ${paper.paperDark}`,
+  cursor: "pointer",
+};

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -176,7 +176,18 @@ export default function LoginPage() {
                 type="button"
                 onClick={() => setShowPassword((v) => !v)}
                 aria-label={showPassword ? t("action.hide_password") : t("action.show_password")}
-                style={{ position: "absolute", right: 10, top: "50%", transform: "translateY(-50%)", background: "none", border: "none", cursor: "pointer", padding: 0, color: paper.inkMute, display: "flex" }}
+                style={{
+                  position: "absolute",
+                  right: 10,
+                  top: "50%",
+                  transform: "translateY(-50%)",
+                  background: "none",
+                  border: "none",
+                  cursor: "pointer",
+                  padding: 0,
+                  color: paper.inkMute,
+                  display: "flex",
+                }}
               >
                 {showPassword ? <EyeOff size={15} /> : <Eye size={15} />}
               </button>
@@ -219,6 +230,22 @@ export default function LoginPage() {
           >
             {loading ? t("state.loading") : t("action.login")}
           </button>
+
+          <a
+            href="/forgot"
+            style={{
+              display: "block",
+              textAlign: "center",
+              marginTop: 16,
+              fontFamily: fontMono,
+              fontSize: 10,
+              letterSpacing: 1,
+              color: paper.inkDim,
+              textDecoration: "none",
+            }}
+          >
+            {t("auth.forgot_password")}
+          </a>
         </form>
       </div>
     </div>

--- a/app/reset/[token]/page.tsx
+++ b/app/reset/[token]/page.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter, useParams } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
+import { Eye, EyeOff } from "lucide-react";
+import { useT } from "@/components/locale-provider";
+import { paper, fontMono, fontSerif } from "@/lib/paper-theme";
+
+export default function ResetPasswordPage() {
+  const t = useT();
+  const router = useRouter();
+  const qc = useQueryClient();
+  const { token } = useParams<{ token: string }>();
+
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+
+  const inputStyle: React.CSSProperties = {
+    width: "100%",
+    padding: "10px 12px",
+    border: `1.5px solid ${paper.inkDim}`,
+    background: paper.paper,
+    fontFamily: fontMono,
+    fontSize: 14,
+    color: paper.ink,
+    outline: "none",
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (password.length < 8) {
+      setError(t("invite.too_short"));
+      return;
+    }
+    if (password !== confirm) {
+      setError(t("invite.mismatch"));
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/auth/reset/${token}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ password }),
+      });
+      if (res.ok) {
+        qc.clear();
+        router.replace("/");
+      } else {
+        setError(t("auth.reset_error"));
+        setLoading(false);
+      }
+    } catch {
+      setError(t("auth.reset_error"));
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        minHeight: "100dvh",
+        background: paper.paperDeep,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: "20px",
+      }}
+    >
+      <div style={{ width: "100%", maxWidth: 360 }}>
+        <div style={{ textAlign: "center", marginBottom: 28 }}>
+          <div
+            style={{
+              fontFamily: fontSerif,
+              fontSize: 26,
+              fontWeight: 600,
+              color: paper.ink,
+              letterSpacing: -0.5,
+              marginBottom: 6,
+            }}
+          >
+            {t("auth.reset_title")}
+          </div>
+          <div
+            style={{
+              fontFamily: fontMono,
+              fontSize: 11,
+              color: paper.inkDim,
+              letterSpacing: 0.5,
+            }}
+          >
+            {t("auth.reset_subtitle")}
+          </div>
+        </div>
+
+        <form
+          onSubmit={handleSubmit}
+          style={{
+            background: paper.paper,
+            padding: "24px 20px",
+            boxShadow: "0 4px 24px rgba(0,0,0,0.1)",
+          }}
+        >
+          <div style={{ marginBottom: 16 }}>
+            <label htmlFor="reset-password" style={labelStyle}>
+              {t("invite.password_label")}
+            </label>
+            <div style={{ position: "relative" }}>
+              <input
+                id="reset-password"
+                type={showPassword ? "text" : "password"}
+                autoComplete="new-password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                style={{ ...inputStyle, paddingRight: 36 }}
+                required
+                autoFocus
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword((v) => !v)}
+                aria-label={showPassword ? t("action.hide_password") : t("action.show_password")}
+                style={eyeButtonStyle}
+              >
+                {showPassword ? <EyeOff size={15} /> : <Eye size={15} />}
+              </button>
+            </div>
+          </div>
+
+          <div style={{ marginBottom: 20 }}>
+            <label htmlFor="reset-confirm" style={labelStyle}>
+              {t("invite.confirm_label")}
+            </label>
+            <input
+              id="reset-confirm"
+              type={showPassword ? "text" : "password"}
+              autoComplete="new-password"
+              value={confirm}
+              onChange={(e) => setConfirm(e.target.value)}
+              style={inputStyle}
+              required
+            />
+          </div>
+
+          {error && (
+            <div
+              style={{
+                fontFamily: fontMono,
+                fontSize: 11,
+                color: paper.accent,
+                marginBottom: 16,
+                letterSpacing: 0.5,
+              }}
+            >
+              {error}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={loading}
+            style={{
+              width: "100%",
+              padding: "12px",
+              background: loading ? paper.inkDim : paper.ink,
+              color: paper.paper,
+              border: "none",
+              fontFamily: fontMono,
+              fontSize: 11,
+              letterSpacing: 2,
+              textTransform: "uppercase",
+              cursor: loading ? "not-allowed" : "pointer",
+            }}
+          >
+            {loading ? t("state.loading") : t("invite.submit")}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+const labelStyle: React.CSSProperties = {
+  display: "block",
+  fontFamily: fontMono,
+  fontSize: 9,
+  letterSpacing: 1.5,
+  textTransform: "uppercase",
+  color: paper.inkDim,
+  marginBottom: 6,
+};
+
+const eyeButtonStyle: React.CSSProperties = {
+  position: "absolute",
+  right: 10,
+  top: "50%",
+  transform: "translateY(-50%)",
+  background: "none",
+  border: "none",
+  cursor: "pointer",
+  padding: 0,
+  color: paper.inkMute,
+  display: "flex",
+};

--- a/app/user/[id]/edit/page.tsx
+++ b/app/user/[id]/edit/page.tsx
@@ -115,6 +115,17 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
     }
   }
 
+  async function handleLogoutAll() {
+    if (!window.confirm(t("auth.logout_all_confirm"))) return;
+    try {
+      await apiFetch("/api/auth/logout-all", { method: "POST" });
+    } catch {
+      // Ignore — redirect to login regardless of the response.
+    }
+    queryClient.clear();
+    router.replace("/login");
+  }
+
   async function handleThemeToggle(newTheme: Theme) {
     setThemePreference(newTheme);
     setTheme(newTheme);
@@ -435,6 +446,32 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
               </div>
             )}
           </div>
+
+          {me?.personId === id && (
+            <div
+              style={{ marginTop: 20, paddingTop: 16, borderTop: `1px solid ${paper.paperDark}` }}
+            >
+              <button
+                type="button"
+                onClick={handleLogoutAll}
+                style={{
+                  width: "100%",
+                  padding: "8px",
+                  fontFamily: fontMono,
+                  fontSize: 9,
+                  fontWeight: 700,
+                  letterSpacing: 2,
+                  textTransform: "uppercase",
+                  background: "transparent",
+                  color: paper.accent,
+                  border: `1.5px solid ${paper.accent}`,
+                  cursor: "pointer",
+                }}
+              >
+                {t("auth.logout_all")}
+              </button>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/e2e/auth-recovery.spec.ts
+++ b/e2e/auth-recovery.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * E2E for self-service account recovery (issue #267):
+ *   - "Forgot password?" link + /forgot page
+ *   - password-reset and magic-link request endpoints (no account enumeration)
+ *   - invalid reset / magic tokens are rejected
+ *
+ * These tests are self-contained: the request endpoints always return 200 and
+ * never reveal whether an account exists, so they need no seeded data.
+ */
+
+test.describe("Account recovery", () => {
+  test("login page links to the forgot-password page", async ({ page }) => {
+    await page.goto("/login");
+    const link = page.getByRole("link", { name: /forgot|vergeten/i });
+    await expect(link).toBeVisible();
+    await link.click();
+    await page.waitForURL(/\/forgot/);
+    // The email field is focused and present.
+    await expect(page.locator("#forgot-email")).toBeVisible();
+  });
+
+  test("submitting the forgot form shows a neutral confirmation", async ({ page }) => {
+    await page.goto("/forgot");
+    await page.locator("#forgot-email").fill("definitely-not-a-user@example.com");
+    await page.getByRole("button", { name: /reset link|resetlink/i }).click();
+    // A status message is shown regardless of whether the account exists.
+    await expect(page.getByRole("status")).toBeVisible();
+  });
+
+  test("POST /api/auth/forgot returns 200 for an unknown email (no enumeration)", async ({
+    request,
+  }) => {
+    const res = await request.post("/api/auth/forgot", {
+      data: { email: "nobody-" + Date.now() + "@example.com" },
+    });
+    expect(res.status()).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  test("POST /api/auth/magic returns 200 for an unknown email (no enumeration)", async ({
+    request,
+  }) => {
+    const res = await request.post("/api/auth/magic", {
+      data: { email: "nobody-" + Date.now() + "@example.com" },
+    });
+    expect(res.status()).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  test("an invalid reset token is rejected", async ({ request }) => {
+    const res = await request.post("/api/auth/reset/not-a-real-token", {
+      data: { password: "a-strong-password" },
+    });
+    expect(res.status()).toBe(400);
+    expect(await res.json()).toMatchObject({ error: "invalid_token" });
+  });
+
+  test("an invalid magic-link token redirects to login", async ({ request }) => {
+    const res = await request.get("/api/auth/magic/not-a-real-token", {
+      maxRedirects: 0,
+    });
+    expect(res.status()).toBeGreaterThanOrEqual(300);
+    expect(res.status()).toBeLessThan(400);
+    expect(res.headers()["location"]).toContain("/login");
+  });
+});

--- a/e2e/session-revocation.spec.ts
+++ b/e2e/session-revocation.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect, type APIRequestContext } from "@playwright/test";
+import { makeApi } from "./helpers";
+
+/**
+ * E2E for "log out everywhere" / server-side session revocation (issue #266).
+ *
+ * Bumping the user's session epoch must invalidate every previously issued
+ * cookie — including sessions held by other devices — on the next request.
+ */
+
+const EMAIL = process.env.TEST_EMAIL ?? "alice";
+const PASSWORD = process.env.TEST_PASSWORD ?? "alice";
+
+/** Logs a fresh context in and returns its CSRF token (or null on failure). */
+async function login(ctx: APIRequestContext): Promise<string | null> {
+  const res = await ctx.post("/api/auth/login", { data: { username: EMAIL, password: PASSWORD } });
+  if (!res.ok()) return null;
+  const me = await ctx.get("/api/me");
+  for (const h of await me.headersArray()) {
+    if (h.name.toLowerCase() === "set-cookie") {
+      const m = h.value.match(/csrf-token=([^;]+)/);
+      if (m) return decodeURIComponent(m[1]);
+    }
+  }
+  return null;
+}
+
+test.describe("Session revocation", () => {
+  test("logout-all revokes the current session", async ({ request }) => {
+    const csrf = await login(request);
+    test.skip(!csrf, "Test account not available — needs seeded demo data");
+
+    // Confirm we are authenticated.
+    const before = await request.get("/api/me");
+    expect(await before.json()).not.toBeNull();
+
+    await makeApi(request, csrf!).post("/api/auth/logout-all", {});
+
+    // The cookie's epoch is now stale → /api/me reports logged out.
+    const after = await request.get("/api/me");
+    expect(await after.json()).toBeNull();
+  });
+
+  test("logout-all from one device revokes a second device's session", async ({ playwright }) => {
+    const baseURL = process.env.TEST_BASE_URL ?? "http://localhost:3000";
+    const deviceA = await playwright.request.newContext({ baseURL });
+    const deviceB = await playwright.request.newContext({ baseURL });
+
+    const csrfA = await login(deviceA);
+    const csrfB = await login(deviceB);
+    test.skip(!csrfA || !csrfB, "Test account not available — needs seeded demo data");
+
+    // Both devices are authenticated.
+    expect(await (await deviceA.get("/api/me")).json()).not.toBeNull();
+    expect(await (await deviceB.get("/api/me")).json()).not.toBeNull();
+
+    // Device A triggers "log out everywhere".
+    await makeApi(deviceA, csrfA!).post("/api/auth/logout-all", {});
+
+    // Device B's previously valid cookie is now revoked.
+    expect(await (await deviceB.get("/api/me")).json()).toBeNull();
+
+    await deviceA.dispose();
+    await deviceB.dispose();
+  });
+
+  test("logout-all requires a CSRF token", async ({ request }) => {
+    const csrf = await login(request);
+    test.skip(!csrf, "Test account not available — needs seeded demo data");
+    // Deliberately omit the x-csrf-token header.
+    const res = await request.post("/api/auth/logout-all", {});
+    expect(res.status()).toBe(403);
+  });
+});

--- a/e2e/session-revocation.spec.ts
+++ b/e2e/session-revocation.spec.ts
@@ -1,44 +1,53 @@
 import { test, expect, type APIRequestContext } from "@playwright/test";
-import { makeApi } from "./helpers";
 
 /**
  * E2E for "log out everywhere" / server-side session revocation (issue #266).
  *
  * Bumping the user's session epoch must invalidate every previously issued
  * cookie — including sessions held by other devices — on the next request.
+ *
+ * Note: GET /api/me rotates the csrf-token cookie on every call, so the CSRF
+ * token is read from the context's cookie jar (storageState) immediately before
+ * each mutating call rather than captured earlier.
  */
 
 const EMAIL = process.env.TEST_EMAIL ?? "alice";
 const PASSWORD = process.env.TEST_PASSWORD ?? "alice";
 
-/** Logs a fresh context in and returns its CSRF token (or null on failure). */
-async function login(ctx: APIRequestContext): Promise<string | null> {
+/** Reads the current csrf-token cookie from the context's jar. */
+async function currentCsrf(ctx: APIRequestContext): Promise<string | null> {
+  const state = await ctx.storageState();
+  return state.cookies.find((c) => c.name === "csrf-token")?.value ?? null;
+}
+
+/** Logs the context in and primes a csrf-token cookie via /api/me. */
+async function login(ctx: APIRequestContext): Promise<boolean> {
   const res = await ctx.post("/api/auth/login", { data: { username: EMAIL, password: PASSWORD } });
-  if (!res.ok()) return null;
-  const me = await ctx.get("/api/me");
-  for (const h of await me.headersArray()) {
-    if (h.name.toLowerCase() === "set-cookie") {
-      const m = h.value.match(/csrf-token=([^;]+)/);
-      if (m) return decodeURIComponent(m[1]);
-    }
-  }
-  return null;
+  if (!res.ok()) return false;
+  await ctx.get("/api/me"); // sets the csrf-token cookie
+  return true;
+}
+
+async function logoutAll(ctx: APIRequestContext): Promise<number> {
+  const csrf = await currentCsrf(ctx);
+  const res = await ctx.post("/api/auth/logout-all", {
+    headers: csrf ? { "x-csrf-token": csrf } : {},
+  });
+  return res.status();
 }
 
 test.describe("Session revocation", () => {
   test("logout-all revokes the current session", async ({ request }) => {
-    const csrf = await login(request);
-    test.skip(!csrf, "Test account not available — needs seeded demo data");
+    const ok = await login(request);
+    test.skip(!ok, "Test account not available — needs seeded demo data");
 
-    // Confirm we are authenticated.
-    const before = await request.get("/api/me");
-    expect(await before.json()).not.toBeNull();
+    expect(await (await request.get("/api/me")).json()).not.toBeNull();
 
-    await makeApi(request, csrf!).post("/api/auth/logout-all", {});
+    const status = await logoutAll(request);
+    expect(status).toBe(200);
 
     // The cookie's epoch is now stale → /api/me reports logged out.
-    const after = await request.get("/api/me");
-    expect(await after.json()).toBeNull();
+    expect(await (await request.get("/api/me")).json()).toBeNull();
   });
 
   test("logout-all from one device revokes a second device's session", async ({ playwright }) => {
@@ -46,16 +55,15 @@ test.describe("Session revocation", () => {
     const deviceA = await playwright.request.newContext({ baseURL });
     const deviceB = await playwright.request.newContext({ baseURL });
 
-    const csrfA = await login(deviceA);
-    const csrfB = await login(deviceB);
-    test.skip(!csrfA || !csrfB, "Test account not available — needs seeded demo data");
+    const okA = await login(deviceA);
+    const okB = await login(deviceB);
+    test.skip(!okA || !okB, "Test account not available — needs seeded demo data");
 
-    // Both devices are authenticated.
     expect(await (await deviceA.get("/api/me")).json()).not.toBeNull();
     expect(await (await deviceB.get("/api/me")).json()).not.toBeNull();
 
     // Device A triggers "log out everywhere".
-    await makeApi(deviceA, csrfA!).post("/api/auth/logout-all", {});
+    expect(await logoutAll(deviceA)).toBe(200);
 
     // Device B's previously valid cookie is now revoked.
     expect(await (await deviceB.get("/api/me")).json()).toBeNull();
@@ -65,8 +73,8 @@ test.describe("Session revocation", () => {
   });
 
   test("logout-all requires a CSRF token", async ({ request }) => {
-    const csrf = await login(request);
-    test.skip(!csrf, "Test account not available — needs seeded demo data");
+    const ok = await login(request);
+    test.skip(!ok, "Test account not available — needs seeded demo data");
     // Deliberately omit the x-csrf-token header.
     const res = await request.post("/api/auth/logout-all", {});
     expect(res.status()).toBe(403);

--- a/e2e/session-revocation.spec.ts
+++ b/e2e/session-revocation.spec.ts
@@ -13,8 +13,12 @@ import { test, expect, type APIRequestContext } from "@playwright/test";
  */
 
 const baseURL = process.env.TEST_BASE_URL ?? "http://localhost:3000";
-const EMAIL = process.env.TEST_EMAIL ?? "alice";
-const PASSWORD = process.env.TEST_PASSWORD ?? "alice";
+// Use a DEDICATED user, not the shared TEST_EMAIL (alice). logout-all bumps the
+// user's session epoch in the shared demo.db; if this ran as the same account the
+// CRUD specs authenticate with, it would revoke their in-flight sessions under
+// parallel execution and they'd 403 with "Session revoked".
+const EMAIL = process.env.TEST_REVOKE_EMAIL ?? "carol";
+const PASSWORD = process.env.TEST_REVOKE_PASSWORD ?? "carol";
 
 /** Reads the current csrf-token cookie from the context's jar. */
 async function currentCsrf(ctx: APIRequestContext): Promise<string | null> {

--- a/e2e/session-revocation.spec.ts
+++ b/e2e/session-revocation.spec.ts
@@ -6,11 +6,13 @@ import { test, expect, type APIRequestContext } from "@playwright/test";
  * Bumping the user's session epoch must invalidate every previously issued
  * cookie — including sessions held by other devices — on the next request.
  *
- * Note: GET /api/me rotates the csrf-token cookie on every call, so the CSRF
- * token is read from the context's cookie jar (storageState) immediately before
- * each mutating call rather than captured earlier.
+ * Each test uses its own freshly created request context (its own cookie jar)
+ * so sessions don't leak between tests. GET /api/me rotates the csrf-token
+ * cookie, so the CSRF token is read from the jar immediately before each
+ * mutating call.
  */
 
+const baseURL = process.env.TEST_BASE_URL ?? "http://localhost:3000";
 const EMAIL = process.env.TEST_EMAIL ?? "alice";
 const PASSWORD = process.env.TEST_PASSWORD ?? "alice";
 
@@ -24,8 +26,8 @@ async function currentCsrf(ctx: APIRequestContext): Promise<string | null> {
 async function login(ctx: APIRequestContext): Promise<boolean> {
   const res = await ctx.post("/api/auth/login", { data: { username: EMAIL, password: PASSWORD } });
   if (!res.ok()) return false;
-  await ctx.get("/api/me"); // sets the csrf-token cookie
-  return true;
+  const me = await (await ctx.get("/api/me")).json(); // also sets csrf-token
+  return me !== null;
 }
 
 async function logoutAll(ctx: APIRequestContext): Promise<number> {
@@ -36,22 +38,42 @@ async function logoutAll(ctx: APIRequestContext): Promise<number> {
   return res.status();
 }
 
+/**
+ * Returns true if the context is logged out. A revoked-but-present cookie still
+ * passes the proxy auth gate, so /api/me returns `null` JSON; a destroyed cookie
+ * (current-session logout) fails the gate and the proxy redirects /api/me to
+ * /login (HTML). Treat both as logged out.
+ */
+async function isLoggedOut(ctx: APIRequestContext): Promise<boolean> {
+  const res = await ctx.get("/api/me");
+  const ct = res.headers()["content-type"] ?? "";
+  if (!ct.includes("application/json")) return true; // redirected to /login HTML
+  return (await res.json()) === null;
+}
+
+async function isLoggedIn(ctx: APIRequestContext): Promise<boolean> {
+  const res = await ctx.get("/api/me");
+  if (!(res.headers()["content-type"] ?? "").includes("application/json")) return false;
+  return (await res.json()) !== null;
+}
+
 test.describe("Session revocation", () => {
-  test("logout-all revokes the current session", async ({ request }) => {
-    const ok = await login(request);
+  test("logout-all revokes the current session", async ({ playwright }) => {
+    const ctx = await playwright.request.newContext({ baseURL });
+    const ok = await login(ctx);
     test.skip(!ok, "Test account not available — needs seeded demo data");
 
-    expect(await (await request.get("/api/me")).json()).not.toBeNull();
+    expect(await isLoggedIn(ctx)).toBe(true);
 
-    const status = await logoutAll(request);
-    expect(status).toBe(200);
+    expect(await logoutAll(ctx)).toBe(200);
 
-    // The cookie's epoch is now stale → /api/me reports logged out.
-    expect(await (await request.get("/api/me")).json()).toBeNull();
+    // The current session was destroyed → no longer logged in.
+    expect(await isLoggedOut(ctx)).toBe(true);
+
+    await ctx.dispose();
   });
 
   test("logout-all from one device revokes a second device's session", async ({ playwright }) => {
-    const baseURL = process.env.TEST_BASE_URL ?? "http://localhost:3000";
     const deviceA = await playwright.request.newContext({ baseURL });
     const deviceB = await playwright.request.newContext({ baseURL });
 
@@ -59,24 +81,26 @@ test.describe("Session revocation", () => {
     const okB = await login(deviceB);
     test.skip(!okA || !okB, "Test account not available — needs seeded demo data");
 
-    expect(await (await deviceA.get("/api/me")).json()).not.toBeNull();
-    expect(await (await deviceB.get("/api/me")).json()).not.toBeNull();
+    expect(await isLoggedIn(deviceA)).toBe(true);
+    expect(await isLoggedIn(deviceB)).toBe(true);
 
     // Device A triggers "log out everywhere".
     expect(await logoutAll(deviceA)).toBe(200);
 
     // Device B's previously valid cookie is now revoked.
-    expect(await (await deviceB.get("/api/me")).json()).toBeNull();
+    expect(await isLoggedOut(deviceB)).toBe(true);
 
     await deviceA.dispose();
     await deviceB.dispose();
   });
 
-  test("logout-all requires a CSRF token", async ({ request }) => {
-    const ok = await login(request);
+  test("logout-all requires a CSRF token", async ({ playwright }) => {
+    const ctx = await playwright.request.newContext({ baseURL });
+    const ok = await login(ctx);
     test.skip(!ok, "Test account not available — needs seeded demo data");
     // Deliberately omit the x-csrf-token header.
-    const res = await request.post("/api/auth/logout-all", {});
+    const res = await ctx.post("/api/auth/logout-all", {});
     expect(res.status()).toBe(403);
+    await ctx.dispose();
   });
 });

--- a/lib/__tests__/migration_0004.test.ts
+++ b/lib/__tests__/migration_0004.test.ts
@@ -41,6 +41,8 @@ describe("migration 0004 — car owner era", () => {
       INSERT INTO _migrations (filename) VALUES ('0018_people_theme_preference.sql');
       INSERT INTO _migrations (filename) VALUES ('0019_default_theme_mono.sql');
       INSERT INTO _migrations (filename) VALUES ('0020_date_indexes.sql');
+      INSERT INTO _migrations (filename) VALUES ('0021_people_session_epoch.sql');
+      INSERT INTO _migrations (filename) VALUES ('0022_invite_tokens_purpose.sql');
     `);
     runMigrations(db2);
     const car = db2.prepare("SELECT owner_from FROM cars WHERE short = 'XX'").get() as {

--- a/lib/__tests__/session_epoch.test.ts
+++ b/lib/__tests__/session_epoch.test.ts
@@ -1,0 +1,53 @@
+// lib/__tests__/session_epoch.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { HttpError } from "../api";
+
+vi.mock("@/lib/env", () => ({
+  env: { SESSION_PASSWORD: "test-password-32-chars-minimum!!", NODE_ENV: "test" },
+}));
+
+const mockSession = {
+  authenticated: true,
+  personId: 1,
+  isAdmin: true,
+  epoch: 0 as number | undefined,
+};
+vi.mock("iron-session", () => ({ getIronSession: vi.fn(async () => mockSession) }));
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
+const mockGetSessionEpoch = vi.fn();
+vi.mock("@/lib/queries/people", () => ({
+  getSessionEpoch: (...a: unknown[]) => mockGetSessionEpoch(...a),
+  isOwner: vi.fn(() => false),
+}));
+
+import { requireAdmin } from "../api";
+
+const req = new Request("http://localhost/api/anything");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSession.authenticated = true;
+  mockSession.personId = 1;
+  mockSession.isAdmin = true;
+  mockSession.epoch = 0;
+});
+
+describe("session epoch revocation", () => {
+  it("allows the session when the epoch matches the stored value", async () => {
+    mockGetSessionEpoch.mockReturnValue(0);
+    await expect(requireAdmin(req)).resolves.toBe(mockSession);
+  });
+
+  it("rejects the session (403) when the epoch is stale", async () => {
+    mockGetSessionEpoch.mockReturnValue(1); // user did "log out everywhere"
+    await expect(requireAdmin(req)).rejects.toBeInstanceOf(HttpError);
+    await expect(requireAdmin(req)).rejects.toMatchObject({ status: 403 });
+  });
+
+  it("skips the epoch check for legacy cookies without an epoch", async () => {
+    mockSession.epoch = undefined;
+    await expect(requireAdmin(req)).resolves.toBe(mockSession);
+    expect(mockGetSessionEpoch).not.toHaveBeenCalled();
+  });
+});

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -33,12 +33,27 @@ export function conflict(msg = "Conflict"): never {
   throw new HttpError(409, msg);
 }
 
+/**
+ * Throws 403 if the session has been revoked (its epoch no longer matches the
+ * user's current `session_epoch`). Legacy cookies and unit-test sessions carry
+ * no epoch and are treated as valid.
+ */
+async function assertSessionEpoch(session: SessionData): Promise<void> {
+  if (session.epoch === undefined || session.personId === undefined) return;
+  const { getDb } = await import("./db");
+  const { getSessionEpoch } = await import("./queries/people");
+  if (getSessionEpoch(getDb(), session.personId) !== session.epoch) {
+    forbidden("Session revoked");
+  }
+}
+
 /** Reads the session from the request and throws 403 if the user is not an admin. */
 export async function requireAdmin(req: Request) {
   const { getIronSession } = await import("iron-session");
   const { sessionOptions } = await import("./session");
   const session = await getIronSession<SessionData>(req, NextResponse.next(), sessionOptions);
   if (!session.isAdmin) forbidden();
+  await assertSessionEpoch(session);
   return session;
 }
 
@@ -47,6 +62,7 @@ export async function requireAdminOrOwner(req: Request) {
   const { getIronSession } = await import("iron-session");
   const { sessionOptions } = await import("./session");
   const session = await getIronSession<SessionData>(req, NextResponse.next(), sessionOptions);
+  await assertSessionEpoch(session);
   if (session.isAdmin) return session;
   const personId = session.personId;
   if (!personId) forbidden();
@@ -76,6 +92,7 @@ export async function requireSession(req: Request) {
   const { sessionOptions } = await import("./session");
   const session = await getIronSession<SessionData>(req, NextResponse.next(), sessionOptions);
   if (!session.personId) forbidden("Not authenticated");
+  await assertSessionEpoch(session);
   return session;
 }
 

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -17,6 +17,10 @@ const envSchema = z.object({
   CRON_SECRET: z.string().optional(),
   GOOGLE_CLIENT_ID: z.string().optional(),
   GOOGLE_CLIENT_SECRET: z.string().optional(),
+  // Outbound email for password-reset / magic-link. When MAIL_WEBHOOK_URL is set,
+  // messages are POSTed there as JSON; otherwise they are logged (self-host dev).
+  MAIL_WEBHOOK_URL: z.string().url().optional(),
+  MAIL_FROM: z.string().optional(),
 });
 
 type Env = z.infer<typeof envSchema>;

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -519,6 +519,22 @@ export const en: Messages = {
   "invite.invalid": "Invalid or expired invitation",
   "invite.success": "Password set — you're logged in",
 
+  // Account recovery & session
+  "auth.forgot_password": "Forgot password?",
+  "auth.forgot_title": "Reset your password",
+  "auth.forgot_subtitle": "Enter your email and we'll send you a reset link.",
+  "auth.email": "Email",
+  "auth.send_reset_link": "Send reset link",
+  "auth.send_magic_link": "Email me a sign-in link",
+  "auth.forgot_sent": "If an account exists for that email, a link is on its way.",
+  "auth.forgot_error": "Something went wrong. Please try again.",
+  "auth.reset_title": "Choose a new password",
+  "auth.reset_subtitle": "Enter a new password for your account.",
+  "auth.reset_error": "This reset link is invalid or has expired.",
+  "auth.back_to_login": "Back to log in",
+  "auth.logout_all": "Log out all devices",
+  "auth.logout_all_confirm": "Sign out of every device, including this one?",
+
   // Admin settings page
   "settings.title": "Settings",
   "settings.bank_title": "Cooperative bank account",

--- a/lib/i18n/messages/nl.ts
+++ b/lib/i18n/messages/nl.ts
@@ -519,6 +519,22 @@ export const nl = {
   "invite.invalid": "Ongeldige of verlopen uitnodiging",
   "invite.success": "Wachtwoord ingesteld — je bent ingelogd",
 
+  // Account recovery & session
+  "auth.forgot_password": "Wachtwoord vergeten?",
+  "auth.forgot_title": "Wachtwoord opnieuw instellen",
+  "auth.forgot_subtitle": "Vul je e-mailadres in en we sturen je een resetlink.",
+  "auth.email": "E-mail",
+  "auth.send_reset_link": "Resetlink versturen",
+  "auth.send_magic_link": "Stuur me een inloglink",
+  "auth.forgot_sent": "Als er een account bestaat voor dit e-mailadres, is er een link onderweg.",
+  "auth.forgot_error": "Er ging iets mis. Probeer het opnieuw.",
+  "auth.reset_title": "Kies een nieuw wachtwoord",
+  "auth.reset_subtitle": "Vul een nieuw wachtwoord in voor je account.",
+  "auth.reset_error": "Deze resetlink is ongeldig of verlopen.",
+  "auth.back_to_login": "Terug naar inloggen",
+  "auth.logout_all": "Op alle apparaten uitloggen",
+  "auth.logout_all_confirm": "Uitloggen op elk apparaat, ook dit apparaat?",
+
   // Admin settings page
   "settings.title": "Instellingen",
   "settings.bank_title": "Coöperatie bankrekening",

--- a/lib/mailer.ts
+++ b/lib/mailer.ts
@@ -1,0 +1,36 @@
+import { env } from "./env";
+
+export interface OutgoingEmail {
+  to: string;
+  subject: string;
+  text: string;
+}
+
+/**
+ * Sends a transactional email.
+ *
+ * Delivery is transport-agnostic so the self-hosted app needs no SMTP library:
+ * - If `MAIL_WEBHOOK_URL` is configured, the message is POSTed there as JSON
+ *   (point it at a provider/serverless function — Resend, Postmark, SES, …).
+ * - Otherwise the message is logged so a self-hoster can still retrieve the link
+ *   from the server logs. Failures never throw — callers must not leak whether a
+ *   recipient exists, and email delivery must not break the request.
+ */
+export async function sendMail(email: OutgoingEmail): Promise<void> {
+  const webhook = env.MAIL_WEBHOOK_URL;
+  if (webhook) {
+    try {
+      await fetch(webhook, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ from: env.MAIL_FROM ?? "noreply@carsharing.local", ...email }),
+      });
+      return;
+    } catch (e) {
+      console.error("[mailer] webhook delivery failed", e);
+    }
+  }
+  console.log(
+    `[mailer] no transport configured — would send:\n  to: ${email.to}\n  subject: ${email.subject}\n  ${email.text}`
+  );
+}

--- a/lib/queries/people.ts
+++ b/lib/queries/people.ts
@@ -2,9 +2,17 @@ import type Database from "better-sqlite3";
 import type { Person } from "@/types";
 export { shortNameOf, fullNameOf } from "@/lib/person-utils";
 
-// Strip password_hash from public-facing person objects
+// Strip internal-only columns (password hash, session epoch) from public-facing
+// person objects.
 function strip(p: Person): Person {
-  const { password_hash: _ph, ...rest } = p as Person & { password_hash: string | null };
+  const {
+    password_hash: _ph,
+    session_epoch: _se,
+    ...rest
+  } = p as Person & {
+    password_hash: string | null;
+    session_epoch?: number;
+  };
   return rest as unknown as Person;
 }
 
@@ -29,6 +37,20 @@ export function getPersonById(db: Database.Database, id: number): Person | null 
 
 export function getPersonByUsername(db: Database.Database, username: string): Person | null {
   return (db.prepare("SELECT * FROM people WHERE username=?").get(username) as Person) ?? null;
+}
+
+/**
+ * Looks up an active person by email (case-insensitive). Returns the raw row
+ * (server-internal use only, e.g. the password-reset flow).
+ */
+export function getPersonByEmail(db: Database.Database, email: string): Person | null {
+  return (
+    (db
+      .prepare(
+        "SELECT * FROM people WHERE email IS NOT NULL AND lower(email)=lower(?) AND active=1"
+      )
+      .get(email) as Person) ?? null
+  );
 }
 
 export function insertPerson(
@@ -80,6 +102,22 @@ export function setPasswordHash(db: Database.Database, id: number, passwordHash:
   db.prepare("UPDATE people SET password_hash=? WHERE id=?").run(passwordHash, id);
 }
 
+/** Returns the person's current session epoch (0 if the person does not exist). */
+export function getSessionEpoch(db: Database.Database, id: number): number {
+  const row = db.prepare("SELECT session_epoch AS e FROM people WHERE id=?").get(id) as
+    | { e: number }
+    | undefined;
+  return row?.e ?? 0;
+}
+
+/**
+ * Increments the person's session epoch, invalidating every session cookie
+ * previously issued to them. Used by "log out everywhere" and password reset.
+ */
+export function bumpSessionEpoch(db: Database.Database, id: number): void {
+  db.prepare("UPDATE people SET session_epoch = session_epoch + 1 WHERE id=?").run(id);
+}
+
 export function isOwner(db: Database.Database, personId: number): boolean {
   const row = db
     .prepare("SELECT COUNT(*) as n FROM cars WHERE owner_person_id=?")
@@ -87,29 +125,59 @@ export function isOwner(db: Database.Database, personId: number): boolean {
   return row.n > 0;
 }
 
-// Invite token helpers
+// Auth token helpers (invite, password reset, magic-link — all share one table)
+export type TokenPurpose = "invite" | "reset" | "magic";
+
+/** Stores an auth token with a purpose and expiry. */
+export function createAuthToken(
+  db: Database.Database,
+  personId: number,
+  token: string,
+  expiresAt: string,
+  purpose: TokenPurpose = "invite"
+): void {
+  db.prepare(
+    "INSERT OR REPLACE INTO invite_tokens (token,person_id,expires_at,purpose) VALUES (?,?,?,?)"
+  ).run(token, personId, expiresAt, purpose);
+}
+
+/** Fetches a stored auth token along with its purpose. */
+export function getAuthToken(
+  db: Database.Database,
+  token: string
+): { person_id: number; expires_at: string; purpose: TokenPurpose } | null {
+  return (
+    (db
+      .prepare("SELECT person_id,expires_at,purpose FROM invite_tokens WHERE token=?")
+      .get(token) as
+      | { person_id: number; expires_at: string; purpose: TokenPurpose }
+      | undefined) ?? null
+  );
+}
+
+export function deleteAuthToken(db: Database.Database, token: string): void {
+  db.prepare("DELETE FROM invite_tokens WHERE token=?").run(token);
+}
+
+// ── Back-compat invite-specific wrappers (used by the existing invite flow) ──
 export function createInviteToken(
   db: Database.Database,
   personId: number,
   token: string,
   expiresAt: string
 ): void {
-  db.prepare(
-    "INSERT OR REPLACE INTO invite_tokens (token,person_id,expires_at) VALUES (?,?,?)"
-  ).run(token, personId, expiresAt);
+  createAuthToken(db, personId, token, expiresAt, "invite");
 }
 
 export function getInviteToken(
   db: Database.Database,
   token: string
 ): { person_id: number; expires_at: string } | null {
-  return (
-    (db.prepare("SELECT person_id,expires_at FROM invite_tokens WHERE token=?").get(token) as
-      | { person_id: number; expires_at: string }
-      | undefined) ?? null
-  );
+  const row = getAuthToken(db, token);
+  if (!row || row.purpose !== "invite") return null;
+  return { person_id: row.person_id, expires_at: row.expires_at };
 }
 
 export function deleteInviteToken(db: Database.Database, token: string): void {
-  db.prepare("DELETE FROM invite_tokens WHERE token=?").run(token);
+  deleteAuthToken(db, token);
 }

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -16,6 +16,9 @@ export function checkRateLimit(
   key: string,
   options: RateLimitOptions
 ): { ok: boolean; retryAfter?: number } {
+  // Escape hatch for E2E/dev: the Playwright dev server sets this so the suite,
+  // which logs in repeatedly from one host, isn't throttled. Never set in prod.
+  if (process.env.DISABLE_RATE_LIMIT === "1") return { ok: true };
   const now = Date.now();
   const entry = store.get(key);
   if (!entry || entry.resetAt <= now) {

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -7,6 +7,12 @@ export interface SessionData {
   personId?: number;
   shortName?: string;
   isAdmin?: boolean;
+  /**
+   * The user's session epoch at the time this cookie was issued. If it no longer
+   * matches `people.session_epoch`, the session has been revoked. Absent on
+   * legacy cookies issued before this field existed (treated as still valid).
+   */
+  epoch?: number;
   /** Set while an admin is impersonating another person. */
   cloakedAs?: {
     personId: number;

--- a/migrations/0021_people_session_epoch.sql
+++ b/migrations/0021_people_session_epoch.sql
@@ -1,0 +1,4 @@
+-- Per-user session epoch for server-side session revocation ("log out everywhere").
+-- Each issued session cookie records the user's current epoch; bumping this value
+-- invalidates every previously issued cookie for that user on the next request.
+ALTER TABLE people ADD COLUMN session_epoch INTEGER NOT NULL DEFAULT 0;

--- a/migrations/0022_invite_tokens_purpose.sql
+++ b/migrations/0022_invite_tokens_purpose.sql
@@ -1,0 +1,3 @@
+-- Generalise invite_tokens so the same table can also carry password-reset and
+-- magic-link sign-in tokens. Existing rows are invite tokens.
+ALTER TABLE invite_tokens ADD COLUMN purpose TEXT NOT NULL DEFAULT 'invite';

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,5 +16,8 @@ export default defineConfig({
         url: "http://localhost:3000",
         reuseExistingServer: !process.env.CI,
         timeout: 60_000,
+        // The suite authenticates many times from one host; disable the login
+        // brute-force rate limit on the test server so logins aren't 429'd.
+        env: { ...process.env, DISABLE_RATE_LIMIT: "1" },
       },
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,14 @@ import { defineConfig } from "@playwright/test";
 
 const baseURL = process.env.TEST_BASE_URL ?? "http://localhost:3000";
 
+// Fixed session password for the e2e server. The admin-skeleton spec seals a
+// session cookie with this exact value (see e2e/admin-skeleton.spec.ts), so the
+// server MUST use the same password or the cookie can't be decrypted and the
+// middleware redirects /admin → /login (which made the skeleton tests flaky).
+// Keep this in sync with E2E_SESSION_PASSWORD in e2e/admin-skeleton.spec.ts.
+export const E2E_SESSION_PASSWORD =
+  process.env.SESSION_PASSWORD ?? "autodelen-dev-session-password-32-chars-xyz";
+
 export default defineConfig({
   testDir: "./e2e",
   use: {
@@ -16,8 +24,19 @@ export default defineConfig({
         url: "http://localhost:3000",
         reuseExistingServer: !process.env.CI,
         timeout: 60_000,
-        // The suite authenticates many times from one host; disable the login
-        // brute-force rate limit on the test server so logins aren't 429'd.
-        env: { ...process.env, DISABLE_RATE_LIMIT: "1" },
+        // Pin the env the suite depends on so it doesn't rely on a local
+        // .env.local. Kept identical across the e2e branches so the file never
+        // conflicts on merge:
+        //   - SESSION_PASSWORD  — matches admin-skeleton's sealed cookie
+        //   - NEXT_PUBLIC_BASE_URL — absolute redirects
+        //   - DISABLE_RATE_LIMIT — the suite logs in many times from one host,
+        //     so the login brute-force limiter must not 429 it (no-op unless the
+        //     rate-limit code that reads it is present).
+        env: {
+          ...process.env,
+          SESSION_PASSWORD: E2E_SESSION_PASSWORD,
+          NEXT_PUBLIC_BASE_URL: baseURL,
+          DISABLE_RATE_LIMIT: "1",
+        },
       },
 });

--- a/proxy.ts
+++ b/proxy.ts
@@ -14,6 +14,13 @@ const PUBLIC_PATHS = [
   "/api/invite",
   "/api/admin/calendar-renew",
   "/api/calendar-id",
+  // Self-service password reset / magic-link sign-in (issue #267).
+  "/forgot",
+  "/reset",
+  "/magic",
+  "/api/auth/forgot",
+  "/api/auth/reset",
+  "/api/auth/magic",
 ];
 
 // Pages only admins can visit (non-admins get redirected to /).

--- a/types/index.ts
+++ b/types/index.ts
@@ -10,7 +10,9 @@ export interface Person {
   is_admin: 0 | 1;
   bank_account: string;
   email: string | null;
-  theme_preference: 'paper' | 'mono';
+  theme_preference: "paper" | "mono";
+  /** Bumped to revoke all of a user's existing sessions ("log out everywhere"). */
+  session_epoch?: number;
   updated_at: string;
 }
 
@@ -181,7 +183,10 @@ export interface DashboardRow {
 }
 
 // Form input types (no id, no computed fields)
-export type PersonInput = Pick<Person, "first_name" | "last_name" | "discount" | "discount_long" | "active"> & {
+export type PersonInput = Pick<
+  Person,
+  "first_name" | "last_name" | "discount" | "discount_long" | "active"
+> & {
   username?: string | null;
   is_admin?: 0 | 1;
 };


### PR DESCRIPTION
## Summary

Self-service account recovery and server-side session revocation, split out from the security-hardening PR (#268) into their own branch.

Closes #266
Closes #267

## #266 — "Log out everywhere" / server-side session revocation

`iron-session` cookies are stateless, so a leaked cookie couldn't be revoked before its 7-day expiry. Added a per-user **session epoch**:

- Migration `0021` adds `people.session_epoch` (default 0).
- The epoch is embedded in the session cookie at login / invite / reset / magic-link, and re-checked in `requireAdmin` / `requireSession` / `requireAdminOrOwner` and `/api/me`. A stale cookie is rejected and destroyed; legacy cookies without an epoch stay valid.
- `POST /api/auth/logout-all` bumps the epoch (revoking every device) and destroys the current session — surfaced as **"Log out all devices"** on the profile page (`/user/[id]/edit`, own profile only).

## #267 — Self-service password reset / magic-link sign-in

- Migration `0022` adds `invite_tokens.purpose` so one table carries invite / reset / magic tokens; query helpers generalised to `createAuthToken` / `getAuthToken`.
- `POST /api/auth/forgot` and `POST /api/auth/magic` always return `200` (**no account enumeration**), are rate-limited per IP, and email a short-lived single-use link via a transport-agnostic `lib/mailer.ts` (webhook if `MAIL_WEBHOOK_URL` is set, otherwise logged for self-hosters).
- `POST /api/auth/reset/[token]` (1h TTL) sets the new password **and bumps the session epoch** so a reset invalidates old sessions. `GET /api/auth/magic/[token]` (15m TTL) establishes a session and redirects.
- UI: `/forgot` and `/reset/[token]` pages + a "Forgot password?" link on `/login`, en/nl translations. The proxy middleware allow-lists the recovery routes.

## Route reference

| Method & URL | Purpose |
|---|---|
| `GET /forgot` | Request-a-link page |
| `POST /api/auth/forgot` | Email a reset link (1h), no enumeration |
| `POST /api/auth/magic` | Email a magic sign-in link (15m), no enumeration |
| `GET /reset/<token>` | Set-new-password page |
| `POST /api/auth/reset/<token>` | Apply new password + bump epoch + sign in |
| `GET /api/auth/magic/<token>` | Consume magic link → set session → redirect `/` |
| `POST /api/auth/logout-all` | Bump epoch (revoke all devices) + destroy current session |

## Verification

- `tsc --noEmit` clean · `npm run build` succeeds
- **484 unit tests** pass (session-epoch revocation, logout-all, forgot, reset)
- **12 e2e tests** pass — `auth-recovery.spec.ts` (no-enumeration, invalid-token, forgot link) and `session-revocation.spec.ts` (current-session + cross-device revocation, CSRF)

## Relationship to the other open PRs — all independent, all branch off `main`

- **#268** (security hardening) and **#271** (flaky-e2e fixes) are separate. This branch contains the auth features only.
- This branch and #268 both touch `app/api/auth/login/route.ts` and `lib/api.ts` on **different lines** (this one stamps the session epoch; #268 adds the login rate-limit guard) — they auto-merge cleanly in either order.
- `playwright.config.ts` is kept **byte-identical** with #271, so the two no longer conflict. All three PRs merge in any order with no manual resolution.

https://claude.ai/code/session_01EvJThHe6obwJKjS5cnPLv8