### PR TITLE
feat(theme): mono as default theme (#263) + /user redirect

### DIFF
--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -22,7 +22,7 @@ function getPersonFields(personId: number): {
   if (!row) return { shortName: null, themePreference: null };
   return {
     shortName: shortNameOf(row) || null,
-    themePreference: (row.theme_preference === "mono" ? "mono" : "paper") as "paper" | "mono",
+    themePreference: (row.theme_preference === "paper" ? "paper" : "mono") as "paper" | "mono",
   };
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -66,7 +66,7 @@ export const viewport: Viewport = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="nl" className={`${fraunces.variable} ${inter.variable} ${courierPrime.variable} ${interTight.variable} ${jetbrainsMono.variable}`}>
+    <html lang="nl" data-theme="mono" className={`${fraunces.variable} ${inter.variable} ${courierPrime.variable} ${interTight.variable} ${jetbrainsMono.variable}`}>
       <head></head>
       <body>
         <LocaleProvider>

--- a/app/user/[id]/edit/page.tsx
+++ b/app/user/[id]/edit/page.tsx
@@ -409,7 +409,7 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
               {t("form.theme")}
             </div>
             <div style={{ display: "flex", gap: 8 }}>
-              {(["paper", "mono"] as Theme[]).map((t2) => (
+              {(["mono", "paper"] as Theme[]).map((t2) => (
                 <button
                   key={t2}
                   type="button"

--- a/app/user/[id]/edit/page.tsx
+++ b/app/user/[id]/edit/page.tsx
@@ -27,7 +27,7 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
   const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
   const { theme: _theme, setTheme } = useTheme();
-  const [themePreference, setThemePreference] = useState<Theme>("paper");
+  const [themePreference, setThemePreference] = useState<Theme>("mono");
   const [themeSaved, setThemeSaved] = useState(false);
 
   useEffect(() => {
@@ -57,7 +57,7 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
 
   useEffect(() => {
     if (person) {
-      setThemePreference((person.theme_preference as Theme) ?? "paper");
+      setThemePreference((person.theme_preference as Theme) ?? "mono");
     }
   }, [person]);
 

--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -1,0 +1,23 @@
+import { redirect } from "next/navigation";
+import { cookies } from "next/headers";
+import { getIronSession } from "iron-session";
+import { sessionOptions, type SessionData } from "@/lib/session";
+
+// Reads the session cookie, so it must render per-request.
+export const dynamic = "force-dynamic";
+
+/**
+ * `/user` has no page of its own — it sends the signed-in member to their own
+ * profile edit page. Unauthenticated visitors are denied and sent to /login.
+ */
+export default async function UserIndexPage() {
+  const session = await getIronSession<SessionData>(await cookies(), sessionOptions);
+  // While cloaked, edit the impersonated person; otherwise the real session person.
+  const personId = session.cloakedAs?.personId ?? session.personId;
+
+  if (!session.authenticated || !personId) {
+    redirect("/login");
+  }
+
+  redirect(`/user/${personId}/edit`);
+}

--- a/lib/__tests__/theme_context.test.tsx
+++ b/lib/__tests__/theme_context.test.tsx
@@ -14,18 +14,18 @@ afterEach(() => {
 });
 
 describe("ThemeProvider", () => {
-  it("defaults to paper theme", () => {
+  it("defaults to mono theme", () => {
     const { getByTestId } = render(
       <ThemeProvider>
         <ThemeReader />
       </ThemeProvider>
     );
-    expect(getByTestId("theme").textContent).toBe("paper");
+    expect(getByTestId("theme").textContent).toBe("mono");
   });
 
   it("applies data-theme attribute to html element", () => {
     render(<ThemeProvider><div /></ThemeProvider>);
-    expect(document.documentElement.getAttribute("data-theme")).toBe("paper");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("mono");
   });
 
   it("setTheme updates html data-theme attribute", () => {

--- a/lib/schemas/person.ts
+++ b/lib/schemas/person.ts
@@ -10,5 +10,5 @@ export const personSchema = z.object({
   is_admin: z.union([z.literal(0), z.literal(1)]).default(0),
   bank_account: z.string().default(""),
   email: z.string().email().nullable().optional(),
-  theme_preference: z.enum(["paper", "mono"]).optional().default("paper"),
+  theme_preference: z.enum(["paper", "mono"]).optional().default("mono"),
 });

--- a/lib/theme-context.tsx
+++ b/lib/theme-context.tsx
@@ -8,11 +8,11 @@ interface ThemeCtx {
   setTheme: (t: Theme) => void;
 }
 
-const ThemeContext = createContext<ThemeCtx>({ theme: "paper", setTheme: () => {} });
+const ThemeContext = createContext<ThemeCtx>({ theme: "mono", setTheme: () => {} });
 
 export function ThemeProvider({
   children,
-  initialTheme = "paper",
+  initialTheme = "mono",
 }: {
   children: React.ReactNode;
   initialTheme?: Theme;


### PR DESCRIPTION
Closes #263.

## What

Make **mono** the genuine default theme so login and authenticated pages paint mono from first render — kills the paper-theme flash. Paper stays an opt-in.

### Theme default flip
- `app/layout.tsx`: render `<html data-theme="mono">` server-side → existing `[data-theme="mono"]` CSS applies on first paint (no paper flash). The large `globals.css` `:root`/paper block is untouched.
- `lib/theme-context.tsx`: ThemeProvider context + `initialTheme` default → `mono` (hydration matches the SSR attr).
- `lib/schemas/person.ts`: Zod `theme_preference` default → `mono`.
- `app/api/me/route.ts`: fallback flipped — explicit stored `paper` stays paper, `mono`/null/other → mono.
- `app/user/[id]/edit/page.tsx`: switcher state default → mono, **and lists Mono first** in the picker.

### /user redirect (bonus)
- New `app/user/page.tsx` server component: `/user` → `/user/<id>/edit` for the signed-in member (honors cloak); unauthenticated visitors are denied → `/login`.

## Verification
- Lint: 0 errors. Tests: **495/495 pass**. Prod build: success.
- SSR check: `/login` ships `<html ... data-theme="mono">`.
- Live: unauth `/user` → 307 `/login`; alice (id 3) `/user` → 307 `/user/3/edit`, `themePreference=mono`.

## Trade-off
Opt-in paper users see a one-frame mono→paper flash on load (per-user SSR theme was deliberately out of scope). DB column default (migration 0018) left as-is; app inserts already force mono.

🤖 Generated with [Claude Code](https://claude.com/claude-code)