### PR TITLE
test(e2e): stabilize flaky admin-skeleton, reservations, and cache tests

### DIFF
--- a/e2e/admin-skeleton.spec.ts
+++ b/e2e/admin-skeleton.spec.ts
@@ -1,7 +1,11 @@
 import { test, expect } from "@playwright/test";
 import { sealData } from "iron-session";
 
-const SESSION_PASSWORD = "autodelen-dev-session-password-32-chars-xyz";
+// Must match the password the e2e web server boots with — see
+// E2E_SESSION_PASSWORD in playwright.config.ts. If these diverge the sealed
+// cookie can't be decrypted and the app redirects /admin → /login.
+const SESSION_PASSWORD =
+  process.env.SESSION_PASSWORD ?? "autodelen-dev-session-password-32-chars-xyz";
 
 const EMPTY_ADMIN_SUMMARY = {
   carPnL: [],

--- a/e2e/reservations.spec.ts
+++ b/e2e/reservations.spec.ts
@@ -20,7 +20,7 @@ import { loginAndGetCsrf, makeApi, getTestEntities } from "./helpers";
 
 // Future dates to avoid conflicts with existing real reservations
 const FUTURE_START = new Date(Date.now() + 60 * 86400_000).toISOString().slice(0, 10); // +60 days
-const FUTURE_END = new Date(Date.now() + 62 * 86400_000).toISOString().slice(0, 10);   // +62 days
+const FUTURE_END = new Date(Date.now() + 62 * 86400_000).toISOString().slice(0, 10); // +62 days
 
 test.describe("reservation approval flow", () => {
   let userCsrf: string;
@@ -94,23 +94,29 @@ test.describe("reservation approval flow", () => {
       // The confirm button text comes from t("admin.confirm") → "Bevestigen" (nl) / "Confirm" (en).
       // There may be multiple pending reservations; click the first confirm button
       // (our reservation was just inserted so it should be at the top).
-      const confirmBtn = adminPage
-        .getByRole("button", { name: /bevestigen|confirm/i })
-        .first();
+      const confirmBtn = adminPage.getByRole("button", { name: /bevestigen|confirm/i }).first();
+
+      // Wait for the PATCH .../status response triggered by the click, rather
+      // than a fixed timeout — removes the race that left status === "pending".
+      const statusResponse = adminPage.waitForResponse(
+        (r) => /\/api\/reservations\/\d+\/status$/.test(r.url()) && r.request().method() === "PATCH"
+      );
       await confirmBtn.click();
+      await statusResponse;
 
-      // After confirmation a toast appears and the card disappears from the inbox
-      // (or the list refreshes). Wait for the reservation to no longer be "pending"
-      // in the inbox by checking the API.
-      await adminPage.waitForTimeout(1000); // let the mutation settle
-
-      const reservationsAfter = await adminPage.request.get("/api/reservations");
-      const all = await reservationsAfter.json() as Array<{
-        id: number;
-        status: string;
-      }>;
-      const updated = all.find((r) => r.id === reservationId);
-      expect(updated?.status).toBe("confirmed");
+      // Poll the API until the status flips (poll auto-retries, so a single
+      // transient read error — e.g. ECONNRESET — no longer fails the test).
+      await expect
+        .poll(
+          async () => {
+            const res = await adminPage.request.get("/api/reservations");
+            if (!res.ok()) return undefined;
+            const all = (await res.json()) as Array<{ id: number; status: string }>;
+            return all.find((r) => r.id === reservationId)?.status;
+          },
+          { timeout: 10_000 }
+        )
+        .toBe("confirmed");
     } finally {
       await adminContext.close();
     }
@@ -175,7 +181,7 @@ test.describe("reservation approval flow", () => {
 
     // Fetch via API to confirm status is still pending
     const res = await page.request.get("/api/reservations");
-    const all = await res.json() as Array<{ id: number; status: string }>;
+    const all = (await res.json()) as Array<{ id: number; status: string }>;
     const mine = all.find((r) => r.id === reservationId);
     expect(mine?.status).toBe("pending");
   });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -25,12 +25,18 @@ export default defineConfig({
         reuseExistingServer: !process.env.CI,
         timeout: 60_000,
         // Pin the env the suite depends on so it doesn't rely on a local
-        // .env.local: a known session password (matches admin-skeleton's
-        // sealed cookie) and a base URL for absolute redirects.
+        // .env.local. Kept identical across the e2e branches so the file never
+        // conflicts on merge:
+        //   - SESSION_PASSWORD  — matches admin-skeleton's sealed cookie
+        //   - NEXT_PUBLIC_BASE_URL — absolute redirects
+        //   - DISABLE_RATE_LIMIT — the suite logs in many times from one host,
+        //     so the login brute-force limiter must not 429 it (no-op unless the
+        //     rate-limit code that reads it is present).
         env: {
           ...process.env,
           SESSION_PASSWORD: E2E_SESSION_PASSWORD,
           NEXT_PUBLIC_BASE_URL: baseURL,
+          DISABLE_RATE_LIMIT: "1",
         },
       },
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,14 @@ import { defineConfig } from "@playwright/test";
 
 const baseURL = process.env.TEST_BASE_URL ?? "http://localhost:3000";
 
+// Fixed session password for the e2e server. The admin-skeleton spec seals a
+// session cookie with this exact value (see e2e/admin-skeleton.spec.ts), so the
+// server MUST use the same password or the cookie can't be decrypted and the
+// middleware redirects /admin → /login (which made the skeleton tests flaky).
+// Keep this in sync with E2E_SESSION_PASSWORD in e2e/admin-skeleton.spec.ts.
+export const E2E_SESSION_PASSWORD =
+  process.env.SESSION_PASSWORD ?? "autodelen-dev-session-password-32-chars-xyz";
+
 export default defineConfig({
   testDir: "./e2e",
   use: {
@@ -16,5 +24,13 @@ export default defineConfig({
         url: "http://localhost:3000",
         reuseExistingServer: !process.env.CI,
         timeout: 60_000,
+        // Pin the env the suite depends on so it doesn't rely on a local
+        // .env.local: a known session password (matches admin-skeleton's
+        // sealed cookie) and a base URL for absolute redirects.
+        env: {
+          ...process.env,
+          SESSION_PASSWORD: E2E_SESSION_PASSWORD,
+          NEXT_PUBLIC_BASE_URL: baseURL,
+        },
       },
 });


### PR DESCRIPTION
Fixes the four pre-existing flaky e2e tests tracked in #269. Diff is test/config only — no app code changes.

Closes #269

## Root causes & fixes

### admin-skeleton ×2 (`admin inbox/gaps shows skeleton while API is blocked`)
**Cause:** the spec seals a session cookie with a hardcoded `SESSION_PASSWORD`, but the Playwright-managed dev server booted with whatever `SESSION_PASSWORD` happened to be in the environment (or none). When they didn't match, the cookie couldn't be decrypted → middleware redirected `/admin` → `/login` → the skeleton testid never rendered → timeout.

**Fix:**
- `playwright.config.ts` pins the web server's `SESSION_PASSWORD` (and `NEXT_PUBLIC_BASE_URL`) via the `webServer.env` option, exported as `E2E_SESSION_PASSWORD`.
- `admin-skeleton.spec.ts` reads `SESSION_PASSWORD` from env (same default), so the sealed cookie always matches the server.

### reservations (`pending reservation appears in admin inbox and can be approved`)
**Cause:** after clicking confirm, the test did `waitForTimeout(1000)` then a single `GET /api/reservations` — racing the PATCH (intermittently still `"pending"`) and failing hard on a transient `ECONNRESET`.

**Fix:** wait on the actual `PATCH …/status` response (`waitForResponse`), then `expect.poll` the reservations API until the status flips to `confirmed`. Polling auto-retries, so a single transient read error no longer fails the test.

### cache-invalidation ×2
Collateral damage from the same dev-server/session instability; they pass consistently once the server env is pinned. No spec change needed.

## Verification

Ran the three spec files together (serial, as CI runs them) against a freshly seeded demo DB: **8 passed** (all 4 originally-flaky tests + the 4 neighbouring tests in those files). The `Hydration failed` lines in the dev-server log are pre-existing `LangSwitcher`/`OfflineBadge` warnings, unrelated — the tests pass.

## Relationship to the other open PRs — all independent, all branch off `main`

- No app/production code touched; purely test reliability.
- Shares `playwright.config.ts` with #270, but the file is kept **byte-identical** across both branches, so they no longer conflict. No overlap with #268. All three PRs merge in any order with no manual resolution.

https://claude.ai/code/session_01EvJThHe6obwJKjS5cnPLv8