### PR TITLE
fix(auth): make /forgot and /reset guest-only (redirect logged-in users)

### DIFF
--- a/e2e/auth-recovery.spec.ts
+++ b/e2e/auth-recovery.spec.ts
@@ -1,4 +1,7 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, request as playwrightRequest } from "@playwright/test";
+
+const EMAIL = process.env.TEST_EMAIL ?? "alice";
+const PASSWORD = process.env.TEST_PASSWORD ?? "alice";
 
 /**
  * E2E for self-service account recovery (issue #267):
@@ -64,5 +67,56 @@ test.describe("Account recovery", () => {
     expect(res.status()).toBeGreaterThanOrEqual(300);
     expect(res.status()).toBeLessThan(400);
     expect(res.headers()["location"]).toContain("/login");
+  });
+});
+
+/**
+ * Recovery pages are guest-only (issue #275): an already-authenticated user is
+ * redirected away from /forgot and /reset/<token>, the same way /login already
+ * redirects logged-in users. Logged-out users must still reach them.
+ *
+ * Each test uses its own request context (cookie jar) so the logged-in and
+ * logged-out cases don't share session state.
+ */
+test.describe("Recovery pages are guest-only", () => {
+  /** Path of the Location header, or "" if absent. */
+  function redirectPath(location: string | undefined): string {
+    if (!location) return "";
+    return new URL(location, "http://localhost").pathname;
+  }
+
+  test("a logged-in user visiting /forgot is redirected to /", async () => {
+    const ctx = await playwrightRequest.newContext();
+    const login = await ctx.post("/api/auth/login", {
+      data: { username: EMAIL, password: PASSWORD },
+    });
+    expect(login.ok()).toBe(true);
+
+    const res = await ctx.get("/forgot", { maxRedirects: 0 });
+    expect(res.status()).toBeGreaterThanOrEqual(300);
+    expect(res.status()).toBeLessThan(400);
+    expect(redirectPath(res.headers()["location"])).toBe("/");
+    await ctx.dispose();
+  });
+
+  test("a logged-in user visiting /reset/<token> is redirected to /", async () => {
+    const ctx = await playwrightRequest.newContext();
+    const login = await ctx.post("/api/auth/login", {
+      data: { username: EMAIL, password: PASSWORD },
+    });
+    expect(login.ok()).toBe(true);
+
+    const res = await ctx.get("/reset/some-token", { maxRedirects: 0 });
+    expect(res.status()).toBeGreaterThanOrEqual(300);
+    expect(res.status()).toBeLessThan(400);
+    expect(redirectPath(res.headers()["location"])).toBe("/");
+    await ctx.dispose();
+  });
+
+  test("a logged-out user can still reach /forgot", async () => {
+    const ctx = await playwrightRequest.newContext();
+    const res = await ctx.get("/forgot", { maxRedirects: 0 });
+    expect(res.status()).toBe(200);
+    await ctx.dispose();
   });
 });

--- a/proxy.ts
+++ b/proxy.ts
@@ -26,12 +26,17 @@ const PUBLIC_PATHS = [
 // Pages only admins can visit (non-admins get redirected to /).
 const ADMIN_ONLY_PAGES = ["/vehicles", "/people", "/payments"];
 
+// Guest-only pages — authenticated users get redirected to / (mirror of
+// protected routes redirecting logged-out users to /login). The /api/auth/*
+// endpoints and the magic-link consume route stay accessible.
+const GUEST_ONLY_PAGES = ["/login", "/forgot", "/reset"];
+
 export async function proxy(req: NextRequest) {
   const { pathname } = req.nextUrl;
 
   // Static assets and Next.js internals are excluded via the matcher below.
   if (PUBLIC_PATHS.some((p) => pathname === p || pathname.startsWith(p + "/"))) {
-    if (pathname === "/login") {
+    if (GUEST_ONLY_PAGES.some((p) => pathname === p || pathname.startsWith(p + "/"))) {
       const res = NextResponse.next();
       const session = await getIronSession<SessionData>(req, res, sessionOptions);
       if (session.authenticated) {


### PR DESCRIPTION
## Problem
`proxy.ts` allow-lists the recovery routes as public, but only `/login` redirected already-authenticated users to `/`. So a logged-in user could still open `/forgot` and `/reset/<token>`.

## Fix
Generalize the existing `/login` redirect to a `GUEST_ONLY_PAGES` list (`/login`, `/forgot`, `/reset`): authenticated users are redirected to `/`, mirroring how protected routes redirect logged-out users to `/login`. `/api/auth/*` and the magic-link consume route stay accessible.

## Tests
- New e2e (`auth-recovery.spec.ts`): logged-in user bounced from `/forgot` and `/reset/<token>`; logged-out user still reaches `/forgot`.
- `tsc` clean, `eslint` clean, build clean, 9/9 auth-recovery e2e pass, 31 auth unit tests pass.

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)