### PR TITLE
fix(admin): prevent password managers autofilling Google settings fields

### DIFF
--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -194,9 +194,16 @@ export default function AdminSettingsPage() {
                 <div style={labelStyle}>{t("settings.calendar_id_label")}</div>
                 <input
                   type="text"
+                  name="google-calendar-id"
+                  id="google-calendar-id"
                   value={calendarId}
                   onChange={(e) => setCalendarId(e.target.value)}
                   placeholder="abc123@group.calendar.google.com"
+                  autoComplete="off"
+                  data-1p-ignore
+                  data-lpignore="true"
+                  data-bwignore
+                  data-form-type="other"
                   style={{
                     ...inputStyle,
                     border: `1.5px solid ${calendarDirty ? paper.ink : paper.paperDark}`,
@@ -208,6 +215,8 @@ export default function AdminSettingsPage() {
                 <div style={{ position: "relative" }}>
                   <input
                     type={showToken ? "text" : "password"}
+                    name="google-oauth-refresh-token"
+                    id="google-oauth-refresh-token"
                     value={refreshToken}
                     onChange={(e) => setRefreshToken(e.target.value)}
                     placeholder={
@@ -215,6 +224,11 @@ export default function AdminSettingsPage() {
                         ? t("settings.token_stored")
                         : t("settings.token_empty")
                     }
+                    autoComplete="off"
+                    data-1p-ignore
+                    data-lpignore="true"
+                    data-bwignore
+                    data-form-type="other"
                     style={{
                       ...inputStyle,
                       paddingRight: 32,


### PR DESCRIPTION
## Problem

On `/admin/settings`, Bitwarden (and other password managers / browser autofill) auto-filled the **Google Calendar ID** field with a saved username and the **OAuth refresh token** field with a saved password, overwriting the real values.

## Cause

The two inputs look like a standard login form to autofill heuristics: a `type="text"` input (Calendar ID) directly followed by a `type="password"` input (refresh token, when masked).

## Fix

Opt both inputs out of credential autofill in `app/admin/settings/page.tsx`:

- descriptive `name`/`id` (`google-calendar-id`, `google-oauth-refresh-token`)
- `autoComplete="off"`
- `data-1p-ignore`, `data-lpignore="true"`, `data-bwignore`, `data-form-type="other"`

Token field keeps `type="password"` for masking.

## Verification

- `eslint` clean (only a pre-existing unrelated warning)
- Manually verified on `/admin/settings`: Bitwarden no longer fills/prompts the fields; show/hide toggle and save still work.

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)