### PR TITLE
feat(admin): revoke a member's sessions from /admin/members (#266)

### DIFF
--- a/app/admin/members/page.tsx
+++ b/app/admin/members/page.tsx
@@ -20,6 +20,7 @@ function PersonRow({
   onToggle,
   onSave,
   onCloak,
+  onRevokeSessions,
   isSaving,
 }: {
   person: Person;
@@ -27,6 +28,7 @@ function PersonRow({
   onToggle: () => void;
   onSave: (p: Person) => void;
   onCloak?: (personId: number) => void;
+  onRevokeSessions?: (person: Person) => void;
   isSaving?: boolean;
 }) {
   const t = useT();
@@ -409,6 +411,33 @@ function PersonRow({
             </button>
           </div>
 
+          {/* Revoke sessions */}
+          {onRevokeSessions && (
+            <div style={{ marginBottom: 12 }}>
+              <button
+                type="button"
+                disabled={isSaving}
+                onClick={() => onRevokeSessions(person)}
+                style={{
+                  width: "100%",
+                  padding: "8px",
+                  background: "transparent",
+                  color: paper.accent,
+                  border: `1.5px solid ${paper.accent}`,
+                  cursor: isSaving ? "default" : "pointer",
+                  opacity: isSaving ? 0.6 : 1,
+                  fontFamily: fontMono,
+                  fontSize: 9,
+                  fontWeight: 700,
+                  letterSpacing: 1.5,
+                  textTransform: "uppercase",
+                }}
+              >
+                {t("admin.revoke_sessions")}
+              </button>
+            </div>
+          )}
+
           {/* Cancel / Save */}
           <div style={{ display: "flex", gap: 8 }}>
             <button
@@ -516,6 +545,30 @@ export default function AdminLedenPage() {
     window.location.href = "/";
   }
 
+  async function handleRevokeSessions(person: Person) {
+    if (!window.confirm(t("admin.revoke_sessions_confirm", { name: fullNameOf(person) }))) return;
+    // Revoking your own sessions must destroy the current cookie, not just bump
+    // the epoch: the Edge proxy can't see a stale epoch, so an undestroyed cookie
+    // keeps passing page navigation. /api/auth/logout-all bumps the epoch AND
+    // destroys the cookie, so the redirect to /login sticks.
+    if (person.id === me?.personId) {
+      try {
+        await apiFetch("/api/auth/logout-all", { method: "POST" });
+      } catch {
+        // Ignore — redirect to login regardless of the response.
+      }
+      qc.clear();
+      router.replace("/login");
+      return;
+    }
+    try {
+      await apiFetch(`/api/people/${person.id}/revoke-sessions`, { method: "POST" });
+      toast.success(t("toast.sessions_revoked"));
+    } catch {
+      toast.error(t("toast.error"));
+    }
+  }
+
   if (!me?.isAdmin) return null;
 
   const active = people.filter((p) => p.active);
@@ -531,6 +584,7 @@ export default function AdminLedenPage() {
           onToggle={() => toggle(person.id)}
           onSave={(p) => savePerson.mutate(p)}
           onCloak={handleCloak}
+          onRevokeSessions={handleRevokeSessions}
           isSaving={savingId === person.id}
         />
       ))}

--- a/app/api/people/[id]/revoke-sessions/route.test.ts
+++ b/app/api/people/[id]/revoke-sessions/route.test.ts
@@ -1,0 +1,61 @@
+// app/api/people/[id]/revoke-sessions/route.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/env", () => ({
+  env: { SESSION_PASSWORD: "test-password-32-chars-minimum!!", NODE_ENV: "test" },
+}));
+
+const mockBump = vi.fn();
+vi.mock("@/lib/queries/people", () => ({
+  bumpSessionEpoch: (...a: unknown[]) => mockBump(...a),
+}));
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+
+// Keep the real json() wrapper + HttpError; override only requireAdmin.
+const mockRequireAdmin = vi.fn();
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return { ...actual, requireAdmin: (...a: unknown[]) => mockRequireAdmin(...a) };
+});
+
+import { POST } from "./route";
+import { HttpError } from "@/lib/api";
+
+const CSRF = "test-csrf-token";
+function req(withCsrf = true) {
+  return new Request("http://localhost/api/people/7/revoke-sessions", {
+    method: "POST",
+    headers: withCsrf ? { Cookie: `csrf-token=${CSRF}`, "x-csrf-token": CSRF } : {},
+  });
+}
+const ctx = { params: Promise.resolve({ id: "7" }) };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireAdmin.mockResolvedValue({ isAdmin: true, personId: 1 });
+});
+
+describe("POST /api/people/[id]/revoke-sessions", () => {
+  it("bumps the target member's session epoch", async () => {
+    const res = await POST(req() as never, ctx as never);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true });
+    expect(mockBump).toHaveBeenCalledWith({}, 7);
+  });
+
+  it("rejects a non-admin caller with 403", async () => {
+    mockRequireAdmin.mockImplementation(() => {
+      throw new HttpError(403, "Forbidden");
+    });
+    const res = await POST(req() as never, ctx as never);
+    expect(res.status).toBe(403);
+    expect(mockBump).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the CSRF token is missing", async () => {
+    const res = await POST(req(false) as never, ctx as never);
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ error: "invalid_csrf" });
+    expect(mockBump).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/people/[id]/revoke-sessions/route.ts
+++ b/app/api/people/[id]/revoke-sessions/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import { bumpSessionEpoch } from "@/lib/queries/people";
+import { json, readId, requireAdmin } from "@/lib/api";
+
+/**
+ * Admin "revoke sessions": bumps the target member's session epoch, invalidating
+ * every cookie they hold so they must re-authenticate. Does not deactivate the
+ * account or change the password. The acting admin's own session is untouched
+ * unless they target themselves.
+ */
+export const POST = json(async (req, ctx) => {
+  await requireAdmin(req);
+  const id = await readId(ctx);
+  bumpSessionEpoch(getDb(), id);
+  return NextResponse.json({ ok: true });
+});

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -194,6 +194,7 @@ export const en: Messages = {
 
   // Toasts
   "toast.saved": "Saved",
+  "toast.sessions_revoked": "Sessions revoked",
   "toast.deleted": "Deleted",
   "toast.person_added": "Member added",
   "toast.car_added": "Car added",
@@ -411,6 +412,9 @@ export const en: Messages = {
   "admin.inactive_section": "Others",
   "admin.activate": "Activate",
   "admin.deactivate": "Deactivate",
+  "admin.revoke_sessions": "Revoke sessions",
+  "admin.revoke_sessions_confirm":
+    "Sign {name} out of every device? They will need to log in again.",
   "admin.zero_km_title": "Zero-km trips",
   "admin.no_zero_km": "None found",
   "admin.car_active": "Active",

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -195,6 +195,7 @@ export const en: Messages = {
   // Toasts
   "toast.saved": "Saved",
   "toast.sessions_revoked": "Sessions revoked",
+  "toast.error": "Something went wrong",
   "toast.deleted": "Deleted",
   "toast.person_added": "Member added",
   "toast.car_added": "Car added",

--- a/lib/i18n/messages/nl.ts
+++ b/lib/i18n/messages/nl.ts
@@ -193,6 +193,7 @@ export const nl = {
 
   // Toasts
   "toast.saved": "Opgeslagen",
+  "toast.sessions_revoked": "Sessies ingetrokken",
   "toast.deleted": "Verwijderd",
   "toast.person_added": "Persoon toegevoegd",
   "toast.car_added": "Wagen toegevoegd",
@@ -411,6 +412,8 @@ export const nl = {
   "admin.inactive_section": "Anderen",
   "admin.activate": "Activeren",
   "admin.deactivate": "Deactiveren",
+  "admin.revoke_sessions": "Sessies intrekken",
+  "admin.revoke_sessions_confirm": "{name} op elk apparaat uitloggen? Ze moeten opnieuw inloggen.",
   "admin.zero_km_title": "Ritten met 0 km",
   "admin.no_zero_km": "Geen gevonden",
   "admin.car_active": "Actief",

--- a/lib/i18n/messages/nl.ts
+++ b/lib/i18n/messages/nl.ts
@@ -194,6 +194,7 @@ export const nl = {
   // Toasts
   "toast.saved": "Opgeslagen",
   "toast.sessions_revoked": "Sessies ingetrokken",
+  "toast.error": "Er ging iets mis",
   "toast.deleted": "Verwijderd",
   "toast.person_added": "Persoon toegevoegd",
   "toast.car_added": "Wagen toegevoegd",


### PR DESCRIPTION
## What

Adds an admin action to force-logout any member, complementing the self-service "log out everywhere" from #266.

- **New endpoint** `POST /api/people/[id]/revoke-sessions` — `requireAdmin` guard + `bumpSessionEpoch(db, id)`, wrapped in `json()` (auto-CSRF). Unit-tested: admin happy path, non-admin 403, missing-CSRF 403.
- **UI** — "Revoke sessions" button on **active** member cards in `/admin/members` (hidden on inactive). Confirm dialog naming the member.
- **Self-revoke** — if an admin revokes their own row, the client routes through `/api/auth/logout-all` (destroys the current cookie) then clears cache + redirects to `/login`, so the logout actually sticks. Revoking another member bumps their epoch; the server cuts their data access on the next request.
- i18n keys (en + nl).

## Verification

- Full unit suite green (498 tests).
- Proven end-to-end against a dev server: a revoked member's cookie gets `403 {"error":"Session revoked"}` on the next data request.
- Self-revoke verified in-browser (lands on `/login`).

## Known limitation (out of scope, tracked separately)

A revoked *other* member keeps a warm client cache and isn't bounced to `/login` until their next `/api/me` (the Edge `proxy.ts` can't read the DB epoch). Pre-existing, app-wide. Tracked in #284.

🤖 Generated with [Claude Code](https://claude.com/claude-code)