### PR TITLE
fix(e2e): kill reservation-approve flake via id-targeted confirm button

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -298,6 +298,7 @@ export default function AdminInboxPage() {
             <Perf margin="8px 0" />
             <div style={{ display: "flex", gap: 8 }}>
               <button
+                data-testid={`confirm-${r.id}`}
                 onClick={() =>
                   approve.mutate(
                     { id: r.id, status: "confirmed" },

--- a/e2e/reservations.spec.ts
+++ b/e2e/reservations.spec.ts
@@ -90,16 +90,19 @@ test.describe("reservation approval flow", () => {
       const reservationNote = adminPage.getByText("E2E-test-reservation").first();
       await expect(reservationNote).toBeVisible({ timeout: 10_000 });
 
-      // Click the "Bevestigen" / "Confirm" button that sits next to our card.
-      // The confirm button text comes from t("admin.confirm") → "Bevestigen" (nl) / "Confirm" (en).
-      // There may be multiple pending reservations; click the first confirm button
-      // (our reservation was just inserted so it should be at the top).
-      const confirmBtn = adminPage.getByRole("button", { name: /bevestigen|confirm/i }).first();
+      // Click the confirm button for OUR reservation, addressed by id. There may be
+      // several pending reservations (sibling tests, parallel workers) sharing the
+      // same start_date and note, so the inbox order is undefined — a ".first()"
+      // selector could confirm a different reservation and leave ours pending.
+      const confirmBtn = adminPage.getByTestId(`confirm-${reservationId}`);
+      await expect(confirmBtn).toBeVisible({ timeout: 10_000 });
 
       // Wait for the PATCH .../status response triggered by the click, rather
       // than a fixed timeout — removes the race that left status === "pending".
       const statusResponse = adminPage.waitForResponse(
-        (r) => /\/api\/reservations\/\d+\/status$/.test(r.url()) && r.request().method() === "PATCH"
+        (r) =>
+          new RegExp(`/api/reservations/${reservationId}/status$`).test(r.url()) &&
+          r.request().method() === "PATCH"
       );
       await confirmBtn.click();
       await statusResponse;
@@ -118,6 +121,72 @@ test.describe("reservation approval flow", () => {
         )
         .toBe("confirmed");
     } finally {
+      await adminContext.close();
+    }
+  });
+
+  test("approves the targeted reservation when several are pending", async ({ browser }) => {
+    const adminEmail = process.env.TEST_ADMIN_EMAIL ?? "admin";
+    const adminPassword = process.env.TEST_ADMIN_PASSWORD ?? "admin";
+
+    // Create a second, decoy pending reservation with the SAME start_date as ours.
+    // Tied start_date means the inbox order between the two is undefined, so a
+    // ".first()" selector cannot reliably target our reservation. The confirm
+    // button must be addressable by reservation id.
+    const decoy = await userApi.post<{ id: number }>("/api/reservations", {
+      person_id: personId,
+      car_id: carId,
+      start_date: FUTURE_START,
+      end_date: FUTURE_END,
+      note: "E2E-decoy-reservation",
+    });
+    const decoyId = decoy.id;
+
+    const adminContext = await browser.newContext();
+    const adminPage = await adminContext.newPage();
+
+    try {
+      await adminPage.request.post("/api/auth/login", {
+        data: { username: adminEmail, password: adminPassword },
+      });
+      await adminPage.goto("/admin");
+      await adminPage.waitForLoadState("networkidle");
+
+      // Target OUR reservation's confirm button deterministically by id.
+      const confirmBtn = adminPage.getByTestId(`confirm-${reservationId}`);
+      await expect(confirmBtn).toBeVisible({ timeout: 10_000 });
+
+      const statusResponse = adminPage.waitForResponse(
+        (r) =>
+          new RegExp(`/api/reservations/${reservationId}/status$`).test(r.url()) &&
+          r.request().method() === "PATCH"
+      );
+      await confirmBtn.click();
+      await statusResponse;
+
+      // Ours flips to confirmed; the decoy must stay pending (we never touched it).
+      await expect
+        .poll(
+          async () => {
+            const res = await adminPage.request.get("/api/reservations");
+            if (!res.ok()) return undefined;
+            const all = (await res.json()) as Array<{ id: number; status: string }>;
+            const mine = all.find((r) => r.id === reservationId)?.status;
+            const other = all.find((r) => r.id === decoyId)?.status;
+            return `${mine}/${other}`;
+          },
+          { timeout: 10_000 }
+        )
+        .toBe("confirmed/pending");
+    } finally {
+      // Clean up the decoy with admin credentials.
+      try {
+        const cleanupCsrf = await loginAndGetCsrf(adminPage.request, adminEmail, adminPassword);
+        const cleanupApi = makeApi(adminPage.request, cleanupCsrf);
+        await cleanupApi.delete(`/api/reservations/${decoyId}`);
+      } catch {
+        // Ignore
+      }
       await adminContext.close();
     }
   });


### PR DESCRIPTION
## Root cause
The admin-inbox approve test (`reservations.spec.ts:69`) clicked the **first** confirm button (`.first()`), assuming its just-created reservation sat at the top of the inbox.

It does not, reliably:
- `getReservations` orders by `ORDER BY r.start_date DESC` (`lib/queries/reservations.ts:19`); the admin page renders that order unfiltered.
- Every test iteration uses an identical module-level `start_date` constant **and** identical note `"E2E-test-reservation"`. Tied `start_date` → SQLite returns ties in arbitrary order.
- `--repeat-each` × 2 workers create multiple simultaneous pending reservations.

So `.first()` frequently confirmed a *different* reservation, leaving ours `pending` → the 10s status poll timed out (~1-in-5 failures). PR #271 fixed a different (post-click) race but not this selector ambiguity.

## Fix
- **`app/admin/page.tsx`** — add `data-testid={\`confirm-${r.id}\`}` to the inbox confirm button.
- **`e2e/reservations.spec.ts`** — target the confirm button by reservation id (`getByTestId`) instead of `.first()`; add a regression test that creates a **decoy** pending reservation and asserts only the targeted one flips to `confirmed` while the decoy stays `pending`.

## Verification
- New regression test: **8/8** under `--repeat-each=8`.
- reservations + admin-skeleton: **35/35** at `--repeat-each=5` (was **1 fail/30** before).
- Full e2e suite: **53 passed**. Lint: 0 errors. Unit: **469 passed**.

> Note: at `--repeat-each=8` the reservation POST hits the pre-existing rate limiter (`429`, `lib/api.ts:115`) during `beforeEach` — synthetic-burst artifact, unrelated to this flake.

Closes #269
Follow-up to #271.

🤖 Generated with [Claude Code](https://claude.com/claude-code)