### PR TITLE
test(e2e): add coverage for vehicles, members, payments, settlement, invite

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -98,6 +98,20 @@ export function makeApi(request: APIRequestContext, csrf: string) {
       return res.json() as Promise<T>;
     },
 
+    async put<T>(path: string, body: unknown): Promise<T> {
+      const res = await request.put(path, {
+        data: body,
+        headers: {
+          "Content-Type": "application/json",
+          "x-csrf-token": csrf,
+        },
+      });
+      if (!res.ok()) {
+        throw new Error(`PUT ${path} failed: ${res.status()} ${await res.text()}`);
+      }
+      return res.json() as Promise<T>;
+    },
+
     async get<T>(path: string): Promise<T> {
       const res = await request.get(path);
       if (!res.ok()) {

--- a/e2e/invite.spec.ts
+++ b/e2e/invite.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from "@playwright/test";
+import { loginAndGetSession, loginAndGetCsrf, makeApi } from "./helpers";
+
+/**
+ * Invite flow e2e tests.
+ *
+ * Strategy:
+ * - Admin creates a new person without a password.
+ * - Admin generates an invite token via POST /api/people/[id]/invite.
+ * - Extract the token from the returned URL.
+ * - POST to /api/invite/[token] with a password — simulates accepting the invite.
+ * - Verify the response indicates success and a person_id is returned.
+ * - Cleanup: deactivate the test person in afterEach.
+ */
+
+const INVITE_FIRST = "E2EInvite";
+const INVITE_LAST = "Tester";
+const INVITE_PASSWORD = "securepassword123";
+
+test.describe("invite flow", () => {
+  let csrf: string;
+  let api: ReturnType<typeof makeApi>;
+  let personId: number;
+
+  const personData = {
+    first_name: INVITE_FIRST,
+    last_name: INVITE_LAST,
+    discount: 0,
+    discount_long: 0,
+    active: 1 as const,
+    bank_account: "",
+  };
+
+  test.beforeEach(async ({ request }) => {
+    const session = await loginAndGetSession(request, "admin", "admin");
+    csrf = session.csrf;
+    api = makeApi(request, csrf);
+
+    const res = await api.post<{ id: number }>("/api/people", personData);
+    personId = res.id;
+  });
+
+  test.afterEach(async ({ request }) => {
+    if (!personId) return;
+    // Reactivate — deactivated members have low-contrast styling that breaks a11y audit.
+    try {
+      const cleanupCsrf = await loginAndGetCsrf(request, "admin", "admin");
+      const cleanupApi = makeApi(request, cleanupCsrf);
+      await cleanupApi.put<{ ok: boolean }>(`/api/people/${personId}`, {
+        ...personData,
+        active: 1,
+      });
+    } catch {
+      // Ignore
+    }
+  });
+
+  test("admin can generate an invite URL for a new person", async () => {
+    const result = await api.post<{ url: string }>(`/api/people/${personId}/invite`, {});
+    expect(result.url).toMatch(/\/invite\/[a-f0-9]{48}$/);
+  });
+
+  test("accepting an invite sets password and logs user in", async ({ request }) => {
+    const { url } = await api.post<{ url: string }>(`/api/people/${personId}/invite`, {});
+    const token = url.split("/invite/")[1];
+    expect(token).toBeTruthy();
+
+    // POST to /api/invite/[token] without authentication — simulates the invite accept page
+    const res = await request.post(`/api/invite/${token}`, {
+      data: { password: INVITE_PASSWORD },
+      headers: { "Content-Type": "application/json" },
+    });
+
+    expect(res.ok()).toBe(true);
+    const body = await res.json() as { ok: boolean; person_id: number };
+    expect(body.ok).toBe(true);
+    expect(body.person_id).toBe(personId);
+  });
+
+  test("invite token is invalid after use", async ({ request }) => {
+    const { url } = await api.post<{ url: string }>(`/api/people/${personId}/invite`, {});
+    const token = url.split("/invite/")[1];
+
+    // Use the token once
+    await request.post(`/api/invite/${token}`, {
+      data: { password: INVITE_PASSWORD },
+      headers: { "Content-Type": "application/json" },
+    });
+
+    // Second use should fail — token was deleted after first use
+    const res = await request.post(`/api/invite/${token}`, {
+      data: { password: INVITE_PASSWORD },
+      headers: { "Content-Type": "application/json" },
+    });
+    expect(res.status()).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe("invalid_token");
+  });
+});

--- a/e2e/members.spec.ts
+++ b/e2e/members.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect } from "@playwright/test";
+import { loginAndGetSession, loginAndGetCsrf, makeApi, scrollToLoadAll } from "./helpers";
+
+/**
+ * Members (people) deactivate e2e tests.
+ *
+ * No DELETE endpoint exists — deactivation is done via PUT with active=0.
+ *
+ * Strategy:
+ * - Admin creates a person via API in beforeEach.
+ * - Deactivate via PUT (active=0), verify absence from /people list.
+ * - Reactivate in afterEach (active=1), then final delete not possible — we
+ *   leave the inactive test person in place (demo.db only, not production).
+ *
+ * Cleanup: set active=0 is permanent for the test record since there is no
+ * DELETE endpoint. Tests are run against demo.db which is reset between runs.
+ */
+
+const FIRST_NAME = "E2ETest";
+const LAST_NAME = "Member";
+
+type PersonRow = {
+  id: number;
+  first_name: string;
+  last_name: string;
+  active: number;
+};
+
+test.describe("members deactivate", () => {
+  let csrf: string;
+  let api: ReturnType<typeof makeApi>;
+  let personId: number;
+  let personData: ReturnType<typeof buildPersonData>;
+
+  function buildPersonData() {
+    return {
+      first_name: FIRST_NAME,
+      last_name: LAST_NAME,
+      discount: 0,
+      discount_long: 0,
+      active: 1 as const,
+      bank_account: "",
+    };
+  }
+
+  test.beforeEach(async ({ request }) => {
+    const session = await loginAndGetSession(request, "admin", "admin");
+    csrf = session.csrf;
+    api = makeApi(request, csrf);
+    personData = buildPersonData();
+
+    const res = await api.post<{ id: number }>("/api/people", personData);
+    personId = res.id;
+  });
+
+  test.afterEach(async ({ request }) => {
+    if (!personId) return;
+    // Reactivate — deactivated members show with low-contrast styling on /admin/members
+    // which breaks the a11y audit. Since there's no DELETE endpoint, restore active=1.
+    try {
+      const cleanupCsrf = await loginAndGetCsrf(request, "admin", "admin");
+      const cleanupApi = makeApi(request, cleanupCsrf);
+      await cleanupApi.put<{ ok: boolean }>(`/api/people/${personId}`, {
+        ...personData,
+        active: 1,
+      });
+    } catch {
+      // Ignore
+    }
+  });
+
+  test("new member appears in the people list", async ({ page }) => {
+    await page.request.post("/api/auth/login", {
+      data: { username: "admin", password: "admin" },
+    });
+
+    await page.goto("/people");
+    await page.waitForLoadState("networkidle");
+    await scrollToLoadAll(page);
+
+    await expect(page.locator(`text=${FIRST_NAME}`).first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("deactivated member no longer appears in people list", async ({ page }) => {
+    // Deactivate via API
+    await api.put<{ ok: boolean }>(`/api/people/${personId}`, {
+      ...personData,
+      active: 0,
+    });
+
+    await page.request.post("/api/auth/login", {
+      data: { username: "admin", password: "admin" },
+    });
+
+    await page.goto("/people");
+    await page.waitForLoadState("networkidle");
+    await scrollToLoadAll(page);
+
+    // Active members list should not show the deactivated test member
+    await expect(page.getByText(`${FIRST_NAME} ${LAST_NAME}`, { exact: true })).toHaveCount(0);
+  });
+
+  test("deactivated member still retrievable via API", async () => {
+    await api.put<{ ok: boolean }>(`/api/people/${personId}`, {
+      ...personData,
+      active: 0,
+    });
+
+    const person = await api.get<PersonRow>(`/api/people/${personId}`);
+    expect(person.active).toBe(0);
+    expect(person.first_name).toBe(FIRST_NAME);
+  });
+});

--- a/e2e/payments.spec.ts
+++ b/e2e/payments.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from "@playwright/test";
+import { loginAndGetSession, loginAndGetCsrf, makeApi, getTestEntities } from "./helpers";
+
+/**
+ * Payments update + delete e2e tests.
+ *
+ * The payments list (C+R) is already covered by cache-invalidation.spec.ts.
+ * This file covers the missing U and D operations.
+ *
+ * Strategy:
+ * - Create a payment via API in beforeEach.
+ * - Update amount via PUT, verify via GET.
+ * - Delete via API in afterEach.
+ */
+
+const TODAY = new Date().toISOString().slice(0, 10);
+const AMOUNT_ORIGINAL = 50;
+const AMOUNT_UPDATED = 75;
+
+test.describe("payments update + delete", () => {
+  let csrf: string;
+  let api: ReturnType<typeof makeApi>;
+  let paymentId: number;
+  let personId: number;
+
+  test.beforeEach(async ({ request }) => {
+    const session = await loginAndGetSession(request);
+    csrf = session.csrf;
+    api = makeApi(request, csrf);
+
+    const entities = await getTestEntities(api);
+    personId = session.personId ?? entities.personId;
+
+    const res = await api.post<{ id: number }>("/api/payments", {
+      person_id: personId,
+      date: TODAY,
+      amount: AMOUNT_ORIGINAL,
+    });
+    paymentId = res.id;
+  });
+
+  test.afterEach(async ({ request }) => {
+    if (!paymentId) return;
+    try {
+      const cleanupCsrf = await loginAndGetCsrf(request);
+      const cleanupApi = makeApi(request, cleanupCsrf);
+      await cleanupApi.delete(`/api/payments/${paymentId}`);
+    } catch {
+      // Ignore — payment already deleted
+    }
+  });
+
+  test("payment amount updates via PUT", async ({ request }) => {
+    await api.put<{ ok: boolean }>(`/api/payments/${paymentId}`, {
+      person_id: personId,
+      date: TODAY,
+      amount: AMOUNT_UPDATED,
+    });
+
+    const updated = await api.get<{ id: number; amount: number }>(`/api/payments/${paymentId}`);
+    expect(updated.amount).toBe(AMOUNT_UPDATED);
+  });
+
+  test("payment is deleted via DELETE", async ({ request }) => {
+    const deletedId = paymentId;
+    await api.delete(`/api/payments/${deletedId}`);
+    paymentId = 0;
+
+    const res = await request.get(`/api/payments/${deletedId}`);
+    // After deletion the record is gone — expect 404
+    expect(res.status()).toBe(404);
+  });
+});

--- a/e2e/settlement.spec.ts
+++ b/e2e/settlement.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from "@playwright/test";
+import { loginAndGetSession, makeApi } from "./helpers";
+
+/**
+ * Settlement lock / unlock e2e tests.
+ *
+ * Strategy:
+ * - Admin POSTs to /api/settlement/[year] to toggle lock state.
+ * - Verify frozen flag via GET response.
+ * - Unlock in afterEach to restore clean state for the next run.
+ *
+ * Uses a year far in the past (2020) to avoid touching the current year's
+ * real settlement data in demo.db.
+ */
+
+const TEST_YEAR = 2020;
+
+test.describe("settlement lock / unlock", () => {
+  let csrf: string;
+  let api: ReturnType<typeof makeApi>;
+  let wasAlreadyFrozen: boolean;
+
+  test.beforeEach(async ({ request }) => {
+    const session = await loginAndGetSession(request, "admin", "admin");
+    csrf = session.csrf;
+    api = makeApi(request, csrf);
+
+    const current = await api.get<{ frozen: boolean }>(`/api/settlement/${TEST_YEAR}`);
+    wasAlreadyFrozen = current.frozen;
+
+    // Ensure we start from an unlocked state
+    if (wasAlreadyFrozen) {
+      await api.post<{ ok: boolean }>(`/api/settlement/${TEST_YEAR}`, {});
+    }
+  });
+
+  test.afterEach(async () => {
+    // Restore original lock state
+    const current = await api.get<{ frozen: boolean }>(`/api/settlement/${TEST_YEAR}`);
+    if (current.frozen !== wasAlreadyFrozen) {
+      await api.post<{ ok: boolean }>(`/api/settlement/${TEST_YEAR}`, {});
+    }
+  });
+
+  test("locking a settlement marks it frozen", async () => {
+    // Lock
+    await api.post<{ ok: boolean }>(`/api/settlement/${TEST_YEAR}`, {});
+
+    const result = await api.get<{ frozen: boolean }>(`/api/settlement/${TEST_YEAR}`);
+    expect(result.frozen).toBe(true);
+  });
+
+  test("unlocking a frozen settlement clears frozen flag", async () => {
+    // Lock first
+    await api.post<{ ok: boolean }>(`/api/settlement/${TEST_YEAR}`, {});
+
+    // Unlock
+    await api.post<{ ok: boolean }>(`/api/settlement/${TEST_YEAR}`, {});
+
+    const result = await api.get<{ frozen: boolean }>(`/api/settlement/${TEST_YEAR}`);
+    expect(result.frozen).toBe(false);
+  });
+});

--- a/e2e/vehicles.spec.ts
+++ b/e2e/vehicles.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect } from "@playwright/test";
+import { loginAndGetSession, loginAndGetCsrf, makeApi, scrollToLoadAll } from "./helpers";
+
+/**
+ * Vehicles CRUD e2e tests.
+ *
+ * Strategy:
+ * - Admin creates a car via API in beforeEach.
+ * - Assert it appears in the /vehicles list UI.
+ * - Update name via PUT, verify the change.
+ * - Delete via the API in afterEach (cleanup).
+ *
+ * Uses unique "short" code (E2ET) to avoid collisions with demo data.
+ */
+
+const CAR_SHORT = "E2ET";
+const CAR_NAME = "E2E-Test-Vehicle";
+const CAR_NAME_UPDATED = "E2E-Test-Vehicle-Updated";
+const PRICE_PER_KM = 0.25;
+
+test.describe("vehicles CRUD", () => {
+  let csrf: string;
+  let api: ReturnType<typeof makeApi>;
+  let carId: number;
+
+  test.beforeEach(async ({ request }) => {
+    const session = await loginAndGetSession(request, "admin", "admin");
+    csrf = session.csrf;
+    api = makeApi(request, csrf);
+
+    const res = await api.post<{ id: number }>("/api/vehicles", {
+      short: CAR_SHORT,
+      name: CAR_NAME,
+      price_per_km: PRICE_PER_KM,
+    });
+    carId = res.id;
+  });
+
+  test.afterEach(async ({ request }) => {
+    if (!carId) return;
+    try {
+      const cleanupCsrf = await loginAndGetCsrf(request, "admin", "admin");
+      const cleanupApi = makeApi(request, cleanupCsrf);
+      await cleanupApi.delete(`/api/vehicles/${carId}`);
+    } catch {
+      // Ignore — car may have been deleted or deactivated already
+    }
+  });
+
+  test("vehicle appears in the vehicles list after creation", async ({ page }) => {
+    await page.request.post("/api/auth/login", {
+      data: { username: "admin", password: "admin" },
+    });
+
+    await page.goto("/vehicles");
+    await page.waitForLoadState("networkidle");
+    await scrollToLoadAll(page);
+
+    await expect(page.locator(`text=${CAR_NAME}`).first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("vehicle name updates via PUT and change appears in list", async ({ page }) => {
+    // Update via API
+    await api.put<{ ok: boolean }>(`/api/vehicles/${carId}`, {
+      short: CAR_SHORT,
+      name: CAR_NAME_UPDATED,
+      price_per_km: PRICE_PER_KM,
+    });
+
+    await page.request.post("/api/auth/login", {
+      data: { username: "admin", password: "admin" },
+    });
+
+    await page.goto("/vehicles");
+    await page.waitForLoadState("networkidle");
+    await scrollToLoadAll(page);
+
+    await expect(page.locator(`text=${CAR_NAME_UPDATED}`).first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText(CAR_NAME, { exact: true })).toHaveCount(0);
+  });
+
+  test("vehicle disappears from list after deletion", async ({ page }) => {
+    await page.request.post("/api/auth/login", {
+      data: { username: "admin", password: "admin" },
+    });
+
+    await page.goto("/vehicles");
+    await page.waitForLoadState("networkidle");
+    await scrollToLoadAll(page);
+
+    await expect(page.locator(`text=${CAR_NAME}`).first()).toBeVisible({ timeout: 10_000 });
+
+    await api.delete(`/api/vehicles/${carId}`);
+    carId = 0;
+
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+    await expect(page.getByText(CAR_NAME, { exact: true })).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
Fills e2e gaps from coverage audit #224.

## New specs
- `vehicles.spec.ts` — vehicle CRUD (create, edit via PUT, delete)
- `members.spec.ts` — member deactivate, removed from list, still retrievable via API
- `payments.spec.ts` — payment update (PUT) + delete (DELETE)
- `settlement.spec.ts` — settlement lock / unlock frozen flag
- `invite.spec.ts` — generate invite URL, accept + set password, token single-use

## Verification
Full suite run against prod build (`next start`, demo.db) on port 4257: **52/52 passed**.

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)