### PR TITLE
chore(api): expose app version in /api/health

### DIFF
--- a/app/api/health/route.test.ts
+++ b/app/api/health/route.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect } from "vitest";
+import { version } from "@/package.json";
 import { GET, HEAD } from "./route";
 
 describe("GET /api/health", () => {
-  it("returns 200 with { ok: true }", async () => {
+  it("returns 200 with { ok: true, version }", async () => {
     const res = GET();
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ ok: true });
+    expect(await res.json()).toEqual({ ok: true, version });
   });
 
   it("does not set any auth cookie", async () => {

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,9 +1,11 @@
 import { NextResponse } from "next/server";
 
+import { version } from "@/package.json";
+
 export const dynamic = "force-dynamic";
 
 export function GET() {
-  return NextResponse.json({ ok: true });
+  return NextResponse.json({ ok: true, version });
 }
 
 export function HEAD() {


### PR DESCRIPTION
## Why

Verifying the live prod version previously required SSH + `docker ps` to read the image tag (done manually after the v1.16.1 deploy). This makes deploy verification a single HTTP request.

## What

`GET /api/health` now returns `{ ok: true, version }`, sourced from `package.json` (release-please bumps it each release, so it stays accurate with no build-arg wiring). `HEAD` unchanged.

## Verification

- `eslint` clean
- Local: `GET /api/health` → `{"ok":true,"version":"1.16.1"}`, `HEAD` → 200

## Security note

`/api/health` is unauthenticated, so the version becomes public — minor info disclosure (CVE matching). Accepted as low-risk; standard for health endpoints.

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)