### PR TITLE
feat(forms): show edit forms read-only when user lacks edit permission

### DIFF
--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -13,6 +13,8 @@ import {
   useDeleteReservation,
 } from "@/hooks/use-reservations";
 import { useCars } from "@/hooks/use-vehicles";
+import { useMe } from "@/hooks/use-me";
+import { canEdit } from "@/lib/permissions";
 import type { Reservation, Car } from "@/types";
 import { paper, fontMono, fontSerif } from "@/lib/paper-theme";
 import { useT } from "@/components/locale-provider";
@@ -114,6 +116,7 @@ function CalendarContent() {
 
   const { data: reservations = [], isLoading } = useReservations();
   const { data: cars = [] } = useCars();
+  const { data: me } = useMe();
   const { data: calendarMeta } = useQuery<{ calendarId: string | null }>({
     queryKey: ["calendar-id"],
     queryFn: () => apiFetch("/api/calendar-id"),
@@ -136,6 +139,18 @@ function CalendarContent() {
     !isLoading && editIdParam
       ? (reservations.find((r) => r.id === Number(editIdParam)) ?? null)
       : null;
+
+  const editingReadOnly =
+    editing != null &&
+    !(
+      me?.personId != null &&
+      canEdit(
+        me.personId,
+        me.isAdmin,
+        editing,
+        cars.find((c) => c.id === editing.car_id)?.owner_person_id ?? null
+      )
+    );
 
   const [sheetClosed, setSheetClosed] = useState(false);
   useEffect(() => {
@@ -338,6 +353,7 @@ function CalendarContent() {
           <>
             <ReservationForm
               defaultValues={editing}
+              readOnly={editingReadOnly}
               onSubmit={(data) =>
                 updateR.mutate(
                   { id: editing.id, ...data },
@@ -352,34 +368,36 @@ function CalendarContent() {
               }
               onCancel={() => closeSheet()}
             />
-            <div style={{ padding: "0 16px 24px" }}>
-              <button
-                onClick={() =>
-                  deleteR.mutate(editing.id, {
-                    onSuccess: () => {
-                      closeSheet();
-                      toast.success(t("toast.deleted"));
-                    },
-                    onError: (e) => toast.error(e.message),
-                  })
-                }
-                style={{
-                  width: "100%",
-                  padding: "10px",
-                  background: "transparent",
-                  border: `1.5px solid ${paper.accent}`,
-                  color: paper.accent,
-                  fontFamily: fontMono,
-                  fontSize: 10,
-                  fontWeight: 700,
-                  letterSpacing: 2,
-                  textTransform: "uppercase",
-                  cursor: "pointer",
-                }}
-              >
-                {t("action.delete")}
-              </button>
-            </div>
+            {!editingReadOnly && (
+              <div style={{ padding: "0 16px 24px" }}>
+                <button
+                  onClick={() =>
+                    deleteR.mutate(editing.id, {
+                      onSuccess: () => {
+                        closeSheet();
+                        toast.success(t("toast.deleted"));
+                      },
+                      onError: (e) => toast.error(e.message),
+                    })
+                  }
+                  style={{
+                    width: "100%",
+                    padding: "10px",
+                    background: "transparent",
+                    border: `1.5px solid ${paper.accent}`,
+                    color: paper.accent,
+                    fontFamily: fontMono,
+                    fontSize: 10,
+                    fontWeight: 700,
+                    letterSpacing: 2,
+                    textTransform: "uppercase",
+                    cursor: "pointer",
+                  }}
+                >
+                  {t("action.delete")}
+                </button>
+              </div>
+            )}
           </>
         )}
       </BottomSheet>

--- a/app/calendar/reservation-form.tsx
+++ b/app/calendar/reservation-form.tsx
@@ -42,7 +42,16 @@ interface Props {
   defaultValues?: Partial<Reservation>;
   onSubmit: (data: ReservationInput) => void;
   onCancel: () => void;
+  /** When true the form is shown read-only: inputs disabled, save hidden. */
+  readOnly?: boolean;
 }
+
+const fieldsetReset: React.CSSProperties = {
+  border: 0,
+  margin: 0,
+  padding: 0,
+  minInlineSize: "auto",
+};
 
 function diffDays(start: string, end: string): number {
   return Math.round((new Date(end).getTime() - new Date(start).getTime()) / 86400000) + 1;
@@ -67,7 +76,7 @@ const monoLabel: React.CSSProperties = {
   marginBottom: 4,
 };
 
-export function ReservationForm({ defaultValues, onSubmit, onCancel }: Props) {
+export function ReservationForm({ defaultValues, onSubmit, onCancel, readOnly = false }: Props) {
   const t = useT();
   const { locale } = useLocale();
   const { theme } = useTheme();
@@ -145,6 +154,10 @@ export function ReservationForm({ defaultValues, onSubmit, onCancel }: Props) {
   return (
     <form
       onSubmit={(e) => {
+        if (readOnly) {
+          e.preventDefault();
+          return;
+        }
         if (!online) {
           e.preventDefault();
           toast.error(t("offline.mutation_blocked"));
@@ -210,501 +223,543 @@ export function ReservationForm({ defaultValues, onSubmit, onCancel }: Props) {
         >
           {mono ? t("form.reservation") : `▦ ${t("form.reservation").toUpperCase()}`}
         </div>
-        <div style={{ position: "relative" }} className="submit-wrap">
-          <button
-            type="submit"
-            disabled={!canSubmit}
+        {readOnly ? (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+              fontFamily: fontMono,
+              fontSize: 9,
+              fontWeight: 700,
+              letterSpacing: 2,
+              textTransform: "uppercase",
+              color: paper.inkMute,
+            }}
+          >
+            <Lock size={13} color={paper.inkMute} strokeWidth={1.75} />
+            {t("form.read_only")}
+          </div>
+        ) : (
+          <div style={{ position: "relative" }} className="submit-wrap">
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              style={
+                mono
+                  ? {
+                      fontFamily: "var(--font-inter, 'Inter', system-ui, sans-serif)",
+                      fontSize: 14,
+                      fontWeight: 600,
+                      background: paper.accent,
+                      color: "#fff",
+                      border: "none",
+                      padding: "8px 18px",
+                      borderRadius: "var(--radius-pill, 999px)",
+                      cursor: canSubmit && online ? "pointer" : "default",
+                      opacity: canSubmit && online ? 1 : 0.5,
+                      transition: "opacity 0.15s",
+                    }
+                  : {
+                      fontFamily: fontMono,
+                      fontSize: 9,
+                      fontWeight: 700,
+                      letterSpacing: 2,
+                      textTransform: "uppercase" as const,
+                      background: isAdmin ? paper.blue : paper.accent,
+                      color: "#fff",
+                      border: "none",
+                      padding: "8px 14px",
+                      cursor: canSubmit && online ? "pointer" : "default",
+                      opacity: canSubmit && online ? 1 : 0.35,
+                    }
+              }
+            >
+              {mono
+                ? t("action.save")
+                : isAdmin
+                  ? t("action.confirm_reservation").toUpperCase()
+                  : t("action.request_reservation").toUpperCase()}
+            </button>
+            {!canSubmit && (
+              <div
+                className="submit-tip"
+                style={{
+                  position: "absolute",
+                  right: 0,
+                  top: "calc(100% + 6px)",
+                  background: paper.ink,
+                  color: paper.paper,
+                  fontFamily: fontMono,
+                  fontSize: 9,
+                  letterSpacing: 1,
+                  padding: "5px 8px",
+                  whiteSpace: "pre-line",
+                  pointerEvents: "none",
+                  opacity: 0,
+                  transition: "opacity 0.15s",
+                  zIndex: 20,
+                }}
+              >
+                {missingLabel}
+              </div>
+            )}
+          </div>
+        )}
+        <style>{`.submit-wrap:hover .submit-tip, .submit-wrap:focus-within .submit-tip { opacity: 1 !important; }`}</style>
+      </div>
+
+      <fieldset disabled={readOnly} style={fieldsetReset}>
+        {readOnly && (
+          <div
+            style={{
+              padding: "8px 14px",
+              fontFamily: fontMono,
+              fontSize: 9,
+              fontWeight: 700,
+              letterSpacing: 1,
+              color: paper.amber,
+              borderBottom: mono
+                ? `1px solid ${paper.paperDark}`
+                : `1.5px dashed ${paper.paperDark}`,
+            }}
+          >
+            🔒 {t("form.read_only_hint")}
+          </div>
+        )}
+
+        {/* Car tabs */}
+        <Controller
+          name="car_id"
+          control={control}
+          render={({ field }) => (
+            <CarToggle cars={cars} value={field.value} onChange={field.onChange} />
+          )}
+        />
+
+        {/* Driver row */}
+        <div
+          style={{
+            padding: "10px 14px",
+            borderBottom: mono ? `1px solid ${paper.paperDark}` : `1.5px dashed ${paper.paperDark}`,
+            background: paper.paper,
+          }}
+        >
+          {mono ? (
+            isAdmin ? (
+              <>
+                <span style={lbl}>{t("form.driver")}</span>
+                <select
+                  value={personId ?? ""}
+                  onChange={(e) => setValue("person_id", Number(e.target.value))}
+                  style={{
+                    fontFamily: fontSerif,
+                    fontSize: 17,
+                    fontWeight: 600,
+                    color: paper.ink,
+                    background: "transparent",
+                    border: "none",
+                    outline: "none",
+                    width: "100%",
+                    padding: 0,
+                    cursor: "pointer",
+                  }}
+                >
+                  <option value="" disabled>
+                    {t("form.select_person_placeholder")}
+                  </option>
+                  {people
+                    .filter((p) => p.active)
+                    .map((p) => (
+                      <option key={p.id} value={p.id}>
+                        {fullNameOf(p)}
+                      </option>
+                    ))}
+                </select>
+              </>
+            ) : (
+              <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                <span
+                  style={{
+                    fontFamily:
+                      "var(--font-inter-tight, 'Inter Tight', 'Inter', system-ui, sans-serif)",
+                    fontSize: 19,
+                    fontWeight: 700,
+                    color: paper.ink,
+                  }}
+                >
+                  {person ? fullNameOf(person) : (me?.shortName ?? "—")}
+                </span>
+                <Lock size={14} color={paper.inkMute} strokeWidth={1.75} />
+              </div>
+            )
+          ) : (
+            <>
+              <span style={lbl}>{t("form.driver")}</span>
+              {isAdmin ? (
+                <select
+                  value={personId ?? ""}
+                  onChange={(e) => setValue("person_id", Number(e.target.value))}
+                  style={{
+                    fontFamily: fontSerif,
+                    fontSize: 17,
+                    fontWeight: 600,
+                    color: paper.ink,
+                    background: "transparent",
+                    border: "none",
+                    outline: "none",
+                    width: "100%",
+                    padding: 0,
+                    cursor: "pointer",
+                  }}
+                >
+                  <option value="" disabled>
+                    {t("form.select_person_placeholder")}
+                  </option>
+                  {people
+                    .filter((p) => p.active)
+                    .map((p) => (
+                      <option key={p.id} value={p.id}>
+                        {fullNameOf(p)}
+                      </option>
+                    ))}
+                </select>
+              ) : (
+                <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                  <span
+                    style={{
+                      fontFamily: fontSerif,
+                      fontSize: 17,
+                      fontWeight: 600,
+                      color: paper.ink,
+                    }}
+                  >
+                    {person ? fullNameOf(person) : (me?.shortName ?? "—")}
+                  </span>
+                  <span style={{ fontSize: 13 }}>🔒</span>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+        {!isAdmin && !mono && (
+          <div
+            style={{
+              padding: "6px 14px",
+              fontFamily: fontMono,
+              fontSize: 9,
+              color: paper.amber,
+              letterSpacing: 1,
+            }}
+          >
+            🔒 {t("form.driver_locked_hint")}
+          </div>
+        )}
+
+        {/* Hidden RHF fields */}
+        <input type="hidden" {...register("start_date")} />
+        <input type="hidden" {...register("end_date")} />
+
+        {/* Calendar date picker */}
+        <div
+          style={
+            mono
+              ? {
+                  margin: "12px 14px",
+                  background: paper.paper,
+                  border: `1px solid ${paper.paperDark}`,
+                  borderRadius: "var(--radius-md, 10px)",
+                  overflow: "hidden",
+                }
+              : {
+                  margin: "12px 14px",
+                  background: paper.paper,
+                  border: `1.5px solid ${paper.paperDark}`,
+                }
+          }
+        >
+          {/* Header: date range + day count */}
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              padding: "8px 14px",
+              borderBottom: mono ? `1px solid ${paper.paperDark}` : `1px dashed ${paper.paperDark}`,
+            }}
+          >
+            <div>
+              {!mono && (
+                <div
+                  style={{
+                    fontFamily: fontMono,
+                    fontSize: 10,
+                    fontWeight: 700,
+                    letterSpacing: 2,
+                    color: paper.blue,
+                  }}
+                >
+                  ● {t("page.reservation_request")}
+                </div>
+              )}
+              {startDate && endDate && startDate !== endDate ? (
+                <div
+                  style={
+                    mono
+                      ? {
+                          fontFamily:
+                            "var(--font-inter-tight, 'Inter Tight', 'Inter', system-ui, sans-serif)",
+                          fontSize: 15,
+                          fontWeight: 700,
+                          color: paper.ink,
+                        }
+                      : {
+                          fontFamily: fontSerif,
+                          fontSize: 13,
+                          fontWeight: 600,
+                          color: paper.inkDim,
+                          marginTop: 2,
+                        }
+                  }
+                >
+                  {fmtDate(startDate, locale as "nl" | "en")}
+                  {mono ? " – " : " → "}
+                  {fmtDate(endDate, locale as "nl" | "en")}
+                </div>
+              ) : startDate ? (
+                <div
+                  style={
+                    mono
+                      ? {
+                          fontFamily:
+                            "var(--font-inter-tight, 'Inter Tight', 'Inter', system-ui, sans-serif)",
+                          fontSize: 15,
+                          fontWeight: 700,
+                          color: paper.ink,
+                        }
+                      : {
+                          fontFamily: fontSerif,
+                          fontSize: 13,
+                          fontWeight: 600,
+                          color: paper.inkDim,
+                          marginTop: 2,
+                        }
+                  }
+                >
+                  {fmtDate(startDate, locale as "nl" | "en")}
+                </div>
+              ) : (
+                mono && (
+                  <div
+                    style={{
+                      fontFamily: fontMono,
+                      fontSize: 12,
+                      color: paper.inkMute,
+                    }}
+                  >
+                    {t("field.dates")}
+                  </div>
+                )
+              )}
+            </div>
+            <div style={{ textAlign: "center" }}>
+              <div
+                style={{
+                  fontFamily: fontSerif,
+                  fontSize: 24,
+                  fontWeight: 700,
+                  color: datesSelected ? paper.ink : paper.inkMute,
+                  lineHeight: 1,
+                }}
+              >
+                {dayCount}
+              </div>
+              <div
+                style={
+                  mono
+                    ? {
+                        fontFamily: fontMono,
+                        fontSize: 9,
+                        color: paper.inkMute,
+                      }
+                    : {
+                        fontFamily: fontMono,
+                        fontSize: 7,
+                        color: paper.inkMute,
+                        letterSpacing: 1.5,
+                        textTransform: "uppercase" as const,
+                      }
+                }
+              >
+                {t("form.days")}
+              </div>
+            </div>
+          </div>
+
+          {/* Calendar grid */}
+          <div style={{ padding: "10px 14px 12px" }}>
+            <PickCalendar
+              initialOffset={calendarInitOffset}
+              reservations={reservations}
+              carId={carId}
+              excludeId={defaultValues?.id}
+              from={startDate ?? null}
+              to={endDate ?? null}
+              onRangePick={(from, to) => {
+                if (readOnly) return;
+                setValue("start_date", from, { shouldValidate: true });
+                setValue("end_date", to, { shouldValidate: true });
+              }}
+            />
+          </div>
+        </div>
+
+        {/* Conflict warning */}
+        {conflicts.length > 0 && (
+          <div
             style={
               mono
                 ? {
-                    fontFamily: "var(--font-inter, 'Inter', system-ui, sans-serif)",
-                    fontSize: 14,
-                    fontWeight: 600,
-                    background: paper.accent,
-                    color: "#fff",
-                    border: "none",
-                    padding: "8px 18px",
-                    borderRadius: "var(--radius-pill, 999px)",
-                    cursor: canSubmit && online ? "pointer" : "default",
-                    opacity: canSubmit && online ? 1 : 0.5,
-                    transition: "opacity 0.15s",
+                    margin: "0 14px 12px",
+                    border: `1px solid ${paper.amber}`,
+                    borderRadius: "var(--radius-md, 10px)",
+                    padding: "10px 14px",
+                    background: "rgba(180, 83, 9, 0.05)",
                   }
+                : {
+                    margin: "0 14px 12px",
+                    background: "transparent",
+                    border: `1.5px solid ${paper.accent}`,
+                    padding: "10px 14px",
+                  }
+            }
+          >
+            <div
+              style={
+                mono
+                  ? {
+                      fontFamily:
+                        "var(--font-inter-tight, 'Inter Tight', 'Inter', system-ui, sans-serif)",
+                      fontSize: 13,
+                      fontWeight: 600,
+                      color: paper.amber,
+                      marginBottom: 6,
+                    }
+                  : {
+                      fontFamily: fontMono,
+                      fontSize: 9,
+                      fontWeight: 700,
+                      color: paper.accent,
+                      letterSpacing: 1.5,
+                      textTransform: "uppercase" as const,
+                      marginBottom: 6,
+                    }
+              }
+            >
+              {mono ? "⚠ " : "▲ "}
+              {t("form.conflict_warning")}
+            </div>
+            {conflicts.map((r) => (
+              <div key={r.id} style={{ marginBottom: 4 }}>
+                <div
+                  style={
+                    mono
+                      ? {
+                          fontFamily: "var(--font-inter, 'Inter', system-ui, sans-serif)",
+                          fontSize: 13,
+                          fontWeight: 600,
+                          color: paper.ink,
+                        }
+                      : {
+                          fontFamily: fontSerif,
+                          fontSize: 13,
+                          fontWeight: 600,
+                          color: paper.ink,
+                        }
+                  }
+                >
+                  {r.person_name} — {r.car_short}
+                </div>
+                <div
+                  style={{
+                    fontFamily: fontMono,
+                    fontSize: 9,
+                    color: paper.inkDim,
+                    letterSpacing: mono ? 0 : 1,
+                  }}
+                >
+                  {r.start_date} · {r.status}
+                </div>
+              </div>
+            ))}
+            <div
+              style={{
+                fontFamily: mono ? "var(--font-inter, 'Inter', system-ui, sans-serif)" : fontMono,
+                fontSize: mono ? 11 : 9,
+                color: paper.inkMute,
+                letterSpacing: mono ? 0 : 1,
+                marginTop: 6,
+                fontStyle: "italic",
+              }}
+            >
+              {t("form.conflict_note")}
+            </div>
+          </div>
+        )}
+
+        {/* Note */}
+        <div style={{ padding: "4px 14px 16px" }}>
+          <span
+            style={
+              mono
+                ? { ...monoLabel }
                 : {
                     fontFamily: fontMono,
                     fontSize: 9,
                     fontWeight: 700,
                     letterSpacing: 2,
                     textTransform: "uppercase" as const,
-                    background: isAdmin ? paper.blue : paper.accent,
-                    color: "#fff",
-                    border: "none",
-                    padding: "8px 14px",
-                    cursor: canSubmit && online ? "pointer" : "default",
-                    opacity: canSubmit && online ? 1 : 0.35,
+                    color: paper.inkMute,
+                    display: "block",
+                    marginBottom: 4,
                   }
             }
           >
-            {mono
-              ? t("action.save")
-              : isAdmin
-                ? t("action.confirm_reservation").toUpperCase()
-                : t("action.request_reservation").toUpperCase()}
-          </button>
-          {!canSubmit && (
-            <div
-              className="submit-tip"
-              style={{
-                position: "absolute",
-                right: 0,
-                top: "calc(100% + 6px)",
-                background: paper.ink,
-                color: paper.paper,
-                fontFamily: fontMono,
-                fontSize: 9,
-                letterSpacing: 1,
-                padding: "5px 8px",
-                whiteSpace: "pre-line",
-                pointerEvents: "none",
-                opacity: 0,
-                transition: "opacity 0.15s",
-                zIndex: 20,
-              }}
-            >
-              {missingLabel}
-            </div>
-          )}
-        </div>
-        <style>{`.submit-wrap:hover .submit-tip, .submit-wrap:focus-within .submit-tip { opacity: 1 !important; }`}</style>
-      </div>
-
-      {/* Car tabs */}
-      <Controller
-        name="car_id"
-        control={control}
-        render={({ field }) => (
-          <CarToggle cars={cars} value={field.value} onChange={field.onChange} />
-        )}
-      />
-
-      {/* Driver row */}
-      <div
-        style={{
-          padding: "10px 14px",
-          borderBottom: mono ? `1px solid ${paper.paperDark}` : `1.5px dashed ${paper.paperDark}`,
-          background: paper.paper,
-        }}
-      >
-        {mono ? (
-          isAdmin ? (
-            <>
-              <span style={lbl}>{t("form.driver")}</span>
-              <select
-                value={personId ?? ""}
-                onChange={(e) => setValue("person_id", Number(e.target.value))}
-                style={{
-                  fontFamily: fontSerif,
-                  fontSize: 17,
-                  fontWeight: 600,
-                  color: paper.ink,
-                  background: "transparent",
-                  border: "none",
-                  outline: "none",
-                  width: "100%",
-                  padding: 0,
-                  cursor: "pointer",
-                }}
-              >
-                <option value="" disabled>
-                  {t("form.select_person_placeholder")}
-                </option>
-                {people
-                  .filter((p) => p.active)
-                  .map((p) => (
-                    <option key={p.id} value={p.id}>
-                      {fullNameOf(p)}
-                    </option>
-                  ))}
-              </select>
-            </>
-          ) : (
-            <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-              <span
-                style={{
-                  fontFamily:
-                    "var(--font-inter-tight, 'Inter Tight', 'Inter', system-ui, sans-serif)",
-                  fontSize: 19,
-                  fontWeight: 700,
-                  color: paper.ink,
-                }}
-              >
-                {person ? fullNameOf(person) : (me?.shortName ?? "—")}
-              </span>
-              <Lock size={14} color={paper.inkMute} strokeWidth={1.75} />
-            </div>
-          )
-        ) : (
-          <>
-            <span style={lbl}>{t("form.driver")}</span>
-            {isAdmin ? (
-              <select
-                value={personId ?? ""}
-                onChange={(e) => setValue("person_id", Number(e.target.value))}
-                style={{
-                  fontFamily: fontSerif,
-                  fontSize: 17,
-                  fontWeight: 600,
-                  color: paper.ink,
-                  background: "transparent",
-                  border: "none",
-                  outline: "none",
-                  width: "100%",
-                  padding: 0,
-                  cursor: "pointer",
-                }}
-              >
-                <option value="" disabled>
-                  {t("form.select_person_placeholder")}
-                </option>
-                {people
-                  .filter((p) => p.active)
-                  .map((p) => (
-                    <option key={p.id} value={p.id}>
-                      {fullNameOf(p)}
-                    </option>
-                  ))}
-              </select>
-            ) : (
-              <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-                <span
-                  style={{ fontFamily: fontSerif, fontSize: 17, fontWeight: 600, color: paper.ink }}
-                >
-                  {person ? fullNameOf(person) : (me?.shortName ?? "—")}
-                </span>
-                <span style={{ fontSize: 13 }}>🔒</span>
-              </div>
-            )}
-          </>
-        )}
-      </div>
-      {!isAdmin && !mono && (
-        <div
-          style={{
-            padding: "6px 14px",
-            fontFamily: fontMono,
-            fontSize: 9,
-            color: paper.amber,
-            letterSpacing: 1,
-          }}
-        >
-          🔒 {t("form.driver_locked_hint")}
-        </div>
-      )}
-
-      {/* Hidden RHF fields */}
-      <input type="hidden" {...register("start_date")} />
-      <input type="hidden" {...register("end_date")} />
-
-      {/* Calendar date picker */}
-      <div
-        style={
-          mono
-            ? {
-                margin: "12px 14px",
-                background: paper.paper,
-                border: `1px solid ${paper.paperDark}`,
-                borderRadius: "var(--radius-md, 10px)",
-                overflow: "hidden",
-              }
-            : {
-                margin: "12px 14px",
-                background: paper.paper,
-                border: `1.5px solid ${paper.paperDark}`,
-              }
-        }
-      >
-        {/* Header: date range + day count */}
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-            padding: "8px 14px",
-            borderBottom: mono ? `1px solid ${paper.paperDark}` : `1px dashed ${paper.paperDark}`,
-          }}
-        >
-          <div>
-            {!mono && (
-              <div
-                style={{
-                  fontFamily: fontMono,
-                  fontSize: 10,
-                  fontWeight: 700,
-                  letterSpacing: 2,
-                  color: paper.blue,
-                }}
-              >
-                ● {t("page.reservation_request")}
-              </div>
-            )}
-            {startDate && endDate && startDate !== endDate ? (
-              <div
-                style={
-                  mono
-                    ? {
-                        fontFamily:
-                          "var(--font-inter-tight, 'Inter Tight', 'Inter', system-ui, sans-serif)",
-                        fontSize: 15,
-                        fontWeight: 700,
-                        color: paper.ink,
-                      }
-                    : {
-                        fontFamily: fontSerif,
-                        fontSize: 13,
-                        fontWeight: 600,
-                        color: paper.inkDim,
-                        marginTop: 2,
-                      }
-                }
-              >
-                {fmtDate(startDate, locale as "nl" | "en")}
-                {mono ? " – " : " → "}
-                {fmtDate(endDate, locale as "nl" | "en")}
-              </div>
-            ) : startDate ? (
-              <div
-                style={
-                  mono
-                    ? {
-                        fontFamily:
-                          "var(--font-inter-tight, 'Inter Tight', 'Inter', system-ui, sans-serif)",
-                        fontSize: 15,
-                        fontWeight: 700,
-                        color: paper.ink,
-                      }
-                    : {
-                        fontFamily: fontSerif,
-                        fontSize: 13,
-                        fontWeight: 600,
-                        color: paper.inkDim,
-                        marginTop: 2,
-                      }
-                }
-              >
-                {fmtDate(startDate, locale as "nl" | "en")}
-              </div>
-            ) : (
-              mono && (
-                <div
-                  style={{
-                    fontFamily: fontMono,
-                    fontSize: 12,
-                    color: paper.inkMute,
-                  }}
-                >
-                  {t("field.dates")}
-                </div>
-              )
-            )}
-          </div>
-          <div style={{ textAlign: "center" }}>
-            <div
-              style={{
-                fontFamily: fontSerif,
-                fontSize: 24,
-                fontWeight: 700,
-                color: datesSelected ? paper.ink : paper.inkMute,
-                lineHeight: 1,
-              }}
-            >
-              {dayCount}
-            </div>
-            <div
-              style={
-                mono
-                  ? {
-                      fontFamily: fontMono,
-                      fontSize: 9,
-                      color: paper.inkMute,
-                    }
-                  : {
-                      fontFamily: fontMono,
-                      fontSize: 7,
-                      color: paper.inkMute,
-                      letterSpacing: 1.5,
-                      textTransform: "uppercase" as const,
-                    }
-              }
-            >
-              {t("form.days")}
-            </div>
-          </div>
-        </div>
-
-        {/* Calendar grid */}
-        <div style={{ padding: "10px 14px 12px" }}>
-          <PickCalendar
-            initialOffset={calendarInitOffset}
-            reservations={reservations}
-            carId={carId}
-            excludeId={defaultValues?.id}
-            from={startDate ?? null}
-            to={endDate ?? null}
-            onRangePick={(from, to) => {
-              setValue("start_date", from, { shouldValidate: true });
-              setValue("end_date", to, { shouldValidate: true });
-            }}
-          />
-        </div>
-      </div>
-
-      {/* Conflict warning */}
-      {conflicts.length > 0 && (
-        <div
-          style={
-            mono
-              ? {
-                  margin: "0 14px 12px",
-                  border: `1px solid ${paper.amber}`,
-                  borderRadius: "var(--radius-md, 10px)",
-                  padding: "10px 14px",
-                  background: "rgba(180, 83, 9, 0.05)",
-                }
-              : {
-                  margin: "0 14px 12px",
-                  background: "transparent",
-                  border: `1.5px solid ${paper.accent}`,
-                  padding: "10px 14px",
-                }
-          }
-        >
+            {t("form.reservation_reason")}
+          </span>
           <div
             style={
               mono
                 ? {
-                    fontFamily:
-                      "var(--font-inter-tight, 'Inter Tight', 'Inter', system-ui, sans-serif)",
-                    fontSize: 13,
-                    fontWeight: 600,
-                    color: paper.amber,
-                    marginBottom: 6,
+                    border: `1px solid ${paper.paperDark}`,
+                    borderRadius: "var(--radius-md, 10px)",
+                    padding: "8px 14px",
                   }
                 : {
-                    fontFamily: fontMono,
-                    fontSize: 9,
-                    fontWeight: 700,
-                    color: paper.accent,
-                    letterSpacing: 1.5,
-                    textTransform: "uppercase" as const,
-                    marginBottom: 6,
+                    border: `1.5px dashed ${paper.paperDark}`,
+                    padding: "8px 14px",
                   }
             }
           >
-            {mono ? "⚠ " : "▲ "}
-            {t("form.conflict_warning")}
-          </div>
-          {conflicts.map((r) => (
-            <div key={r.id} style={{ marginBottom: 4 }}>
-              <div
-                style={
-                  mono
-                    ? {
-                        fontFamily:
-                          "var(--font-inter, 'Inter', system-ui, sans-serif)",
-                        fontSize: 13,
-                        fontWeight: 600,
-                        color: paper.ink,
-                      }
-                    : {
-                        fontFamily: fontSerif,
-                        fontSize: 13,
-                        fontWeight: 600,
-                        color: paper.ink,
-                      }
-                }
-              >
-                {r.person_name} — {r.car_short}
-              </div>
-              <div
-                style={{
-                  fontFamily: fontMono,
-                  fontSize: 9,
-                  color: paper.inkDim,
-                  letterSpacing: mono ? 0 : 1,
-                }}
-              >
-                {r.start_date} · {r.status}
-              </div>
-            </div>
-          ))}
-          <div
-            style={{
-              fontFamily: mono
-                ? "var(--font-inter, 'Inter', system-ui, sans-serif)"
-                : fontMono,
-              fontSize: mono ? 11 : 9,
-              color: paper.inkMute,
-              letterSpacing: mono ? 0 : 1,
-              marginTop: 6,
-              fontStyle: "italic",
-            }}
-          >
-            {t("form.conflict_note")}
+            <input
+              {...register("note")}
+              type="text"
+              placeholder={t("form.reservation_reason_placeholder")}
+              style={{
+                fontFamily: fontSerif,
+                fontSize: 15,
+                fontWeight: 600,
+                color: paper.ink,
+                background: "transparent",
+                border: "none",
+                outline: "none",
+                width: "100%",
+                padding: 0,
+              }}
+            />
           </div>
         </div>
-      )}
-
-      {/* Note */}
-      <div style={{ padding: "4px 14px 16px" }}>
-        <span
-          style={
-            mono
-              ? { ...monoLabel }
-              : {
-                  fontFamily: fontMono,
-                  fontSize: 9,
-                  fontWeight: 700,
-                  letterSpacing: 2,
-                  textTransform: "uppercase" as const,
-                  color: paper.inkMute,
-                  display: "block",
-                  marginBottom: 4,
-                }
-          }
-        >
-          {t("form.reservation_reason")}
-        </span>
-        <div
-          style={
-            mono
-              ? {
-                  border: `1px solid ${paper.paperDark}`,
-                  borderRadius: "var(--radius-md, 10px)",
-                  padding: "8px 14px",
-                }
-              : {
-                  border: `1.5px dashed ${paper.paperDark}`,
-                  padding: "8px 14px",
-                }
-          }
-        >
-          <input
-            {...register("note")}
-            type="text"
-            placeholder={t("form.reservation_reason_placeholder")}
-            style={{
-              fontFamily: fontSerif,
-              fontSize: 15,
-              fontWeight: 600,
-              color: paper.ink,
-              background: "transparent",
-              border: "none",
-              outline: "none",
-              width: "100%",
-              padding: 0,
-            }}
-          />
-        </div>
-      </div>
+      </fieldset>
 
       <div style={{ height: 32 }} />
     </form>

--- a/app/expenses/expense-form.tsx
+++ b/app/expenses/expense-form.tsx
@@ -55,7 +55,16 @@ interface Props {
   onSubmit: (data: ExpenseInput) => void;
   onCancel: () => void;
   onDelete?: () => void;
+  /** When true the form is shown read-only: inputs disabled, save hidden. */
+  readOnly?: boolean;
 }
+
+const fieldsetReset: React.CSSProperties = {
+  border: 0,
+  margin: 0,
+  padding: 0,
+  minInlineSize: "auto",
+};
 
 const paperLabel: React.CSSProperties = {
   fontFamily: fontMono,
@@ -80,7 +89,13 @@ const dashedBox: React.CSSProperties = {
   border: `1.5px dashed ${paper.paperDark}`,
 };
 
-export function ExpenseForm({ defaultValues, onSubmit, onCancel, onDelete }: Props) {
+export function ExpenseForm({
+  defaultValues,
+  onSubmit,
+  onCancel,
+  onDelete,
+  readOnly = false,
+}: Props) {
   const t = useT();
   const { locale } = useLocale();
   const { theme } = useTheme();
@@ -145,6 +160,10 @@ export function ExpenseForm({ defaultValues, onSubmit, onCancel, onDelete }: Pro
   return (
     <form
       onSubmit={(e) => {
+        if (readOnly) {
+          e.preventDefault();
+          return;
+        }
         if (!online) {
           e.preventDefault();
           toast.error(t("offline.mutation_blocked"));
@@ -192,7 +211,8 @@ export function ExpenseForm({ defaultValues, onSubmit, onCancel, onDelete }: Pro
           style={
             mono
               ? {
-                  fontFamily: "var(--font-inter-tight, 'Inter Tight', 'Inter', system-ui, sans-serif)",
+                  fontFamily:
+                    "var(--font-inter-tight, 'Inter Tight', 'Inter', system-ui, sans-serif)",
                   fontSize: 16,
                   fontWeight: 700,
                   color: paper.ink,
@@ -209,99 +229,186 @@ export function ExpenseForm({ defaultValues, onSubmit, onCancel, onDelete }: Pro
         >
           {mono ? t("form.extra_cost") : `📋 ${t("form.extra_cost")}`}
         </div>
-        <div style={{ position: "relative" }} className="submit-wrap">
-          <button
-            type="submit"
-            disabled={!canSubmit}
-            style={
-              mono
-                ? {
-                    fontFamily: "var(--font-inter, 'Inter', system-ui, sans-serif)",
-                    fontSize: 14,
-                    fontWeight: 600,
-                    background: paper.accent,
-                    color: "#fff",
-                    border: "none",
-                    padding: "8px 18px",
-                    borderRadius: "var(--radius-pill, 999px)",
-                    cursor: canSubmit && online ? "pointer" : "default",
-                    opacity: canSubmit && online ? 1 : 0.5,
-                    transition: "opacity 0.15s",
-                  }
-                : {
-                    fontFamily: fontMono,
-                    fontSize: 9,
-                    fontWeight: 700,
-                    letterSpacing: 2,
-                    textTransform: "uppercase" as const,
-                    background: paper.inkDim,
-                    color: "#fff",
-                    border: "none",
-                    padding: "8px 14px",
-                    cursor: canSubmit && online ? "pointer" : "default",
-                    opacity: canSubmit && online ? 1 : 0.35,
-                  }
-            }
+        {readOnly ? (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+              fontFamily: fontMono,
+              fontSize: 9,
+              fontWeight: 700,
+              letterSpacing: 2,
+              textTransform: "uppercase",
+              color: paper.inkMute,
+            }}
           >
-            {mono ? t("action.save") : t("action.save_cost")}
-          </button>
-          {!canSubmit && (
-            <div
-              className="submit-tip"
-              style={{
-                position: "absolute",
-                right: 0,
-                top: "calc(100% + 6px)",
-                background: paper.ink,
-                color: paper.paper,
-                fontFamily: fontMono,
-                fontSize: 9,
-                letterSpacing: 1,
-                padding: "5px 8px",
-                whiteSpace: "pre-line",
-                pointerEvents: "none",
-                opacity: 0,
-                transition: "opacity 0.15s",
-                zIndex: 20,
-              }}
+            <Lock size={13} color={paper.inkMute} strokeWidth={1.75} />
+            {t("form.read_only")}
+          </div>
+        ) : (
+          <div style={{ position: "relative" }} className="submit-wrap">
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              style={
+                mono
+                  ? {
+                      fontFamily: "var(--font-inter, 'Inter', system-ui, sans-serif)",
+                      fontSize: 14,
+                      fontWeight: 600,
+                      background: paper.accent,
+                      color: "#fff",
+                      border: "none",
+                      padding: "8px 18px",
+                      borderRadius: "var(--radius-pill, 999px)",
+                      cursor: canSubmit && online ? "pointer" : "default",
+                      opacity: canSubmit && online ? 1 : 0.5,
+                      transition: "opacity 0.15s",
+                    }
+                  : {
+                      fontFamily: fontMono,
+                      fontSize: 9,
+                      fontWeight: 700,
+                      letterSpacing: 2,
+                      textTransform: "uppercase" as const,
+                      background: paper.inkDim,
+                      color: "#fff",
+                      border: "none",
+                      padding: "8px 14px",
+                      cursor: canSubmit && online ? "pointer" : "default",
+                      opacity: canSubmit && online ? 1 : 0.35,
+                    }
+              }
             >
-              {missingLabel}
-            </div>
-          )}
-        </div>
+              {mono ? t("action.save") : t("action.save_cost")}
+            </button>
+            {!canSubmit && (
+              <div
+                className="submit-tip"
+                style={{
+                  position: "absolute",
+                  right: 0,
+                  top: "calc(100% + 6px)",
+                  background: paper.ink,
+                  color: paper.paper,
+                  fontFamily: fontMono,
+                  fontSize: 9,
+                  letterSpacing: 1,
+                  padding: "5px 8px",
+                  whiteSpace: "pre-line",
+                  pointerEvents: "none",
+                  opacity: 0,
+                  transition: "opacity 0.15s",
+                  zIndex: 20,
+                }}
+              >
+                {missingLabel}
+              </div>
+            )}
+          </div>
+        )}
         <style>{`.submit-wrap:hover .submit-tip, .submit-wrap:focus-within .submit-tip { opacity: 1 !important; }`}</style>
       </div>
 
-      {/* Car tabs */}
-      <Controller
-        name="car_id"
-        control={control}
-        render={({ field }) => (
-          <CarToggle cars={cars} value={field.value} onChange={field.onChange} />
+      <fieldset disabled={readOnly} style={fieldsetReset}>
+        {readOnly && (
+          <div
+            style={{
+              padding: "8px 14px",
+              fontFamily: fontMono,
+              fontSize: 9,
+              fontWeight: 700,
+              letterSpacing: 1,
+              color: paper.amber,
+              borderBottom: mono
+                ? `1px solid ${paper.paperDark}`
+                : `1.5px dashed ${paper.paperDark}`,
+            }}
+          >
+            🔒 {t("form.read_only_hint")}
+          </div>
         )}
-      />
 
-      {/* Driver + Date row */}
-      <div
-        style={{
-          display: "flex",
-          borderBottom: mono ? `1px solid ${paper.paperDark}` : `1.5px dashed ${paper.paperDark}`,
-        }}
-      >
+        {/* Car tabs */}
+        <Controller
+          name="car_id"
+          control={control}
+          render={({ field }) => (
+            <CarToggle cars={cars} value={field.value} onChange={field.onChange} />
+          )}
+        />
+
+        {/* Driver + Date row */}
         <div
           style={{
-            flex: 1,
-            padding: "10px 14px",
-            borderRight: mono
-              ? `1px solid ${paper.paperDark}`
-              : `1.5px dashed ${paper.paperDark}`,
+            display: "flex",
+            borderBottom: mono ? `1px solid ${paper.paperDark}` : `1.5px dashed ${paper.paperDark}`,
           }}
         >
-          {mono ? (
-            <>
-              {isAdmin ? (
-                <>
-                  <span style={lbl}>{t("form.driver")}</span>
+          <div
+            style={{
+              flex: 1,
+              padding: "10px 14px",
+              borderRight: mono
+                ? `1px solid ${paper.paperDark}`
+                : `1.5px dashed ${paper.paperDark}`,
+            }}
+          >
+            {mono ? (
+              <>
+                {isAdmin ? (
+                  <>
+                    <span style={lbl}>{t("form.driver")}</span>
+                    <select
+                      value={personId ?? ""}
+                      onChange={(e) => setValue("person_id", Number(e.target.value))}
+                      style={{
+                        fontFamily: fontSerif,
+                        fontSize: 17,
+                        fontWeight: 600,
+                        color: paper.ink,
+                        background: "transparent",
+                        border: "none",
+                        outline: "none",
+                        width: "100%",
+                        padding: 0,
+                        cursor: "pointer",
+                      }}
+                    >
+                      <option value="" disabled>
+                        {t("form.select_person_placeholder")}
+                      </option>
+                      {people
+                        .filter((p) => p.active)
+                        .map((p) => (
+                          <option key={p.id} value={p.id}>
+                            {fullNameOf(p)}
+                          </option>
+                        ))}
+                    </select>
+                  </>
+                ) : (
+                  <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                    <span
+                      style={{
+                        fontFamily:
+                          "var(--font-inter-tight, 'Inter Tight', 'Inter', system-ui, sans-serif)",
+                        fontSize: 19,
+                        fontWeight: 700,
+                        color: paper.ink,
+                      }}
+                    >
+                      {person ? fullNameOf(person) : (me?.shortName ?? "—")}
+                    </span>
+                    <Lock size={14} color={paper.inkMute} strokeWidth={1.75} />
+                  </div>
+                )}
+              </>
+            ) : (
+              <>
+                <span style={lbl}>{t("form.driver")}</span>
+                {isAdmin ? (
                   <select
                     value={personId ?? ""}
                     onChange={(e) => setValue("person_id", Number(e.target.value))}
@@ -329,30 +436,62 @@ export function ExpenseForm({ defaultValues, onSubmit, onCancel, onDelete }: Pro
                         </option>
                       ))}
                   </select>
-                </>
-              ) : (
-                <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-                  <span
-                    style={{
-                      fontFamily: "var(--font-inter-tight, 'Inter Tight', 'Inter', system-ui, sans-serif)",
-                      fontSize: 19,
-                      fontWeight: 700,
-                      color: paper.ink,
-                    }}
-                  >
-                    {person ? fullNameOf(person) : me?.shortName ?? "—"}
-                  </span>
-                  <Lock size={14} color={paper.inkMute} strokeWidth={1.75} />
+                ) : (
+                  <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                    <span
+                      style={{
+                        fontFamily: fontSerif,
+                        fontSize: 17,
+                        fontWeight: 600,
+                        color: paper.ink,
+                      }}
+                    >
+                      {person ? fullNameOf(person) : (me?.shortName ?? "—")}
+                    </span>
+                    {(person?.discount ?? 0) > 0 && (
+                      <span style={{ color: paper.accent, fontSize: 13 }}>★</span>
+                    )}
+                    <span style={{ fontSize: 13 }}>🔒</span>
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+          <div style={{ flex: 1, padding: "10px 14px" }}>
+            {mono ? (
+              <div style={{ position: "relative" }}>
+                <span style={{ ...monoLabel, marginBottom: 2 }}>{t("form.date")}</span>
+                <div
+                  style={{
+                    fontFamily:
+                      "var(--font-inter-tight, 'Inter Tight', 'Inter', system-ui, sans-serif)",
+                    fontSize: 17,
+                    fontWeight: 700,
+                    color: paper.ink,
+                    pointerEvents: "none",
+                  }}
+                >
+                  {dateW ? fmtDate(dateW, locale) : "—"}
                 </div>
-              )}
-            </>
-          ) : (
-            <>
-              <span style={lbl}>{t("form.driver")}</span>
-              {isAdmin ? (
-                <select
-                  value={personId ?? ""}
-                  onChange={(e) => setValue("person_id", Number(e.target.value))}
+                <input
+                  {...register("date")}
+                  type="date"
+                  style={{
+                    position: "absolute",
+                    inset: 0,
+                    opacity: 0.001,
+                    cursor: "pointer",
+                    width: "100%",
+                    height: "100%",
+                  }}
+                />
+              </div>
+            ) : (
+              <>
+                <span style={lbl}>{t("form.date")}</span>
+                <input
+                  {...register("date")}
+                  type="date"
                   style={{
                     fontFamily: fontSerif,
                     fontSize: 17,
@@ -365,383 +504,313 @@ export function ExpenseForm({ defaultValues, onSubmit, onCancel, onDelete }: Pro
                     padding: 0,
                     cursor: "pointer",
                   }}
-                >
-                  <option value="" disabled>
-                    {t("form.select_person_placeholder")}
-                  </option>
-                  {people
-                    .filter((p) => p.active)
-                    .map((p) => (
-                      <option key={p.id} value={p.id}>
-                        {fullNameOf(p)}
-                      </option>
-                    ))}
-                </select>
-              ) : (
-                <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-                  <span
-                    style={{ fontFamily: fontSerif, fontSize: 17, fontWeight: 600, color: paper.ink }}
-                  >
-                    {person ? fullNameOf(person) : me?.shortName ?? "—"}
-                  </span>
-                  {(person?.discount ?? 0) > 0 && (
-                    <span style={{ color: paper.accent, fontSize: 13 }}>★</span>
-                  )}
-                  <span style={{ fontSize: 13 }}>🔒</span>
-                </div>
-              )}
-            </>
-          )}
-        </div>
-        <div style={{ flex: 1, padding: "10px 14px" }}>
-          {mono ? (
-            <div style={{ position: "relative" }}>
-              <span style={{ ...monoLabel, marginBottom: 2 }}>{t("form.date")}</span>
-              <div
-                style={{
-                  fontFamily: "var(--font-inter-tight, 'Inter Tight', 'Inter', system-ui, sans-serif)",
-                  fontSize: 17,
-                  fontWeight: 700,
-                  color: paper.ink,
-                  pointerEvents: "none",
-                }}
-              >
-                {dateW ? fmtDate(dateW, locale) : "—"}
-              </div>
-              <input
-                {...register("date")}
-                type="date"
-                style={{
-                  position: "absolute",
-                  inset: 0,
-                  opacity: 0.001,
-                  cursor: "pointer",
-                  width: "100%",
-                  height: "100%",
-                }}
-              />
-            </div>
-          ) : (
-            <>
-              <span style={lbl}>{t("form.date")}</span>
-              <input
-                {...register("date")}
-                type="date"
-                style={{
-                  fontFamily: fontSerif,
-                  fontSize: 17,
-                  fontWeight: 600,
-                  color: paper.ink,
-                  background: "transparent",
-                  border: "none",
-                  outline: "none",
-                  width: "100%",
-                  padding: 0,
-                  cursor: "pointer",
-                }}
-              />
-            </>
-          )}
-        </div>
-      </div>
-      {!isAdmin && !mono && (
-        <div
-          style={{
-            padding: "6px 14px",
-            fontFamily: fontMono,
-            fontSize: 9,
-            color: paper.amber,
-            letterSpacing: 1,
-          }}
-        >
-          🔒 {t("form.driver_locked_hint")}
-        </div>
-      )}
-
-      {/* Category */}
-      <div style={{ padding: "12px 14px 4px" }}>
-        <span
-          style={
-            mono
-              ? {
-                  fontFamily: "var(--font-inter-tight, 'Inter Tight', 'Inter', system-ui, sans-serif)",
-                  fontSize: 13,
-                  fontWeight: 600,
-                  color: paper.inkDim,
-                  display: "block",
-                  marginBottom: 8,
-                }
-              : {
-                  fontFamily: fontMono,
-                  fontSize: 9,
-                  fontWeight: 700,
-                  letterSpacing: 2,
-                  textTransform: "uppercase" as const,
-                  color: paper.inkMute,
-                  display: "block",
-                  marginBottom: 8,
-                }
-          }
-        >
-          {mono ? t("form.category") : `— ${t("form.category").toUpperCase()} —`}
-        </span>
-        <div
-          style={
-            mono
-              ? { display: "flex", width: "100%", gap: 6 }
-              : { display: "flex", width: "100%", border: `1.5px solid ${paper.paperDark}` }
-          }
-        >
-          {EXPENSE_CATEGORIES.map((cat, i, arr) => {
-            const selected = category === cat.key;
-            return (
-              <button
-                key={cat.key}
-                type="button"
-                onClick={() => setValue("category", cat.key)}
-                style={
-                  mono
-                    ? {
-                        flex: 1,
-                        padding: "10px 4px",
-                        background: selected ? paper.ink : "transparent",
-                        border: selected ? "none" : `1px solid ${paper.paperDark}`,
-                        borderRadius: "var(--radius-sm, 6px)",
-                        cursor: "pointer",
-                        textAlign: "center" as const,
-                        transition: "background 0.15s",
-                      }
-                    : {
-                        flex: 1,
-                        padding: "12px 4px",
-                        background: selected ? paper.ink : "transparent",
-                        borderTop: "none",
-                        borderLeft: "none",
-                        borderBottom: "none",
-                        borderRight: i < arr.length - 1 ? `1px solid ${paper.paperDark}` : "none",
-                        cursor: "pointer",
-                        textAlign: "center" as const,
-                      }
-                }
-              >
-                {mono ? (
-                  <>
-                    <cat.Icon
-                      size={18}
-                      strokeWidth={1.75}
-                      color={selected ? paper.paper : paper.inkDim}
-                    />
-                    <div
-                      style={{
-                        fontFamily: "var(--font-inter, 'Inter', system-ui, sans-serif)",
-                        fontSize: 9,
-                        fontWeight: 500,
-                        color: selected ? paper.paper : paper.inkDim,
-                        marginTop: 4,
-                      }}
-                    >
-                      {t(cat.labelKey as any)}
-                    </div>
-                  </>
-                ) : (
-                  <>
-                    <div style={{ fontSize: 18, marginBottom: 4 }}>{cat.icon}</div>
-                    <div
-                      style={{
-                        fontFamily: fontMono,
-                        fontSize: 8,
-                        fontWeight: 700,
-                        letterSpacing: 1,
-                        textTransform: "uppercase" as const,
-                        color: selected ? paper.paper : paper.inkDim,
-                      }}
-                    >
-                      {t(cat.labelKey as any)}
-                    </div>
-                  </>
-                )}
-              </button>
-            );
-          })}
-        </div>
-      </div>
-
-      {/* Amount */}
-      <div
-        style={
-          mono
-            ? {
-                margin: "12px 14px",
-                border: `1px solid ${paper.paperDark}`,
-                borderRadius: "var(--radius-md, 10px)",
-                padding: "12px 14px",
-              }
-            : { margin: "12px 14px", ...dashedBox, padding: "12px 14px" }
-        }
-      >
-        <span style={lbl}>{t("form.amount")}</span>
-        <div style={{ display: "flex", alignItems: "baseline", gap: 4 }}>
-          <span
-            style={{ fontFamily: fontSerif, fontSize: 32, fontWeight: 700, color: paper.inkDim }}
-          >
-            €
-          </span>
-          <input
-            {...register("amount")}
-            type="number"
-            step="0.01"
-            placeholder="0,00"
-            style={{
-              fontFamily: fontSerif,
-              fontSize: 32,
-              fontWeight: 700,
-              color: paper.ink,
-              background: "transparent",
-              border: "none",
-              outline: "none",
-              flex: 1,
-              padding: 0,
-            }}
-          />
-        </div>
-      </div>
-
-      {/* Description */}
-      <div style={{ padding: "0 14px" }}>
-        <span style={lbl}>{mono ? t("form.description") : t("form.note")}</span>
-        <div
-          style={
-            mono
-              ? {
-                  border: `1px solid ${paper.paperDark}`,
-                  borderRadius: "var(--radius-md, 10px)",
-                  padding: "10px 14px",
-                }
-              : { ...dashedBox, padding: "10px 14px" }
-          }
-        >
-          <input
-            {...register("description")}
-            type="text"
-            placeholder={t("form.note")}
-            style={{
-              fontFamily: fontSerif,
-              fontSize: 17,
-              fontWeight: 500,
-              color: paper.ink,
-              background: "transparent",
-              border: "none",
-              outline: "none",
-              width: "100%",
-              padding: 0,
-            }}
-          />
-        </div>
-      </div>
-
-      {/* Settled outside */}
-      {mono ? (
-        <div style={{ padding: "12px 14px 4px", display: "flex", alignItems: "flex-start", gap: 10 }}>
-          <div
-            onClick={() => setValue("settled_outside", !settledOutside)}
-            style={{
-              width: 22,
-              height: 22,
-              borderRadius: "50%",
-              border: `2px solid ${settledOutside ? paper.ink : paper.paperDark}`,
-              background: settledOutside ? paper.ink : "transparent",
-              cursor: "pointer",
-              flexShrink: 0,
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              transition: "all 0.15s",
-              marginTop: 2,
-            }}
-          >
-            {settledOutside && (
-              <div
-                style={{ width: 8, height: 8, borderRadius: "50%", background: paper.paper }}
-              />
+                />
+              </>
             )}
           </div>
-          <div>
-            <div
-              style={{
-                fontFamily: "var(--font-inter, 'Inter', system-ui, sans-serif)",
-                fontSize: 15,
-                fontWeight: 600,
-                color: paper.ink,
-              }}
+        </div>
+        {!isAdmin && !mono && (
+          <div
+            style={{
+              padding: "6px 14px",
+              fontFamily: fontMono,
+              fontSize: 9,
+              color: paper.amber,
+              letterSpacing: 1,
+            }}
+          >
+            🔒 {t("form.driver_locked_hint")}
+          </div>
+        )}
+
+        {/* Category */}
+        <div style={{ padding: "12px 14px 4px" }}>
+          <span
+            style={
+              mono
+                ? {
+                    fontFamily:
+                      "var(--font-inter-tight, 'Inter Tight', 'Inter', system-ui, sans-serif)",
+                    fontSize: 13,
+                    fontWeight: 600,
+                    color: paper.inkDim,
+                    display: "block",
+                    marginBottom: 8,
+                  }
+                : {
+                    fontFamily: fontMono,
+                    fontSize: 9,
+                    fontWeight: 700,
+                    letterSpacing: 2,
+                    textTransform: "uppercase" as const,
+                    color: paper.inkMute,
+                    display: "block",
+                    marginBottom: 8,
+                  }
+            }
+          >
+            {mono ? t("form.category") : `— ${t("form.category").toUpperCase()} —`}
+          </span>
+          <div
+            style={
+              mono
+                ? { display: "flex", width: "100%", gap: 6 }
+                : { display: "flex", width: "100%", border: `1.5px solid ${paper.paperDark}` }
+            }
+          >
+            {EXPENSE_CATEGORIES.map((cat, i, arr) => {
+              const selected = category === cat.key;
+              return (
+                <button
+                  key={cat.key}
+                  type="button"
+                  onClick={() => setValue("category", cat.key)}
+                  style={
+                    mono
+                      ? {
+                          flex: 1,
+                          padding: "10px 4px",
+                          background: selected ? paper.ink : "transparent",
+                          border: selected ? "none" : `1px solid ${paper.paperDark}`,
+                          borderRadius: "var(--radius-sm, 6px)",
+                          cursor: "pointer",
+                          textAlign: "center" as const,
+                          transition: "background 0.15s",
+                        }
+                      : {
+                          flex: 1,
+                          padding: "12px 4px",
+                          background: selected ? paper.ink : "transparent",
+                          borderTop: "none",
+                          borderLeft: "none",
+                          borderBottom: "none",
+                          borderRight: i < arr.length - 1 ? `1px solid ${paper.paperDark}` : "none",
+                          cursor: "pointer",
+                          textAlign: "center" as const,
+                        }
+                  }
+                >
+                  {mono ? (
+                    <>
+                      <cat.Icon
+                        size={18}
+                        strokeWidth={1.75}
+                        color={selected ? paper.paper : paper.inkDim}
+                      />
+                      <div
+                        style={{
+                          fontFamily: "var(--font-inter, 'Inter', system-ui, sans-serif)",
+                          fontSize: 9,
+                          fontWeight: 500,
+                          color: selected ? paper.paper : paper.inkDim,
+                          marginTop: 4,
+                        }}
+                      >
+                        {t(cat.labelKey as any)}
+                      </div>
+                    </>
+                  ) : (
+                    <>
+                      <div style={{ fontSize: 18, marginBottom: 4 }}>{cat.icon}</div>
+                      <div
+                        style={{
+                          fontFamily: fontMono,
+                          fontSize: 8,
+                          fontWeight: 700,
+                          letterSpacing: 1,
+                          textTransform: "uppercase" as const,
+                          color: selected ? paper.paper : paper.inkDim,
+                        }}
+                      >
+                        {t(cat.labelKey as any)}
+                      </div>
+                    </>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Amount */}
+        <div
+          style={
+            mono
+              ? {
+                  margin: "12px 14px",
+                  border: `1px solid ${paper.paperDark}`,
+                  borderRadius: "var(--radius-md, 10px)",
+                  padding: "12px 14px",
+                }
+              : { margin: "12px 14px", ...dashedBox, padding: "12px 14px" }
+          }
+        >
+          <span style={lbl}>{t("form.amount")}</span>
+          <div style={{ display: "flex", alignItems: "baseline", gap: 4 }}>
+            <span
+              style={{ fontFamily: fontSerif, fontSize: 32, fontWeight: 700, color: paper.inkDim }}
             >
-              {t("form.settled_outside")}
-            </div>
-            <div
+              €
+            </span>
+            <input
+              {...register("amount")}
+              type="number"
+              step="0.01"
+              placeholder="0,00"
               style={{
-                fontFamily: "var(--font-inter, 'Inter', system-ui, sans-serif)",
-                fontSize: 12,
-                color: paper.inkMute,
+                fontFamily: fontSerif,
+                fontSize: 32,
+                fontWeight: 700,
+                color: paper.ink,
+                background: "transparent",
+                border: "none",
+                outline: "none",
+                flex: 1,
+                padding: 0,
+              }}
+            />
+          </div>
+        </div>
+
+        {/* Description */}
+        <div style={{ padding: "0 14px" }}>
+          <span style={lbl}>{mono ? t("form.description") : t("form.note")}</span>
+          <div
+            style={
+              mono
+                ? {
+                    border: `1px solid ${paper.paperDark}`,
+                    borderRadius: "var(--radius-md, 10px)",
+                    padding: "10px 14px",
+                  }
+                : { ...dashedBox, padding: "10px 14px" }
+            }
+          >
+            <input
+              {...register("description")}
+              type="text"
+              placeholder={t("form.note")}
+              style={{
+                fontFamily: fontSerif,
+                fontSize: 17,
+                fontWeight: 500,
+                color: paper.ink,
+                background: "transparent",
+                border: "none",
+                outline: "none",
+                width: "100%",
+                padding: 0,
+              }}
+            />
+          </div>
+        </div>
+
+        {/* Settled outside */}
+        {mono ? (
+          <div
+            style={{ padding: "12px 14px 4px", display: "flex", alignItems: "flex-start", gap: 10 }}
+          >
+            <div
+              onClick={() => !readOnly && setValue("settled_outside", !settledOutside)}
+              style={{
+                width: 22,
+                height: 22,
+                borderRadius: "50%",
+                border: `2px solid ${settledOutside ? paper.ink : paper.paperDark}`,
+                background: settledOutside ? paper.ink : "transparent",
+                cursor: "pointer",
+                flexShrink: 0,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                transition: "all 0.15s",
                 marginTop: 2,
               }}
             >
-              {t("form.settled_outside_hint")}
+              {settledOutside && (
+                <div
+                  style={{ width: 8, height: 8, borderRadius: "50%", background: paper.paper }}
+                />
+              )}
+            </div>
+            <div>
+              <div
+                style={{
+                  fontFamily: "var(--font-inter, 'Inter', system-ui, sans-serif)",
+                  fontSize: 15,
+                  fontWeight: 600,
+                  color: paper.ink,
+                }}
+              >
+                {t("form.settled_outside")}
+              </div>
+              <div
+                style={{
+                  fontFamily: "var(--font-inter, 'Inter', system-ui, sans-serif)",
+                  fontSize: 12,
+                  color: paper.inkMute,
+                  marginTop: 2,
+                }}
+              >
+                {t("form.settled_outside_hint")}
+              </div>
             </div>
           </div>
-        </div>
-      ) : (
-        <div style={{ padding: "8px 14px 4px", display: "flex", alignItems: "center", gap: 10 }}>
-          <input
-            type="checkbox"
-            id="expense_settled_outside"
-            checked={!!settledOutside}
-            onChange={(e) => setValue("settled_outside", e.target.checked)}
-            style={{ width: 16, height: 16, cursor: "pointer", accentColor: paper.inkMute }}
-          />
-          <label
-            htmlFor="expense_settled_outside"
-            style={{
-              fontFamily: fontMono,
-              fontSize: 10,
-              fontWeight: 700,
-              letterSpacing: 2,
-              textTransform: "uppercase",
-              color: paper.inkDim,
-              cursor: "pointer",
-            }}
-          >
-            {t("form.settled_outside")}
-          </label>
-          <span
-            style={{ fontFamily: fontMono, fontSize: 9, color: paper.inkMute, letterSpacing: 1 }}
-          >
-            — {t("form.settled_outside_hint")}
-          </span>
-        </div>
-      )}
+        ) : (
+          <div style={{ padding: "8px 14px 4px", display: "flex", alignItems: "center", gap: 10 }}>
+            <input
+              type="checkbox"
+              id="expense_settled_outside"
+              checked={!!settledOutside}
+              onChange={(e) => setValue("settled_outside", e.target.checked)}
+              style={{ width: 16, height: 16, cursor: "pointer", accentColor: paper.inkMute }}
+            />
+            <label
+              htmlFor="expense_settled_outside"
+              style={{
+                fontFamily: fontMono,
+                fontSize: 10,
+                fontWeight: 700,
+                letterSpacing: 2,
+                textTransform: "uppercase",
+                color: paper.inkDim,
+                cursor: "pointer",
+              }}
+            >
+              {t("form.settled_outside")}
+            </label>
+            <span
+              style={{ fontFamily: fontMono, fontSize: 9, color: paper.inkMute, letterSpacing: 1 }}
+            >
+              — {t("form.settled_outside_hint")}
+            </span>
+          </div>
+        )}
 
-      {onDelete && (
-        <div style={{ padding: "8px 14px 24px" }}>
-          <button
-            type="button"
-            onClick={onDelete}
-            style={{
-              width: "100%",
-              padding: "10px",
-              background: "transparent",
-              border: `1.5px solid ${paper.accent}`,
-              color: paper.accent,
-              fontFamily: fontMono,
-              fontSize: 10,
-              fontWeight: 700,
-              letterSpacing: 2,
-              textTransform: "uppercase",
-              cursor: "pointer",
-            }}
-          >
-            {t("action.delete")}
-          </button>
-        </div>
-      )}
+        {onDelete && (
+          <div style={{ padding: "8px 14px 24px" }}>
+            <button
+              type="button"
+              onClick={onDelete}
+              style={{
+                width: "100%",
+                padding: "10px",
+                background: "transparent",
+                border: `1.5px solid ${paper.accent}`,
+                color: paper.accent,
+                fontFamily: fontMono,
+                fontSize: 10,
+                fontWeight: 700,
+                letterSpacing: 2,
+                textTransform: "uppercase",
+                cursor: "pointer",
+              }}
+            >
+              {t("action.delete")}
+            </button>
+          </div>
+        )}
+      </fieldset>
       <div style={{ height: 32 }} />
     </form>
   );

--- a/app/expenses/page.tsx
+++ b/app/expenses/page.tsx
@@ -7,8 +7,15 @@ import { Fab } from "@/components/fab";
 import { ListFilterBar } from "@/components/list-filter-bar";
 import { ModalSheet } from "@/components/modal-sheet";
 import { ExpenseForm } from "./expense-form";
-import { useExpenses, useCreateExpense, useUpdateExpense, useDeleteExpense } from "@/hooks/use-expenses";
+import {
+  useExpenses,
+  useCreateExpense,
+  useUpdateExpense,
+  useDeleteExpense,
+} from "@/hooks/use-expenses";
 import { useMe } from "@/hooks/use-me";
+import { useCars } from "@/hooks/use-vehicles";
+import { canEdit } from "@/lib/permissions";
 import { useQueryParam } from "@/hooks/use-query-param";
 import { useEditModal } from "@/hooks/use-edit-modal";
 import { paper, fontMono, fmtYearMonth } from "@/lib/paper-theme";
@@ -20,6 +27,7 @@ function ExpensesContent() {
   const t = useT();
   const { data: expenses = [], isLoading } = useExpenses();
   const { data: me } = useMe();
+  const { data: carList = [] } = useCars();
   const createE = useCreateExpense();
   const updateE = useUpdateExpense();
   const deleteE = useDeleteExpense();
@@ -30,7 +38,20 @@ function ExpensesContent() {
 
   const { adding, editingId, modalClosed, openAdd, openEdit, closeModal } = useEditModal();
 
-  const editing = !isLoading && editingId ? (expenses.find((e) => e.id === editingId) ?? null) : null;
+  const editing =
+    !isLoading && editingId ? (expenses.find((e) => e.id === editingId) ?? null) : null;
+
+  const editingReadOnly =
+    editing != null &&
+    !(
+      me?.personId != null &&
+      canEdit(
+        me.personId,
+        me.isAdmin,
+        editing,
+        carList.find((c) => c.id === editing.car_id)?.owner_person_id ?? null
+      )
+    );
 
   const isMine = mineParam === "true";
   const isOthers = mineParam === "false";
@@ -38,7 +59,9 @@ function ExpensesContent() {
   const cars = Array.from(
     new Set(expenses.map((e) => e.car_short).filter((s): s is string => !!s))
   ).sort();
-  const years = Array.from(new Set(expenses.map((e) => e.date.slice(0, 4)))).sort().reverse();
+  const years = Array.from(new Set(expenses.map((e) => e.date.slice(0, 4))))
+    .sort()
+    .reverse();
 
   const visible = expenses
     .filter((e) => {
@@ -53,7 +76,15 @@ function ExpensesContent() {
     return (
       <div style={{ background: paper.paperDeep, minHeight: "100dvh" }}>
         <PageHeader title={t("page.expenses")} />
-        <div style={{ padding: "32px 20px", fontFamily: fontMono, fontSize: 11, color: paper.inkDim, letterSpacing: 1 }}>
+        <div
+          style={{
+            padding: "32px 20px",
+            fontFamily: fontMono,
+            fontSize: 11,
+            color: paper.inkDim,
+            letterSpacing: 1,
+          }}
+        >
           {t("state.loading")}
         </div>
       </div>
@@ -85,7 +116,16 @@ function ExpensesContent() {
       />
 
       {visible.length === 0 && (
-        <div style={{ padding: "32px 20px", textAlign: "center", fontFamily: fontMono, fontSize: 11, color: paper.inkDim, letterSpacing: 1 }}>
+        <div
+          style={{
+            padding: "32px 20px",
+            textAlign: "center",
+            fontFamily: fontMono,
+            fontSize: 11,
+            color: paper.inkDim,
+            letterSpacing: 1,
+          }}
+        >
           {t("state.empty_expenses")}
         </div>
       )}
@@ -94,7 +134,10 @@ function ExpensesContent() {
         <ExpenseForm
           onSubmit={(data) =>
             createE.mutate(data as any, {
-              onSuccess: () => { closeModal(); toast.success(t("toast.saved")); },
+              onSuccess: () => {
+                closeModal();
+                toast.success(t("toast.saved"));
+              },
               onError: (e) => toast.error(e.message),
             })
           }
@@ -102,22 +145,36 @@ function ExpensesContent() {
         />
       </ModalSheet>
 
-      <ModalSheet open={!!editing && !modalClosed} onClose={closeModal} title={t("page.expense_edit")}>
+      <ModalSheet
+        open={!!editing && !modalClosed}
+        onClose={closeModal}
+        title={t("page.expense_edit")}
+      >
         {editing && (
           <ExpenseForm
             defaultValues={editing}
+            readOnly={editingReadOnly}
             onSubmit={(data) =>
               updateE.mutate({ id: editing.id, ...data } as any, {
-                onSuccess: () => { closeModal(); toast.success(t("toast.saved")); },
+                onSuccess: () => {
+                  closeModal();
+                  toast.success(t("toast.saved"));
+                },
                 onError: (e) => toast.error(e.message),
               })
             }
             onCancel={closeModal}
-            onDelete={() =>
-              deleteE.mutate(editing.id, {
-                onSuccess: () => { closeModal(); toast.success(t("toast.saved")); },
-                onError: (e) => toast.error(e.message),
-              })
+            onDelete={
+              editingReadOnly
+                ? undefined
+                : () =>
+                    deleteE.mutate(editing.id, {
+                      onSuccess: () => {
+                        closeModal();
+                        toast.success(t("toast.saved"));
+                      },
+                      onError: (e) => toast.error(e.message),
+                    })
             }
           />
         )}

--- a/app/fuel/fuel-form.tsx
+++ b/app/fuel/fuel-form.tsx
@@ -60,7 +60,16 @@ interface Props {
   onSubmit: (data: FuelFillupInput) => void;
   onCancel: () => void;
   onDelete?: () => void;
+  /** When true the form is shown read-only: inputs disabled, save hidden. */
+  readOnly?: boolean;
 }
+
+const fieldsetReset: React.CSSProperties = {
+  border: 0,
+  margin: 0,
+  padding: 0,
+  minInlineSize: "auto",
+};
 
 const paperLabel: React.CSSProperties = {
   fontFamily: fontMono,
@@ -84,7 +93,7 @@ const dashedBox: React.CSSProperties = {
   padding: "12px 14px",
 };
 
-export function FuelForm({ defaultValues, onSubmit, onCancel, onDelete }: Props) {
+export function FuelForm({ defaultValues, onSubmit, onCancel, onDelete, readOnly = false }: Props) {
   const { data: people = [] } = usePeople();
   const { data: cars = [] } = useCars();
   const { data: me } = useMe();
@@ -120,7 +129,13 @@ export function FuelForm({ defaultValues, onSubmit, onCancel, onDelete }: Props)
     control,
     name: ["amount", "liters", "car_id", "person_id", "date", "full_tank", "settled_outside"],
   });
-  const canSubmit = !!(personId && carId && date && parseDecimalInput(amount as string) > 0 && parseDecimalInput(liters as string) > 0);
+  const canSubmit = !!(
+    personId &&
+    carId &&
+    date &&
+    parseDecimalInput(amount as string) > 0 &&
+    parseDecimalInput(liters as string) > 0
+  );
   const missingLabel = buildMissingLabel([
     !carId && t("field.car"),
     isAdmin && !personId && t("field.driver"),
@@ -128,7 +143,10 @@ export function FuelForm({ defaultValues, onSubmit, onCancel, onDelete }: Props)
     !(parseDecimalInput(amount as string) > 0) && t("field.amount"),
     !(parseDecimalInput(liters as string) > 0) && t("field.liters"),
   ]);
-  const pricePerLiter = calcPricePerLiter(parseDecimalInput(amount as string) || 0, parseDecimalInput(liters as string) || 0);
+  const pricePerLiter = calcPricePerLiter(
+    parseDecimalInput(amount as string) || 0,
+    parseDecimalInput(liters as string) || 0
+  );
   const person = people.find((p) => p.id === personId);
 
   const { data: lastState } = useLastCarState(carId);
@@ -168,6 +186,10 @@ export function FuelForm({ defaultValues, onSubmit, onCancel, onDelete }: Props)
   return (
     <form
       onSubmit={(e) => {
+        if (readOnly) {
+          e.preventDefault();
+          return;
+        }
         if (!online) {
           e.preventDefault();
           toast.error(t("offline.mutation_blocked"));
@@ -228,136 +250,655 @@ export function FuelForm({ defaultValues, onSubmit, onCancel, onDelete }: Props)
           {!mono && "⛽ "}
           {t("form.fuel_receipt")}
         </div>
-        <div style={{ position: "relative" }} className="submit-wrap">
-          <button
-            type="submit"
-            disabled={!canSubmit}
+        {readOnly ? (
+          <div
             style={{
-              fontFamily: mono ? fontSerif : fontMono,
-              fontSize: mono ? 13 : 9,
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+              fontFamily: fontMono,
+              fontSize: 9,
               fontWeight: 700,
-              letterSpacing: mono ? 0 : 2,
-              textTransform: mono ? "none" : "uppercase",
-              background: mono ? paper.accent : paper.green,
-              color: "#fff",
-              border: "none",
-              borderRadius: mono ? "var(--radius-pill, 999px)" : 0,
-              padding: mono ? "8px 18px" : "8px 14px",
-              cursor: canSubmit && online ? "pointer" : "default",
-              opacity: canSubmit && online ? 1 : 0.35,
+              letterSpacing: 2,
+              textTransform: "uppercase",
+              color: paper.inkMute,
             }}
           >
-            {mono ? t("action.save") : t("action.save_receipt")}
-          </button>
-          {!canSubmit && (
-            <div
-              className="submit-tip"
+            <Lock size={13} color={paper.inkMute} strokeWidth={1.75} />
+            {t("form.read_only")}
+          </div>
+        ) : (
+          <div style={{ position: "relative" }} className="submit-wrap">
+            <button
+              type="submit"
+              disabled={!canSubmit}
               style={{
-                position: "absolute",
-                right: 0,
-                top: "calc(100% + 6px)",
-                background: paper.ink,
-                color: paper.paper,
-                fontFamily: fontMono,
-                fontSize: 9,
-                letterSpacing: 1,
-                padding: "5px 8px",
-                whiteSpace: "pre-line",
-                pointerEvents: "none",
-                opacity: 0,
-                transition: "opacity 0.15s",
-                zIndex: 20,
+                fontFamily: mono ? fontSerif : fontMono,
+                fontSize: mono ? 13 : 9,
+                fontWeight: 700,
+                letterSpacing: mono ? 0 : 2,
+                textTransform: mono ? "none" : "uppercase",
+                background: mono ? paper.accent : paper.green,
+                color: "#fff",
+                border: "none",
+                borderRadius: mono ? "var(--radius-pill, 999px)" : 0,
+                padding: mono ? "8px 18px" : "8px 14px",
+                cursor: canSubmit && online ? "pointer" : "default",
+                opacity: canSubmit && online ? 1 : 0.35,
               }}
             >
-              {missingLabel}
-            </div>
-          )}
-        </div>
+              {mono ? t("action.save") : t("action.save_receipt")}
+            </button>
+            {!canSubmit && (
+              <div
+                className="submit-tip"
+                style={{
+                  position: "absolute",
+                  right: 0,
+                  top: "calc(100% + 6px)",
+                  background: paper.ink,
+                  color: paper.paper,
+                  fontFamily: fontMono,
+                  fontSize: 9,
+                  letterSpacing: 1,
+                  padding: "5px 8px",
+                  whiteSpace: "pre-line",
+                  pointerEvents: "none",
+                  opacity: 0,
+                  transition: "opacity 0.15s",
+                  zIndex: 20,
+                }}
+              >
+                {missingLabel}
+              </div>
+            )}
+          </div>
+        )}
         <style>{`.submit-wrap:hover .submit-tip, .submit-wrap:focus-within .submit-tip { opacity: 1 !important; }`}</style>
       </div>
 
-      {/* Car tabs */}
-      <Controller
-        name="car_id"
-        control={control}
-        render={({ field }) => (
-          <CarToggle cars={cars} value={field.value} onChange={field.onChange} />
+      <fieldset disabled={readOnly} style={fieldsetReset}>
+        {readOnly && (
+          <div
+            style={{
+              padding: "8px 14px",
+              fontFamily: fontMono,
+              fontSize: 9,
+              fontWeight: 700,
+              letterSpacing: 1,
+              color: paper.amber,
+              borderBottom: rowBorder,
+            }}
+          >
+            🔒 {t("form.read_only_hint")}
+          </div>
         )}
-      />
 
-      {/* Driver + Date row */}
-      <div style={{ display: "flex", borderBottom: rowBorder }}>
-        <div style={{ flex: 1, padding: "10px 14px", borderRight: rowBorder }}>
-          {!mono && <span style={lbl}>{t("form.driver")}</span>}
-          {isAdmin ? (
-            <>
-              {mono && <span style={lbl}>{t("form.driver")}</span>}
-              <select
-                value={personId ?? ""}
-                onChange={(e) => setValue("person_id", Number(e.target.value))}
+        {/* Car tabs */}
+        <Controller
+          name="car_id"
+          control={control}
+          render={({ field }) => (
+            <CarToggle cars={cars} value={field.value} onChange={field.onChange} />
+          )}
+        />
+
+        {/* Driver + Date row */}
+        <div style={{ display: "flex", borderBottom: rowBorder }}>
+          <div style={{ flex: 1, padding: "10px 14px", borderRight: rowBorder }}>
+            {!mono && <span style={lbl}>{t("form.driver")}</span>}
+            {isAdmin ? (
+              <>
+                {mono && <span style={lbl}>{t("form.driver")}</span>}
+                <select
+                  value={personId ?? ""}
+                  onChange={(e) => setValue("person_id", Number(e.target.value))}
+                  style={{
+                    fontFamily: fontSerif,
+                    fontSize: mono ? 19 : 17,
+                    fontWeight: mono ? 700 : 600,
+                    color: paper.ink,
+                    background: "transparent",
+                    border: "none",
+                    outline: "none",
+                    width: "100%",
+                    padding: 0,
+                    cursor: "pointer",
+                  }}
+                >
+                  <option value="" disabled>
+                    {t("form.select_person_placeholder")}
+                  </option>
+                  {people
+                    .filter((p) => p.active)
+                    .map((p) => (
+                      <option key={p.id} value={p.id}>
+                        {fullNameOf(p)}
+                      </option>
+                    ))}
+                </select>
+              </>
+            ) : mono ? (
+              <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                <span
+                  style={{
+                    fontFamily: fontSerif,
+                    fontSize: 19,
+                    fontWeight: 700,
+                    color: paper.ink,
+                    lineHeight: 1.15,
+                  }}
+                >
+                  {person ? fullNameOf(person) : (me?.shortName ?? "—")}
+                </span>
+                <Lock
+                  size={14}
+                  color={paper.inkMute}
+                  strokeWidth={1.75}
+                  style={{ flexShrink: 0 }}
+                />
+              </div>
+            ) : (
+              <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                <span
+                  style={{ fontFamily: fontSerif, fontSize: 17, fontWeight: 600, color: paper.ink }}
+                >
+                  {person ? fullNameOf(person) : (me?.shortName ?? "—")}
+                </span>
+                <span style={{ fontSize: 13 }}>🔒</span>
+              </div>
+            )}
+          </div>
+          <div style={{ flex: 1, padding: "10px 14px" }}>
+            {mono ? (
+              <div style={{ position: "relative" }}>
+                <span style={{ ...monoLabel, marginBottom: 2 }}>{t("form.date")}</span>
+                <div
+                  style={{
+                    fontFamily: fontSerif,
+                    fontSize: 17,
+                    fontWeight: 700,
+                    color: paper.ink,
+                    pointerEvents: "none",
+                  }}
+                >
+                  {date ? fmtDate(date, locale) : "—"}
+                </div>
+                <input
+                  {...register("date")}
+                  type="date"
+                  style={{
+                    position: "absolute",
+                    inset: 0,
+                    opacity: 0.001,
+                    cursor: "pointer",
+                    width: "100%",
+                    height: "100%",
+                  }}
+                />
+              </div>
+            ) : (
+              <>
+                <span style={lbl}>{t("form.date")}</span>
+                <input
+                  {...register("date")}
+                  type="date"
+                  style={{
+                    fontFamily: fontSerif,
+                    fontSize: 17,
+                    fontWeight: 600,
+                    color: paper.ink,
+                    background: "transparent",
+                    border: "none",
+                    outline: "none",
+                    width: "100%",
+                    padding: 0,
+                    cursor: "pointer",
+                  }}
+                />
+              </>
+            )}
+          </div>
+        </div>
+        {!isAdmin && !mono && (
+          <div
+            style={{
+              padding: "6px 14px",
+              fontFamily: fontMono,
+              fontSize: 9,
+              color: paper.amber,
+              letterSpacing: 1,
+            }}
+          >
+            🔒 {t("form.driver_locked_hint")}
+          </div>
+        )}
+
+        {/* Pump / fuel section */}
+        {mono ? (
+          <div style={{ padding: "12px 14px 8px" }}>
+            {/* Amount + price/L + Liters row */}
+            <div style={{ display: "flex", alignItems: "flex-end", gap: 8 }}>
+              <div style={{ flex: 1 }}>
+                <span style={{ ...monoLabel, marginBottom: 2 }}>{t("form.amount")}</span>
+                <div style={{ display: "flex", alignItems: "baseline", gap: 4 }}>
+                  <span style={{ fontFamily: fontMono, fontSize: 20, color: paper.inkMute }}>
+                    €
+                  </span>
+                  <input
+                    {...register("amount")}
+                    type="text"
+                    inputMode="decimal"
+                    style={{
+                      fontFamily: fontMono,
+                      fontSize: 28,
+                      fontWeight: 700,
+                      color: paper.ink,
+                      background: "transparent",
+                      border: "none",
+                      outline: "none",
+                      borderBottom: `1px solid ${paper.paperDark}`,
+                      width: "100%",
+                      padding: "2px 0",
+                    }}
+                  />
+                </div>
+              </div>
+              <div style={{ textAlign: "center", flexShrink: 0, padding: "0 6px 8px" }}>
+                <div style={{ fontFamily: fontMono, fontSize: 11.5, color: paper.inkMute }}>
+                  {parseDecimalInput(liters as string) > 0
+                    ? `€ ${pricePerLiter.toFixed(3).replace(".", ",")}/L`
+                    : "€/L"}
+                </div>
+              </div>
+              <div style={{ flex: 1 }}>
+                <span
+                  style={{ ...monoLabel, marginBottom: 2, textAlign: "right", display: "block" }}
+                >
+                  {t("form.liters")}
+                </span>
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "baseline",
+                    gap: 4,
+                    justifyContent: "flex-end",
+                  }}
+                >
+                  <input
+                    {...register("liters")}
+                    type="text"
+                    inputMode="decimal"
+                    style={{
+                      fontFamily: fontMono,
+                      fontSize: 28,
+                      fontWeight: 700,
+                      color: paper.ink,
+                      background: "transparent",
+                      border: "none",
+                      outline: "none",
+                      borderBottom: `1px solid ${paper.paperDark}`,
+                      width: "100%",
+                      padding: "2px 0",
+                      textAlign: "right",
+                    }}
+                  />
+                  <span
+                    style={{
+                      fontFamily: fontMono,
+                      fontSize: 14,
+                      color: paper.inkMute,
+                      flexShrink: 0,
+                    }}
+                  >
+                    L
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div
+            style={{
+              margin: "12px 14px",
+              background: paper.paper,
+              border: `1.5px solid ${paper.paperDark}`,
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                padding: "10px 14px 6px",
+                borderBottom: `1px dashed ${paper.paperDark}`,
+              }}
+            >
+              <span
                 style={{
-                  fontFamily: fontSerif,
-                  fontSize: mono ? 19 : 17,
-                  fontWeight: mono ? 700 : 600,
-                  color: paper.ink,
-                  background: "transparent",
-                  border: "none",
-                  outline: "none",
-                  width: "100%",
-                  padding: 0,
-                  cursor: "pointer",
+                  fontFamily: fontMono,
+                  fontSize: 10,
+                  fontWeight: 700,
+                  letterSpacing: 2,
+                  color: paper.amber,
+                  textTransform: "uppercase",
                 }}
               >
-                <option value="" disabled>
-                  {t("form.select_person_placeholder")}
-                </option>
-                {people
-                  .filter((p) => p.active)
-                  .map((p) => (
-                    <option key={p.id} value={p.id}>
-                      {fullNameOf(p)}
-                    </option>
-                  ))}
-              </select>
-            </>
-          ) : mono ? (
-            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-              <span style={{ fontFamily: fontSerif, fontSize: 19, fontWeight: 700, color: paper.ink, lineHeight: 1.15 }}>
-                {person ? fullNameOf(person) : me?.shortName ?? "—"}
+                ● {t("form.pump")}
               </span>
-              <Lock size={14} color={paper.inkMute} strokeWidth={1.75} style={{ flexShrink: 0 }} />
-            </div>
-          ) : (
-            <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-              <span style={{ fontFamily: fontSerif, fontSize: 17, fontWeight: 600, color: paper.ink }}>
-                {person ? fullNameOf(person) : me?.shortName ?? "—"}
+              <span
+                style={{
+                  fontFamily: fontMono,
+                  fontSize: 10,
+                  color: paper.inkMute,
+                  letterSpacing: 1,
+                }}
+              >
+                {displayDate}
               </span>
-              <span style={{ fontSize: 13 }}>🔒</span>
             </div>
-          )}
-        </div>
-        <div style={{ flex: 1, padding: "10px 14px" }}>
-          {mono ? (
-            <div style={{ position: "relative" }}>
-              <span style={{ ...monoLabel, marginBottom: 2 }}>{t("form.date")}</span>
-              <div style={{ fontFamily: fontSerif, fontSize: 17, fontWeight: 700, color: paper.ink, pointerEvents: "none" }}>
-                {date ? fmtDate(date, locale) : "—"}
+
+            {/* Amount + Liters */}
+            <div
+              style={{ display: "flex", alignItems: "flex-end", padding: "10px 14px 6px", gap: 0 }}
+            >
+              <div style={{ flex: 1 }}>
+                <span style={{ ...paperLabel, fontSize: 8 }}>{t("form.amount")}</span>
+                <div style={{ display: "flex", alignItems: "baseline", gap: 4 }}>
+                  <input
+                    {...register("amount")}
+                    type="text"
+                    inputMode="decimal"
+                    style={{
+                      fontFamily: fontMono,
+                      fontSize: 32,
+                      fontWeight: 700,
+                      color: paper.ink,
+                      background: "transparent",
+                      border: "none",
+                      outline: "none",
+                      borderBottom: `1px dashed ${paper.paperDark}`,
+                      width: "100%",
+                      padding: "2px 0",
+                    }}
+                  />
+                </div>
               </div>
-              <input
-                {...register("date")}
-                type="date"
-                style={{ position: "absolute", inset: 0, opacity: 0.001, cursor: "pointer", width: "100%", height: "100%" }}
-              />
+              <div
+                style={{
+                  padding: "0 12px 6px",
+                  fontFamily: fontMono,
+                  fontSize: 14,
+                  color: paper.inkMute,
+                }}
+              >
+                €
+              </div>
+              <div style={{ flex: 1 }}>
+                <span style={{ ...paperLabel, fontSize: 8 }}>{t("form.liters")}</span>
+                <div style={{ display: "flex", alignItems: "baseline", gap: 4 }}>
+                  <input
+                    {...register("liters")}
+                    type="text"
+                    inputMode="decimal"
+                    style={{
+                      fontFamily: fontMono,
+                      fontSize: 32,
+                      fontWeight: 700,
+                      color: paper.ink,
+                      background: "transparent",
+                      border: "none",
+                      outline: "none",
+                      borderBottom: `1px dashed ${paper.paperDark}`,
+                      width: "100%",
+                      padding: "2px 0",
+                    }}
+                  />
+                  <span
+                    style={{
+                      fontFamily: fontMono,
+                      fontSize: 14,
+                      color: paper.inkMute,
+                      flexShrink: 0,
+                    }}
+                  >
+                    L
+                  </span>
+                </div>
+              </div>
             </div>
-          ) : (
-            <>
-              <span style={lbl}>{t("form.date")}</span>
+
+            {/* Price per liter */}
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                padding: "8px 14px 12px",
+                borderTop: `1px dashed ${paper.paperDark}`,
+              }}
+            >
+              <span
+                style={{
+                  fontFamily: fontMono,
+                  fontSize: 9,
+                  letterSpacing: 2,
+                  textTransform: "uppercase",
+                  color: paper.inkMute,
+                }}
+              >
+                {t("form.price_per_liter")}
+              </span>
+              <span
+                style={{
+                  fontFamily: fontMono,
+                  fontSize: 12,
+                  fontWeight: 700,
+                  color: paper.inkDim,
+                  letterSpacing: 1,
+                }}
+              >
+                € {pricePerLiter.toFixed(3).replace(".", ",")}
+              </span>
+            </div>
+          </div>
+        )}
+
+        {/* Full tank toggle */}
+        {mono ? (
+          <div style={{ padding: "8px 14px", display: "flex", alignItems: "flex-start", gap: 12 }}>
+            <div
+              onClick={() => !readOnly && setValue("full_tank", !fullTank)}
+              style={{
+                width: 22,
+                height: 22,
+                borderRadius: "50%",
+                border: `2px solid ${fullTank ? paper.green : paper.paperDark}`,
+                background: fullTank ? paper.green : "transparent",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                flexShrink: 0,
+                marginTop: 2,
+                cursor: "pointer",
+                transition: "all 0.15s",
+              }}
+            >
+              {fullTank && (
+                <div style={{ width: 8, height: 8, borderRadius: "50%", background: "#fff" }} />
+              )}
+            </div>
+            <div
+              style={{ flex: 1, cursor: "pointer" }}
+              onClick={() => !readOnly && setValue("full_tank", !fullTank)}
+            >
+              <div
+                style={{ fontFamily: fontSerif, fontSize: 15, fontWeight: 600, color: paper.ink }}
+              >
+                {t("form.full_tank")}
+              </div>
+              <div
+                style={{ fontFamily: fontMono, fontSize: 11, color: paper.inkMute, marginTop: 2 }}
+              >
+                {t("form.full_tank_hint")}
+              </div>
+            </div>
+            {fullTank && (
+              <div style={{ textAlign: "right", flexShrink: 0, width: 88, overflow: "hidden" }}>
+                <span
+                  style={{ ...monoLabel, textAlign: "right", display: "block", marginBottom: 2 }}
+                >
+                  {t("form.odometer")}
+                </span>
+                <input
+                  {...register("odometer")}
+                  type="number"
+                  placeholder="—"
+                  style={{
+                    fontFamily: fontSerif,
+                    fontSize: 18,
+                    fontWeight: 700,
+                    color: paper.ink,
+                    background: "transparent",
+                    border: "none",
+                    borderBottom: `1px solid ${paper.paperDark}`,
+                    outline: "none",
+                    width: "100%",
+                    padding: "2px 0",
+                    textAlign: "right",
+                  }}
+                />
+              </div>
+            )}
+          </div>
+        ) : (
+          <div style={{ padding: "0 14px 8px", display: "flex", alignItems: "center", gap: 10 }}>
+            <input
+              type="checkbox"
+              id="full_tank"
+              checked={!!fullTank}
+              onChange={(e) => setValue("full_tank", e.target.checked)}
+              style={{ width: 16, height: 16, cursor: "pointer", accentColor: paper.green }}
+            />
+            <label
+              htmlFor="full_tank"
+              style={{
+                fontFamily: fontMono,
+                fontSize: 10,
+                fontWeight: 700,
+                letterSpacing: 2,
+                textTransform: "uppercase",
+                color: paper.inkDim,
+                cursor: "pointer",
+              }}
+            >
+              {t("form.full_tank")}
+            </label>
+            <span
+              style={{ fontFamily: fontMono, fontSize: 9, color: paper.inkMute, letterSpacing: 1 }}
+            >
+              — {t("form.full_tank_hint")}
+            </span>
+          </div>
+        )}
+
+        {/* Settled outside toggle */}
+        {mono ? (
+          <div
+            style={{
+              padding: "8px 14px 12px",
+              display: "flex",
+              alignItems: "flex-start",
+              gap: 12,
+              cursor: "pointer",
+            }}
+            onClick={() => !readOnly && setValue("settled_outside", !settledOutside)}
+          >
+            <div
+              style={{
+                width: 22,
+                height: 22,
+                borderRadius: "50%",
+                border: `2px solid ${settledOutside ? paper.inkMute : paper.paperDark}`,
+                background: settledOutside ? paper.inkMute : "transparent",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                flexShrink: 0,
+                marginTop: 2,
+                transition: "all 0.15s",
+              }}
+            >
+              {settledOutside && (
+                <div style={{ width: 8, height: 8, borderRadius: "50%", background: "#fff" }} />
+              )}
+            </div>
+            <div>
+              <div
+                style={{ fontFamily: fontSerif, fontSize: 15, fontWeight: 600, color: paper.ink }}
+              >
+                {t("form.settled_outside")}
+              </div>
+              <div
+                style={{ fontFamily: fontMono, fontSize: 11, color: paper.inkMute, marginTop: 2 }}
+              >
+                {t("form.settled_outside_hint")}
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div style={{ padding: "0 14px 8px", display: "flex", alignItems: "center", gap: 10 }}>
+            <input
+              type="checkbox"
+              id="fuel_settled_outside"
+              checked={!!settledOutside}
+              onChange={(e) => setValue("settled_outside", e.target.checked)}
+              style={{ width: 16, height: 16, cursor: "pointer", accentColor: paper.inkMute }}
+            />
+            <label
+              htmlFor="fuel_settled_outside"
+              style={{
+                fontFamily: fontMono,
+                fontSize: 10,
+                fontWeight: 700,
+                letterSpacing: 2,
+                textTransform: "uppercase",
+                color: paper.inkDim,
+                cursor: "pointer",
+              }}
+            >
+              {t("form.settled_outside")}
+            </label>
+            <span
+              style={{ fontFamily: fontMono, fontSize: 9, color: paper.inkMute, letterSpacing: 1 }}
+            >
+              — {t("form.settled_outside_hint")}
+            </span>
+          </div>
+        )}
+
+        {/* Odometer — only shown for full tank (paper only; mono shows inline with toggle) */}
+        {fullTank && !mono && (
+          <div style={{ padding: "0 14px 8px" }}>
+            <span style={lbl}>{t("form.odometer")}</span>
+            <div
+              style={
+                mono
+                  ? {
+                      border: `1px solid ${paper.paperDark}`,
+                      borderRadius: "var(--radius-sm, 6px)",
+                      padding: "8px 14px",
+                    }
+                  : { ...dashedBox, padding: "8px 14px" }
+              }
+            >
               <input
-                {...register("date")}
-                type="date"
+                {...register("odometer")}
+                type="number"
+                placeholder="—"
                 style={{
                   fontFamily: fontSerif,
-                  fontSize: 17,
+                  fontSize: 20,
                   fontWeight: 600,
                   color: paper.ink,
                   background: "transparent",
@@ -365,378 +906,73 @@ export function FuelForm({ defaultValues, onSubmit, onCancel, onDelete }: Props)
                   outline: "none",
                   width: "100%",
                   padding: 0,
-                  cursor: "pointer",
-                }}
-              />
-            </>
-          )}
-        </div>
-      </div>
-      {!isAdmin && !mono && (
-        <div style={{ padding: "6px 14px", fontFamily: fontMono, fontSize: 9, color: paper.amber, letterSpacing: 1 }}>
-          🔒 {t("form.driver_locked_hint")}
-        </div>
-      )}
-
-      {/* Pump / fuel section */}
-      {mono ? (
-        <div style={{ padding: "12px 14px 8px" }}>
-          {/* Amount + price/L + Liters row */}
-          <div style={{ display: "flex", alignItems: "flex-end", gap: 8 }}>
-            <div style={{ flex: 1 }}>
-              <span style={{ ...monoLabel, marginBottom: 2 }}>{t("form.amount")}</span>
-              <div style={{ display: "flex", alignItems: "baseline", gap: 4 }}>
-                <span style={{ fontFamily: fontMono, fontSize: 20, color: paper.inkMute }}>€</span>
-                <input
-                  {...register("amount")}
-                  type="text"
-                  inputMode="decimal"
-                  style={{
-                    fontFamily: fontMono,
-                    fontSize: 28,
-                    fontWeight: 700,
-                    color: paper.ink,
-                    background: "transparent",
-                    border: "none",
-                    outline: "none",
-                    borderBottom: `1px solid ${paper.paperDark}`,
-                    width: "100%",
-                    padding: "2px 0",
-                  }}
-                />
-              </div>
-            </div>
-            <div style={{ textAlign: "center", flexShrink: 0, padding: "0 6px 8px" }}>
-              <div style={{ fontFamily: fontMono, fontSize: 11.5, color: paper.inkMute }}>
-                {parseDecimalInput(liters as string) > 0 ? `€ ${pricePerLiter.toFixed(3).replace(".", ",")}/L` : "€/L"}
-              </div>
-            </div>
-            <div style={{ flex: 1 }}>
-              <span style={{ ...monoLabel, marginBottom: 2, textAlign: "right", display: "block" }}>{t("form.liters")}</span>
-              <div style={{ display: "flex", alignItems: "baseline", gap: 4, justifyContent: "flex-end" }}>
-                <input
-                  {...register("liters")}
-                  type="text"
-                  inputMode="decimal"
-                  style={{
-                    fontFamily: fontMono,
-                    fontSize: 28,
-                    fontWeight: 700,
-                    color: paper.ink,
-                    background: "transparent",
-                    border: "none",
-                    outline: "none",
-                    borderBottom: `1px solid ${paper.paperDark}`,
-                    width: "100%",
-                    padding: "2px 0",
-                    textAlign: "right",
-                  }}
-                />
-                <span style={{ fontFamily: fontMono, fontSize: 14, color: paper.inkMute, flexShrink: 0 }}>L</span>
-              </div>
-            </div>
-          </div>
-        </div>
-      ) : (
-        <div style={{ margin: "12px 14px", background: paper.paper, border: `1.5px solid ${paper.paperDark}` }}>
-          <div
-            style={{
-              display: "flex",
-              justifyContent: "space-between",
-              alignItems: "center",
-              padding: "10px 14px 6px",
-              borderBottom: `1px dashed ${paper.paperDark}`,
-            }}
-          >
-            <span style={{ fontFamily: fontMono, fontSize: 10, fontWeight: 700, letterSpacing: 2, color: paper.amber, textTransform: "uppercase" }}>
-              ● {t("form.pump")}
-            </span>
-            <span style={{ fontFamily: fontMono, fontSize: 10, color: paper.inkMute, letterSpacing: 1 }}>
-              {displayDate}
-            </span>
-          </div>
-
-          {/* Amount + Liters */}
-          <div style={{ display: "flex", alignItems: "flex-end", padding: "10px 14px 6px", gap: 0 }}>
-            <div style={{ flex: 1 }}>
-              <span style={{ ...paperLabel, fontSize: 8 }}>{t("form.amount")}</span>
-              <div style={{ display: "flex", alignItems: "baseline", gap: 4 }}>
-                <input
-                  {...register("amount")}
-                  type="text"
-                  inputMode="decimal"
-                  style={{
-                    fontFamily: fontMono,
-                    fontSize: 32,
-                    fontWeight: 700,
-                    color: paper.ink,
-                    background: "transparent",
-                    border: "none",
-                    outline: "none",
-                    borderBottom: `1px dashed ${paper.paperDark}`,
-                    width: "100%",
-                    padding: "2px 0",
-                  }}
-                />
-              </div>
-            </div>
-            <div style={{ padding: "0 12px 6px", fontFamily: fontMono, fontSize: 14, color: paper.inkMute }}>€</div>
-            <div style={{ flex: 1 }}>
-              <span style={{ ...paperLabel, fontSize: 8 }}>{t("form.liters")}</span>
-              <div style={{ display: "flex", alignItems: "baseline", gap: 4 }}>
-                <input
-                  {...register("liters")}
-                  type="text"
-                  inputMode="decimal"
-                  style={{
-                    fontFamily: fontMono,
-                    fontSize: 32,
-                    fontWeight: 700,
-                    color: paper.ink,
-                    background: "transparent",
-                    border: "none",
-                    outline: "none",
-                    borderBottom: `1px dashed ${paper.paperDark}`,
-                    width: "100%",
-                    padding: "2px 0",
-                  }}
-                />
-                <span style={{ fontFamily: fontMono, fontSize: 14, color: paper.inkMute, flexShrink: 0 }}>L</span>
-              </div>
-            </div>
-          </div>
-
-          {/* Price per liter */}
-          <div
-            style={{
-              display: "flex",
-              justifyContent: "space-between",
-              alignItems: "center",
-              padding: "8px 14px 12px",
-              borderTop: `1px dashed ${paper.paperDark}`,
-            }}
-          >
-            <span style={{ fontFamily: fontMono, fontSize: 9, letterSpacing: 2, textTransform: "uppercase", color: paper.inkMute }}>
-              {t("form.price_per_liter")}
-            </span>
-            <span style={{ fontFamily: fontMono, fontSize: 12, fontWeight: 700, color: paper.inkDim, letterSpacing: 1 }}>
-              € {pricePerLiter.toFixed(3).replace(".", ",")}
-            </span>
-          </div>
-        </div>
-      )}
-
-      {/* Full tank toggle */}
-      {mono ? (
-        <div style={{ padding: "8px 14px", display: "flex", alignItems: "flex-start", gap: 12 }}>
-          <div
-            onClick={() => setValue("full_tank", !fullTank)}
-            style={{
-              width: 22,
-              height: 22,
-              borderRadius: "50%",
-              border: `2px solid ${fullTank ? paper.green : paper.paperDark}`,
-              background: fullTank ? paper.green : "transparent",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              flexShrink: 0,
-              marginTop: 2,
-              cursor: "pointer",
-              transition: "all 0.15s",
-            }}
-          >
-            {fullTank && <div style={{ width: 8, height: 8, borderRadius: "50%", background: "#fff" }} />}
-          </div>
-          <div style={{ flex: 1, cursor: "pointer" }} onClick={() => setValue("full_tank", !fullTank)}>
-            <div style={{ fontFamily: fontSerif, fontSize: 15, fontWeight: 600, color: paper.ink }}>{t("form.full_tank")}</div>
-            <div style={{ fontFamily: fontMono, fontSize: 11, color: paper.inkMute, marginTop: 2 }}>{t("form.full_tank_hint")}</div>
-          </div>
-          {fullTank && (
-            <div style={{ textAlign: "right", flexShrink: 0, width: 88, overflow: "hidden" }}>
-              <span style={{ ...monoLabel, textAlign: "right", display: "block", marginBottom: 2 }}>{t("form.odometer")}</span>
-              <input
-                {...register("odometer")}
-                type="number"
-                placeholder="—"
-                style={{
-                  fontFamily: fontSerif,
-                  fontSize: 18,
-                  fontWeight: 700,
-                  color: paper.ink,
-                  background: "transparent",
-                  border: "none",
-                  borderBottom: `1px solid ${paper.paperDark}`,
-                  outline: "none",
-                  width: "100%",
-                  padding: "2px 0",
-                  textAlign: "right",
                 }}
               />
             </div>
-          )}
-        </div>
-      ) : (
-        <div style={{ padding: "0 14px 8px", display: "flex", alignItems: "center", gap: 10 }}>
-          <input
-            type="checkbox"
-            id="full_tank"
-            checked={!!fullTank}
-            onChange={(e) => setValue("full_tank", e.target.checked)}
-            style={{ width: 16, height: 16, cursor: "pointer", accentColor: paper.green }}
-          />
-          <label
-            htmlFor="full_tank"
-            style={{ fontFamily: fontMono, fontSize: 10, fontWeight: 700, letterSpacing: 2, textTransform: "uppercase", color: paper.inkDim, cursor: "pointer" }}
-          >
-            {t("form.full_tank")}
-          </label>
-          <span style={{ fontFamily: fontMono, fontSize: 9, color: paper.inkMute, letterSpacing: 1 }}>
-            — {t("form.full_tank_hint")}
-          </span>
-        </div>
-      )}
-
-      {/* Settled outside toggle */}
-      {mono ? (
-        <div
-          style={{ padding: "8px 14px 12px", display: "flex", alignItems: "flex-start", gap: 12, cursor: "pointer" }}
-          onClick={() => setValue("settled_outside", !settledOutside)}
-        >
-          <div
-            style={{
-              width: 22,
-              height: 22,
-              borderRadius: "50%",
-              border: `2px solid ${settledOutside ? paper.inkMute : paper.paperDark}`,
-              background: settledOutside ? paper.inkMute : "transparent",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              flexShrink: 0,
-              marginTop: 2,
-              transition: "all 0.15s",
-            }}
-          >
-            {settledOutside && <div style={{ width: 8, height: 8, borderRadius: "50%", background: "#fff" }} />}
           </div>
-          <div>
-            <div style={{ fontFamily: fontSerif, fontSize: 15, fontWeight: 600, color: paper.ink }}>{t("form.settled_outside")}</div>
-            <div style={{ fontFamily: fontMono, fontSize: 11, color: paper.inkMute, marginTop: 2 }}>{t("form.settled_outside_hint")}</div>
-          </div>
-        </div>
-      ) : (
-        <div style={{ padding: "0 14px 8px", display: "flex", alignItems: "center", gap: 10 }}>
-          <input
-            type="checkbox"
-            id="fuel_settled_outside"
-            checked={!!settledOutside}
-            onChange={(e) => setValue("settled_outside", e.target.checked)}
-            style={{ width: 16, height: 16, cursor: "pointer", accentColor: paper.inkMute }}
-          />
-          <label
-            htmlFor="fuel_settled_outside"
-            style={{ fontFamily: fontMono, fontSize: 10, fontWeight: 700, letterSpacing: 2, textTransform: "uppercase", color: paper.inkDim, cursor: "pointer" }}
-          >
-            {t("form.settled_outside")}
-          </label>
-          <span style={{ fontFamily: fontMono, fontSize: 9, color: paper.inkMute, letterSpacing: 1 }}>
-            — {t("form.settled_outside_hint")}
-          </span>
-        </div>
-      )}
+        )}
 
-      {/* Odometer — only shown for full tank (paper only; mono shows inline with toggle) */}
-      {fullTank && !mono && (
-        <div style={{ padding: "0 14px 8px" }}>
-          <span style={lbl}>{t("form.odometer")}</span>
-          <div
-            style={
-              mono
-                ? { border: `1px solid ${paper.paperDark}`, borderRadius: "var(--radius-sm, 6px)", padding: "8px 14px" }
-                : { ...dashedBox, padding: "8px 14px" }
-            }
-          >
-            <input
-              {...register("odometer")}
-              type="number"
-              placeholder="—"
+        {/* Fuel station location */}
+        <div style={{ padding: "4px 14px 4px" }}>
+          <span style={{ ...lbl, marginBottom: 6 }}>{t("form.fuel_station")}</span>
+          <Controller
+            name="location"
+            control={control}
+            render={({ field: addrField }) => (
+              <Controller
+                name="gps_coords"
+                control={control}
+                render={({ field: coordsField }) => (
+                  <LocationPicker
+                    address={addrField.value ?? null}
+                    coords={coordsField.value ?? null}
+                    onAddressChange={(v) => addrField.onChange(v ?? null)}
+                    onCoordsChange={(v) => coordsField.onChange(v ?? null)}
+                    autoGps={isAddMode}
+                  />
+                )}
+              />
+            )}
+          />
+        </div>
+
+        {/* Receipt */}
+        <div style={{ padding: "8px 14px" }}>
+          {!mono && <span style={lbl}>{t("form.receipt")}</span>}
+          <Controller
+            name="receipt"
+            control={control}
+            render={({ field }) => (
+              <ReceiptUpload value={field.value ?? null} onChange={field.onChange} />
+            )}
+          />
+        </div>
+
+        {onDelete && (
+          <div style={{ padding: "0 14px 24px" }}>
+            <button
+              type="button"
+              onClick={onDelete}
               style={{
-                fontFamily: fontSerif,
-                fontSize: 20,
-                fontWeight: 600,
-                color: paper.ink,
-                background: "transparent",
-                border: "none",
-                outline: "none",
                 width: "100%",
-                padding: 0,
+                padding: "10px",
+                background: "transparent",
+                border: mono ? `1px solid ${paper.accent}` : `1.5px solid ${paper.accent}`,
+                borderRadius: mono ? "var(--radius-pill, 999px)" : 0,
+                color: paper.accent,
+                fontFamily: mono ? fontSerif : fontMono,
+                fontSize: mono ? 13 : 10,
+                fontWeight: 700,
+                letterSpacing: mono ? 0 : 2,
+                textTransform: mono ? "none" : "uppercase",
+                cursor: "pointer",
               }}
-            />
+            >
+              {t("action.delete")}
+            </button>
           </div>
-        </div>
-      )}
-
-      {/* Fuel station location */}
-      <div style={{ padding: "4px 14px 4px" }}>
-        <span style={{ ...lbl, marginBottom: 6 }}>{t("form.fuel_station")}</span>
-        <Controller
-          name="location"
-          control={control}
-          render={({ field: addrField }) => (
-            <Controller
-              name="gps_coords"
-              control={control}
-              render={({ field: coordsField }) => (
-                <LocationPicker
-                  address={addrField.value ?? null}
-                  coords={coordsField.value ?? null}
-                  onAddressChange={(v) => addrField.onChange(v ?? null)}
-                  onCoordsChange={(v) => coordsField.onChange(v ?? null)}
-                  autoGps={isAddMode}
-                />
-              )}
-            />
-          )}
-        />
-      </div>
-
-      {/* Receipt */}
-      <div style={{ padding: "8px 14px" }}>
-        {!mono && <span style={lbl}>{t("form.receipt")}</span>}
-        <Controller
-          name="receipt"
-          control={control}
-          render={({ field }) => (
-            <ReceiptUpload value={field.value ?? null} onChange={field.onChange} />
-          )}
-        />
-      </div>
-
-      {onDelete && (
-        <div style={{ padding: "0 14px 24px" }}>
-          <button
-            type="button"
-            onClick={onDelete}
-            style={{
-              width: "100%",
-              padding: "10px",
-              background: "transparent",
-              border: mono ? `1px solid ${paper.accent}` : `1.5px solid ${paper.accent}`,
-              borderRadius: mono ? "var(--radius-pill, 999px)" : 0,
-              color: paper.accent,
-              fontFamily: mono ? fontSerif : fontMono,
-              fontSize: mono ? 13 : 10,
-              fontWeight: 700,
-              letterSpacing: mono ? 0 : 2,
-              textTransform: mono ? "none" : "uppercase",
-              cursor: "pointer",
-            }}
-          >
-            {t("action.delete")}
-          </button>
-        </div>
-      )}
+        )}
+      </fieldset>
       <div style={{ height: 32 }} />
     </form>
   );

--- a/app/fuel/page.tsx
+++ b/app/fuel/page.tsx
@@ -7,8 +7,15 @@ import { Fab } from "@/components/fab";
 import { ListFilterBar } from "@/components/list-filter-bar";
 import { ModalSheet } from "@/components/modal-sheet";
 import { FuelForm } from "./fuel-form";
-import { useFuelFillups, useCreateFuelFillup, useUpdateFuelFillup, useDeleteFuelFillup } from "@/hooks/use-fuel-fillups";
+import {
+  useFuelFillups,
+  useCreateFuelFillup,
+  useUpdateFuelFillup,
+  useDeleteFuelFillup,
+} from "@/hooks/use-fuel-fillups";
 import { useMe } from "@/hooks/use-me";
+import { useCars } from "@/hooks/use-vehicles";
+import { canEdit } from "@/lib/permissions";
 import { useQueryParam } from "@/hooks/use-query-param";
 import { useEditModal } from "@/hooks/use-edit-modal";
 import { paper, fontMono, fmtYearMonth } from "@/lib/paper-theme";
@@ -20,6 +27,7 @@ function FuelContent() {
   const t = useT();
   const { data: fillups = [], isLoading } = useFuelFillups();
   const { data: me } = useMe();
+  const { data: carList = [] } = useCars();
   const createF = useCreateFuelFillup();
   const updateF = useUpdateFuelFillup();
   const deleteF = useDeleteFuelFillup();
@@ -30,7 +38,20 @@ function FuelContent() {
 
   const { adding, editingId, modalClosed, openAdd, openEdit, closeModal } = useEditModal();
 
-  const editing = !isLoading && editingId ? (fillups.find((f) => f.id === editingId) ?? null) : null;
+  const editing =
+    !isLoading && editingId ? (fillups.find((f) => f.id === editingId) ?? null) : null;
+
+  const editingReadOnly =
+    editing != null &&
+    !(
+      me?.personId != null &&
+      canEdit(
+        me.personId,
+        me.isAdmin,
+        editing,
+        carList.find((c) => c.id === editing.car_id)?.owner_person_id ?? null
+      )
+    );
 
   const isMine = mineParam === "true";
   const isOthers = mineParam === "false";
@@ -38,7 +59,9 @@ function FuelContent() {
   const cars = Array.from(
     new Set(fillups.map((f) => f.car_short).filter((s): s is string => !!s))
   ).sort();
-  const years = Array.from(new Set(fillups.map((f) => f.date.slice(0, 4)))).sort().reverse();
+  const years = Array.from(new Set(fillups.map((f) => f.date.slice(0, 4))))
+    .sort()
+    .reverse();
 
   const visible = fillups
     .filter((f) => {
@@ -53,7 +76,15 @@ function FuelContent() {
     return (
       <div style={{ background: paper.paperDeep, minHeight: "100dvh" }}>
         <PageHeader title={t("page.fuel")} />
-        <div style={{ padding: "32px 20px", fontFamily: fontMono, fontSize: 11, color: paper.inkDim, letterSpacing: 1 }}>
+        <div
+          style={{
+            padding: "32px 20px",
+            fontFamily: fontMono,
+            fontSize: 11,
+            color: paper.inkDim,
+            letterSpacing: 1,
+          }}
+        >
           {t("state.loading")}
         </div>
       </div>
@@ -85,7 +116,16 @@ function FuelContent() {
       />
 
       {visible.length === 0 && (
-        <div style={{ padding: "32px 20px", textAlign: "center", fontFamily: fontMono, fontSize: 11, color: paper.inkDim, letterSpacing: 1 }}>
+        <div
+          style={{
+            padding: "32px 20px",
+            textAlign: "center",
+            fontFamily: fontMono,
+            fontSize: 11,
+            color: paper.inkDim,
+            letterSpacing: 1,
+          }}
+        >
           {t("state.empty_fuel")}
         </div>
       )}
@@ -94,7 +134,10 @@ function FuelContent() {
         <FuelForm
           onSubmit={(data) =>
             createF.mutate(data as any, {
-              onSuccess: () => { closeModal(); toast.success(t("toast.saved")); },
+              onSuccess: () => {
+                closeModal();
+                toast.success(t("toast.saved"));
+              },
               onError: (e) => toast.error(e.message),
             })
           }
@@ -106,18 +149,28 @@ function FuelContent() {
         {editing && (
           <FuelForm
             defaultValues={editing}
+            readOnly={editingReadOnly}
             onSubmit={(data) =>
               updateF.mutate({ id: editing.id, ...data } as any, {
-                onSuccess: () => { closeModal(); toast.success(t("toast.saved")); },
+                onSuccess: () => {
+                  closeModal();
+                  toast.success(t("toast.saved"));
+                },
                 onError: (e) => toast.error(e.message),
               })
             }
             onCancel={closeModal}
-            onDelete={() =>
-              deleteF.mutate(editing.id, {
-                onSuccess: () => { closeModal(); toast.success(t("toast.saved")); },
-                onError: (e) => toast.error(e.message),
-              })
+            onDelete={
+              editingReadOnly
+                ? undefined
+                : () =>
+                    deleteF.mutate(editing.id, {
+                      onSuccess: () => {
+                        closeModal();
+                        toast.success(t("toast.saved"));
+                      },
+                      onError: (e) => toast.error(e.message),
+                    })
             }
           />
         )}

--- a/app/trips/page.tsx
+++ b/app/trips/page.tsx
@@ -9,6 +9,8 @@ import { ModalSheet } from "@/components/modal-sheet";
 import { TripForm } from "./trip-form";
 import { useTrips, useCreateTrip, useUpdateTrip, useDeleteTrip } from "@/hooks/use-trips";
 import { useMe } from "@/hooks/use-me";
+import { useCars } from "@/hooks/use-vehicles";
+import { canEdit } from "@/lib/permissions";
 import { useQueryParam } from "@/hooks/use-query-param";
 import { useEditModal } from "@/hooks/use-edit-modal";
 import { paper, fontMono, fmtYearMonth } from "@/lib/paper-theme";
@@ -20,6 +22,7 @@ function TripsContent() {
   const t = useT();
   const { data: trips = [], isLoading } = useTrips();
   const { data: me } = useMe();
+  const { data: carList = [] } = useCars();
   const createTrip = useCreateTrip();
   const updateTrip = useUpdateTrip();
   const deleteTrip = useDeleteTrip();
@@ -30,7 +33,20 @@ function TripsContent() {
 
   const { adding, editingId, modalClosed, openAdd, openEdit, closeModal } = useEditModal();
 
-  const editing = !isLoading && editingId ? (trips.find((tr) => tr.id === editingId) ?? null) : null;
+  const editing =
+    !isLoading && editingId ? (trips.find((tr) => tr.id === editingId) ?? null) : null;
+
+  const editingReadOnly =
+    editing != null &&
+    !(
+      me?.personId != null &&
+      canEdit(
+        me.personId,
+        me.isAdmin,
+        editing,
+        carList.find((c) => c.id === editing.car_id)?.owner_person_id ?? null
+      )
+    );
 
   const isMine = mineParam === "true";
   const isOthers = mineParam === "false";
@@ -38,7 +54,9 @@ function TripsContent() {
   const cars = Array.from(
     new Set(trips.map((tr) => tr.car_short).filter((s): s is string => !!s))
   ).sort();
-  const years = Array.from(new Set(trips.map((tr) => tr.date.slice(0, 4)))).sort().reverse();
+  const years = Array.from(new Set(trips.map((tr) => tr.date.slice(0, 4))))
+    .sort()
+    .reverse();
 
   const visible = trips
     .filter((tr) => {
@@ -53,7 +71,15 @@ function TripsContent() {
     return (
       <div style={{ background: paper.paperDeep, minHeight: "100dvh" }}>
         <PageHeader title={t("page.trips")} />
-        <div style={{ padding: "32px 20px", fontFamily: fontMono, fontSize: 11, color: paper.inkDim, letterSpacing: 1 }}>
+        <div
+          style={{
+            padding: "32px 20px",
+            fontFamily: fontMono,
+            fontSize: 11,
+            color: paper.inkDim,
+            letterSpacing: 1,
+          }}
+        >
           {t("state.loading")}
         </div>
       </div>
@@ -81,11 +107,22 @@ function TripsContent() {
         getGroupLabel={(key) => fmtYearMonth(key + "-01")}
         getGroupTotal={(items) => items.reduce((s, trip) => s + trip.km, 0)}
         totalSuffix="km"
-        renderItem={(trip) => <TripCard key={trip.id} trip={trip} onClick={() => openEdit(trip.id)} />}
+        renderItem={(trip) => (
+          <TripCard key={trip.id} trip={trip} onClick={() => openEdit(trip.id)} />
+        )}
       />
 
       {visible.length === 0 && (
-        <div style={{ padding: "32px 20px", textAlign: "center", fontFamily: fontMono, fontSize: 11, color: paper.inkDim, letterSpacing: 1 }}>
+        <div
+          style={{
+            padding: "32px 20px",
+            textAlign: "center",
+            fontFamily: fontMono,
+            fontSize: 11,
+            color: paper.inkDim,
+            letterSpacing: 1,
+          }}
+        >
           {t("state.empty_trips")}
         </div>
       )}
@@ -94,7 +131,10 @@ function TripsContent() {
         <TripForm
           onSubmit={(data) =>
             createTrip.mutate(data as any, {
-              onSuccess: () => { closeModal(); toast.success(t("toast.trip_saved")); },
+              onSuccess: () => {
+                closeModal();
+                toast.success(t("toast.trip_saved"));
+              },
               onError: (e) => toast.error(e.message),
             })
           }
@@ -106,18 +146,28 @@ function TripsContent() {
         {editing && (
           <TripForm
             defaultValues={editing}
+            readOnly={editingReadOnly}
             onSubmit={(data) =>
               updateTrip.mutate({ id: editing.id, ...data } as any, {
-                onSuccess: () => { closeModal(); toast.success(t("toast.saved")); },
+                onSuccess: () => {
+                  closeModal();
+                  toast.success(t("toast.saved"));
+                },
                 onError: (e) => toast.error(e.message),
               })
             }
             onCancel={closeModal}
-            onDelete={() =>
-              deleteTrip.mutate(editing.id, {
-                onSuccess: () => { closeModal(); toast.success(t("toast.trip_deleted")); },
-                onError: (e) => toast.error(e.message),
-              })
+            onDelete={
+              editingReadOnly
+                ? undefined
+                : () =>
+                    deleteTrip.mutate(editing.id, {
+                      onSuccess: () => {
+                        closeModal();
+                        toast.success(t("toast.trip_deleted"));
+                      },
+                      onError: (e) => toast.error(e.message),
+                    })
             }
           />
         )}

--- a/app/trips/trip-form.tsx
+++ b/app/trips/trip-form.tsx
@@ -55,7 +55,16 @@ interface Props {
   onSubmit: (data: FormData) => void;
   onCancel: () => void;
   onDelete?: () => void;
+  /** When true the form is shown read-only: inputs disabled, save hidden. */
+  readOnly?: boolean;
 }
+
+const fieldsetReset: React.CSSProperties = {
+  border: 0,
+  margin: 0,
+  padding: 0,
+  minInlineSize: "auto",
+};
 
 const paperLabel: React.CSSProperties = {
   fontFamily: fontMono,
@@ -90,7 +99,7 @@ const bigInput: React.CSSProperties = {
   padding: 0,
 };
 
-export function TripForm({ defaultValues, onSubmit, onCancel, onDelete }: Props) {
+export function TripForm({ defaultValues, onSubmit, onCancel, onDelete, readOnly = false }: Props) {
   const { data: people = [] } = usePeople();
   const { data: cars = [] } = useCars();
   const { data: me } = useMe();
@@ -173,6 +182,10 @@ export function TripForm({ defaultValues, onSubmit, onCancel, onDelete }: Props)
   return (
     <form
       onSubmit={(e) => {
+        if (readOnly) {
+          e.preventDefault();
+          return;
+        }
         if (!online) {
           e.preventDefault();
           toast.error(t("offline.mutation_blocked"));
@@ -238,459 +251,561 @@ export function TripForm({ defaultValues, onSubmit, onCancel, onDelete }: Props)
           {!mono && "↦ "}
           {t("form.log_trip")}
         </div>
-        <div style={{ position: "relative" }} className="submit-wrap">
-          <button
-            type="submit"
-            disabled={!canSubmit}
-            style={{
-              fontFamily: mono ? fontSerif : fontMono,
-              fontSize: mono ? 13 : 9,
-              fontWeight: 700,
-              letterSpacing: mono ? 0 : 2,
-              textTransform: mono ? "none" : "uppercase",
-              background: paper.accent,
-              color: "#fff",
-              border: "none",
-              borderRadius: mono ? "var(--radius-pill, 999px)" : 0,
-              padding: mono ? "8px 18px" : "8px 14px",
-              cursor: canSubmit && online ? "pointer" : "default",
-              opacity: canSubmit && online ? 1 : 0.35,
-            }}
-          >
-            {mono ? t("action.save") : t("action.save_trip")}
-          </button>
-          {!canSubmit && (
-            <div
-              className="submit-tip"
-              style={{
-                position: "absolute",
-                right: 0,
-                top: "calc(100% + 6px)",
-                background: paper.ink,
-                color: paper.paper,
-                fontFamily: fontMono,
-                fontSize: 9,
-                letterSpacing: 1,
-                padding: "5px 8px",
-                whiteSpace: "pre-line",
-                pointerEvents: "none",
-                opacity: 0,
-                transition: "opacity 0.15s",
-                zIndex: 20,
-              }}
-            >
-              {missingLabel}
-            </div>
-          )}
-        </div>
-        <style>{`.submit-wrap:hover .submit-tip, .submit-wrap:focus-within .submit-tip { opacity: 1 !important; }`}</style>
-      </div>
-
-      {/* Car tabs */}
-      <Controller
-        name="car_id"
-        control={control}
-        render={({ field }) => (
-          <CarToggle cars={cars} value={field.value} onChange={field.onChange} />
-        )}
-      />
-
-      {/* Driver + Date row */}
-      <div style={{ display: "flex", borderBottom: rowBorder }}>
-        <div style={{ flex: 1, padding: "10px 14px", borderRight: rowBorder }}>
-          {!mono && <span style={lbl}>{t("form.driver")}</span>}
-          {isAdmin ? (
-            <>
-              {mono && <span style={lbl}>{t("form.driver")}</span>}
-              <select
-                value={personId ?? ""}
-                onChange={(e) => setValue("person_id", Number(e.target.value))}
-                style={{
-                  fontFamily: fontSerif,
-                  fontSize: mono ? 19 : 17,
-                  fontWeight: mono ? 700 : 600,
-                  color: paper.ink,
-                  background: "transparent",
-                  border: "none",
-                  outline: "none",
-                  width: "100%",
-                  padding: 0,
-                  cursor: "pointer",
-                }}
-              >
-                <option value="" disabled>
-                  {t("form.select_person_placeholder")}
-                </option>
-                {people
-                  .filter((p) => p.active)
-                  .map((p) => (
-                    <option key={p.id} value={p.id}>
-                      {fullNameOf(p)}
-                    </option>
-                  ))}
-              </select>
-            </>
-          ) : mono ? (
-            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-              <span style={{ fontFamily: fontSerif, fontSize: 19, fontWeight: 700, color: paper.ink, lineHeight: 1.15 }}>
-                {person ? fullNameOf(person) : me?.shortName ?? "—"}
-              </span>
-              <Lock size={14} color={paper.inkMute} strokeWidth={1.75} style={{ flexShrink: 0 }} />
-            </div>
-          ) : (
-            <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-              <span
-                style={{ fontFamily: fontSerif, fontSize: 17, fontWeight: 600, color: paper.ink }}
-              >
-                {person ? fullNameOf(person) : me?.shortName ?? "—"}
-              </span>
-              {(person?.discount ?? 0) > 0 && (
-                <span style={{ color: paper.accent, fontSize: 13 }}>★</span>
-              )}
-              <span style={{ fontSize: 13 }}>🔒</span>
-            </div>
-          )}
-        </div>
-        <div style={{ flex: 1, padding: "10px 14px" }}>
-          {mono ? (
-            <div style={{ position: "relative" }}>
-              <span style={{ ...monoLabel, marginBottom: 2 }}>{t("form.date")}</span>
-              <div style={{ fontFamily: fontSerif, fontSize: 17, fontWeight: 700, color: paper.ink, pointerEvents: "none" }}>
-                {date ? fmtDate(date, locale) : "—"}
-              </div>
-              <input
-                {...register("date")}
-                type="date"
-                style={{ position: "absolute", inset: 0, opacity: 0.001, cursor: "pointer", width: "100%", height: "100%" }}
-              />
-            </div>
-          ) : (
-            <>
-              <span style={lbl}>{t("form.date")}</span>
-              <input
-                {...register("date")}
-                type="date"
-                style={{
-                  fontFamily: fontSerif,
-                  fontSize: 17,
-                  fontWeight: 600,
-                  color: paper.ink,
-                  background: "transparent",
-                  border: "none",
-                  outline: "none",
-                  width: "100%",
-                  padding: 0,
-                  cursor: "pointer",
-                }}
-              />
-            </>
-          )}
-        </div>
-      </div>
-      {!isAdmin && !mono && (
-        <div
-          style={{
-            padding: "6px 14px",
-            fontFamily: fontMono,
-            fontSize: 9,
-            color: paper.amber,
-            letterSpacing: 1,
-          }}
-        >
-          🔒 {t("form.driver_locked_hint")}
-        </div>
-      )}
-
-      {/* Odometer block */}
-      {mono ? (
-        <div style={{ padding: "12px 14px 8px" }}>
-          <span style={{ fontFamily: fontSerif, fontSize: 13, fontWeight: 600, color: paper.inkMute, display: "block", marginBottom: 8 }}>
-            {t("form.odometer_section")}
-          </span>
-          <div style={{ display: "flex", alignItems: "flex-end", gap: 8 }}>
-            <div style={{ flex: 1 }}>
-              <span style={{ ...monoLabel, marginBottom: 2 }}>{t("form.start_km")}</span>
-              <input
-                {...startReg}
-                type="number"
-                style={{ ...bigInput, fontSize: 26 }}
-                onBlur={(e) => {
-                  startReg.onBlur(e);
-                  const startVal = Number(e.target.value);
-                  const current = getValues("end_odometer");
-                  if (!current || Number(current) === 0) setValue("end_odometer", startVal);
-                }}
-              />
-            </div>
-            <div style={{ textAlign: "center", flexShrink: 0, padding: "0 6px 8px" }}>
-              <div style={{ fontFamily: fontMono, fontSize: 11.5, color: paper.inkMute }}>
-                {km > 0 ? `+${km} km` : "—"}
-              </div>
-            </div>
-            <div style={{ flex: 1, textAlign: "right" }}>
-              <span style={{ ...monoLabel, marginBottom: 2, textAlign: "right", display: "block" }}>{t("form.end_km")}</span>
-              <input
-                {...register("end_odometer")}
-                type="number"
-                style={{ ...bigInput, fontSize: 26, textAlign: "right" }}
-              />
-            </div>
-          </div>
-          {errors.end_odometer && (
-            <div style={{ fontFamily: fontMono, fontSize: 11, color: paper.accent, marginTop: 4 }}>
-              {errors.end_odometer.message}
-            </div>
-          )}
-          {!online && isAddMode && (
-            <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.amber, marginTop: 4 }}>
-              {t("form.offline_start_km_hint")}
-            </div>
-          )}
-        </div>
-      ) : (
-        <div
-          style={{
-            margin: "12px 14px",
-            background: paper.paper,
-            border: `1.5px solid ${paper.paperDark}`,
-          }}
-        >
+        {readOnly ? (
           <div
             style={{
-              textAlign: "center",
-              padding: "8px 0 4px",
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
               fontFamily: fontMono,
               fontSize: 9,
               fontWeight: 700,
-              letterSpacing: 3,
-              color: paper.inkMute,
+              letterSpacing: 2,
               textTransform: "uppercase",
-              borderBottom: `1px dashed ${paper.paperDark}`,
+              color: paper.inkMute,
             }}
           >
-            @ {t("form.odometer_section")}
+            <Lock size={13} color={paper.inkMute} strokeWidth={1.75} />
+            {t("form.read_only")}
           </div>
-          <div style={{ display: "flex", alignItems: "center", padding: "12px 14px", gap: 8 }}>
-            <div style={{ flex: 1 }}>
-              <span style={{ ...paperLabel, fontSize: 8 }}>{t("form.start_km")}</span>
-              <input
-                {...startReg}
-                type="number"
-                style={{ ...bigInput, fontSize: 20 }}
-                onBlur={(e) => {
-                  startReg.onBlur(e);
-                  const startVal = Number(e.target.value);
-                  const current = getValues("end_odometer");
-                  if (!current || Number(current) === 0) setValue("end_odometer", startVal);
+        ) : (
+          <div style={{ position: "relative" }} className="submit-wrap">
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              style={{
+                fontFamily: mono ? fontSerif : fontMono,
+                fontSize: mono ? 13 : 9,
+                fontWeight: 700,
+                letterSpacing: mono ? 0 : 2,
+                textTransform: mono ? "none" : "uppercase",
+                background: paper.accent,
+                color: "#fff",
+                border: "none",
+                borderRadius: mono ? "var(--radius-pill, 999px)" : 0,
+                padding: mono ? "8px 18px" : "8px 14px",
+                cursor: canSubmit && online ? "pointer" : "default",
+                opacity: canSubmit && online ? 1 : 0.35,
+              }}
+            >
+              {mono ? t("action.save") : t("action.save_trip")}
+            </button>
+            {!canSubmit && (
+              <div
+                className="submit-tip"
+                style={{
+                  position: "absolute",
+                  right: 0,
+                  top: "calc(100% + 6px)",
+                  background: paper.ink,
+                  color: paper.paper,
+                  fontFamily: fontMono,
+                  fontSize: 9,
+                  letterSpacing: 1,
+                  padding: "5px 8px",
+                  whiteSpace: "pre-line",
+                  pointerEvents: "none",
+                  opacity: 0,
+                  transition: "opacity 0.15s",
+                  zIndex: 20,
                 }}
-              />
-              {!online && isAddMode && (
+              >
+                {missingLabel}
+              </div>
+            )}
+          </div>
+        )}
+        <style>{`.submit-wrap:hover .submit-tip, .submit-wrap:focus-within .submit-tip { opacity: 1 !important; }`}</style>
+      </div>
+
+      <fieldset disabled={readOnly} style={fieldsetReset}>
+        {readOnly && (
+          <div
+            style={{
+              padding: "8px 14px",
+              fontFamily: fontMono,
+              fontSize: 9,
+              fontWeight: 700,
+              letterSpacing: 1,
+              color: paper.amber,
+              borderBottom: rowBorder,
+            }}
+          >
+            🔒 {t("form.read_only_hint")}
+          </div>
+        )}
+
+        {/* Car tabs */}
+        <Controller
+          name="car_id"
+          control={control}
+          render={({ field }) => (
+            <CarToggle cars={cars} value={field.value} onChange={field.onChange} />
+          )}
+        />
+
+        {/* Driver + Date row */}
+        <div style={{ display: "flex", borderBottom: rowBorder }}>
+          <div style={{ flex: 1, padding: "10px 14px", borderRight: rowBorder }}>
+            {!mono && <span style={lbl}>{t("form.driver")}</span>}
+            {isAdmin ? (
+              <>
+                {mono && <span style={lbl}>{t("form.driver")}</span>}
+                <select
+                  value={personId ?? ""}
+                  onChange={(e) => setValue("person_id", Number(e.target.value))}
+                  style={{
+                    fontFamily: fontSerif,
+                    fontSize: mono ? 19 : 17,
+                    fontWeight: mono ? 700 : 600,
+                    color: paper.ink,
+                    background: "transparent",
+                    border: "none",
+                    outline: "none",
+                    width: "100%",
+                    padding: 0,
+                    cursor: "pointer",
+                  }}
+                >
+                  <option value="" disabled>
+                    {t("form.select_person_placeholder")}
+                  </option>
+                  {people
+                    .filter((p) => p.active)
+                    .map((p) => (
+                      <option key={p.id} value={p.id}>
+                        {fullNameOf(p)}
+                      </option>
+                    ))}
+                </select>
+              </>
+            ) : mono ? (
+              <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                <span
+                  style={{
+                    fontFamily: fontSerif,
+                    fontSize: 19,
+                    fontWeight: 700,
+                    color: paper.ink,
+                    lineHeight: 1.15,
+                  }}
+                >
+                  {person ? fullNameOf(person) : (me?.shortName ?? "—")}
+                </span>
+                <Lock
+                  size={14}
+                  color={paper.inkMute}
+                  strokeWidth={1.75}
+                  style={{ flexShrink: 0 }}
+                />
+              </div>
+            ) : (
+              <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                <span
+                  style={{ fontFamily: fontSerif, fontSize: 17, fontWeight: 600, color: paper.ink }}
+                >
+                  {person ? fullNameOf(person) : (me?.shortName ?? "—")}
+                </span>
+                {(person?.discount ?? 0) > 0 && (
+                  <span style={{ color: paper.accent, fontSize: 13 }}>★</span>
+                )}
+                <span style={{ fontSize: 13 }}>🔒</span>
+              </div>
+            )}
+          </div>
+          <div style={{ flex: 1, padding: "10px 14px" }}>
+            {mono ? (
+              <div style={{ position: "relative" }}>
+                <span style={{ ...monoLabel, marginBottom: 2 }}>{t("form.date")}</span>
+                <div
+                  style={{
+                    fontFamily: fontSerif,
+                    fontSize: 17,
+                    fontWeight: 700,
+                    color: paper.ink,
+                    pointerEvents: "none",
+                  }}
+                >
+                  {date ? fmtDate(date, locale) : "—"}
+                </div>
+                <input
+                  {...register("date")}
+                  type="date"
+                  style={{
+                    position: "absolute",
+                    inset: 0,
+                    opacity: 0.001,
+                    cursor: "pointer",
+                    width: "100%",
+                    height: "100%",
+                  }}
+                />
+              </div>
+            ) : (
+              <>
+                <span style={lbl}>{t("form.date")}</span>
+                <input
+                  {...register("date")}
+                  type="date"
+                  style={{
+                    fontFamily: fontSerif,
+                    fontSize: 17,
+                    fontWeight: 600,
+                    color: paper.ink,
+                    background: "transparent",
+                    border: "none",
+                    outline: "none",
+                    width: "100%",
+                    padding: 0,
+                    cursor: "pointer",
+                  }}
+                />
+              </>
+            )}
+          </div>
+        </div>
+        {!isAdmin && !mono && (
+          <div
+            style={{
+              padding: "6px 14px",
+              fontFamily: fontMono,
+              fontSize: 9,
+              color: paper.amber,
+              letterSpacing: 1,
+            }}
+          >
+            🔒 {t("form.driver_locked_hint")}
+          </div>
+        )}
+
+        {/* Odometer block */}
+        {mono ? (
+          <div style={{ padding: "12px 14px 8px" }}>
+            <span
+              style={{
+                fontFamily: fontSerif,
+                fontSize: 13,
+                fontWeight: 600,
+                color: paper.inkMute,
+                display: "block",
+                marginBottom: 8,
+              }}
+            >
+              {t("form.odometer_section")}
+            </span>
+            <div style={{ display: "flex", alignItems: "flex-end", gap: 8 }}>
+              <div style={{ flex: 1 }}>
+                <span style={{ ...monoLabel, marginBottom: 2 }}>{t("form.start_km")}</span>
+                <input
+                  {...startReg}
+                  type="number"
+                  style={{ ...bigInput, fontSize: 26 }}
+                  onBlur={(e) => {
+                    startReg.onBlur(e);
+                    const startVal = Number(e.target.value);
+                    const current = getValues("end_odometer");
+                    if (!current || Number(current) === 0) setValue("end_odometer", startVal);
+                  }}
+                />
+              </div>
+              <div style={{ textAlign: "center", flexShrink: 0, padding: "0 6px 8px" }}>
+                <div style={{ fontFamily: fontMono, fontSize: 11.5, color: paper.inkMute }}>
+                  {km > 0 ? `+${km} km` : "—"}
+                </div>
+              </div>
+              <div style={{ flex: 1, textAlign: "right" }}>
+                <span
+                  style={{ ...monoLabel, marginBottom: 2, textAlign: "right", display: "block" }}
+                >
+                  {t("form.end_km")}
+                </span>
+                <input
+                  {...register("end_odometer")}
+                  type="number"
+                  style={{ ...bigInput, fontSize: 26, textAlign: "right" }}
+                />
+              </div>
+            </div>
+            {errors.end_odometer && (
+              <div
+                style={{ fontFamily: fontMono, fontSize: 11, color: paper.accent, marginTop: 4 }}
+              >
+                {errors.end_odometer.message}
+              </div>
+            )}
+            {!online && isAddMode && (
+              <div style={{ fontFamily: fontMono, fontSize: 10, color: paper.amber, marginTop: 4 }}>
+                {t("form.offline_start_km_hint")}
+              </div>
+            )}
+          </div>
+        ) : (
+          <div
+            style={{
+              margin: "12px 14px",
+              background: paper.paper,
+              border: `1.5px solid ${paper.paperDark}`,
+            }}
+          >
+            <div
+              style={{
+                textAlign: "center",
+                padding: "8px 0 4px",
+                fontFamily: fontMono,
+                fontSize: 9,
+                fontWeight: 700,
+                letterSpacing: 3,
+                color: paper.inkMute,
+                textTransform: "uppercase",
+                borderBottom: `1px dashed ${paper.paperDark}`,
+              }}
+            >
+              @ {t("form.odometer_section")}
+            </div>
+            <div style={{ display: "flex", alignItems: "center", padding: "12px 14px", gap: 8 }}>
+              <div style={{ flex: 1 }}>
+                <span style={{ ...paperLabel, fontSize: 8 }}>{t("form.start_km")}</span>
+                <input
+                  {...startReg}
+                  type="number"
+                  style={{ ...bigInput, fontSize: 20 }}
+                  onBlur={(e) => {
+                    startReg.onBlur(e);
+                    const startVal = Number(e.target.value);
+                    const current = getValues("end_odometer");
+                    if (!current || Number(current) === 0) setValue("end_odometer", startVal);
+                  }}
+                />
+                {!online && isAddMode && (
+                  <div
+                    style={{
+                      fontFamily: fontMono,
+                      fontSize: 8,
+                      color: paper.amber,
+                      letterSpacing: 1,
+                      marginTop: 2,
+                      textTransform: "uppercase",
+                    }}
+                  >
+                    {t("form.offline_start_km_hint")}
+                  </div>
+                )}
+              </div>
+              <div style={{ textAlign: "center", flexShrink: 0, padding: "0 8px" }}>
                 <div
                   style={{
                     fontFamily: fontMono,
-                    fontSize: 8,
-                    color: paper.amber,
+                    fontSize: 10,
+                    color: paper.inkMute,
                     letterSpacing: 1,
-                    marginTop: 2,
-                    textTransform: "uppercase",
+                    marginBottom: 2,
                   }}
                 >
-                  {t("form.offline_start_km_hint")}
+                  {km > 0 ? `${km} KM` : "—"}
                 </div>
-              )}
-            </div>
-            <div style={{ textAlign: "center", flexShrink: 0, padding: "0 8px" }}>
-              <div
-                style={{
-                  fontFamily: fontMono,
-                  fontSize: 10,
-                  color: paper.inkMute,
-                  letterSpacing: 1,
-                  marginBottom: 2,
-                }}
-              >
-                {km > 0 ? `${km} KM` : "—"}
-              </div>
-              <div
-                style={{ fontSize: 16, color: errors.end_odometer ? paper.accent : paper.inkMute }}
-              >
-                →
-              </div>
-            </div>
-            <div style={{ flex: 1, textAlign: "right" }}>
-              <span style={{ ...paperLabel, fontSize: 8, textAlign: "right", display: "block" }}>
-                {t("form.end_km")}
-              </span>
-              <input
-                {...register("end_odometer")}
-                type="number"
-                style={{ ...bigInput, fontSize: 20, textAlign: "right" }}
-              />
-              {errors.end_odometer && (
                 <div
-                  style={{ fontFamily: fontMono, fontSize: 8, color: paper.accent, letterSpacing: 1 }}
+                  style={{
+                    fontSize: 16,
+                    color: errors.end_odometer ? paper.accent : paper.inkMute,
+                  }}
                 >
-                  {errors.end_odometer.message}
+                  →
                 </div>
-              )}
+              </div>
+              <div style={{ flex: 1, textAlign: "right" }}>
+                <span style={{ ...paperLabel, fontSize: 8, textAlign: "right", display: "block" }}>
+                  {t("form.end_km")}
+                </span>
+                <input
+                  {...register("end_odometer")}
+                  type="number"
+                  style={{ ...bigInput, fontSize: 20, textAlign: "right" }}
+                />
+                {errors.end_odometer && (
+                  <div
+                    style={{
+                      fontFamily: fontMono,
+                      fontSize: 8,
+                      color: paper.accent,
+                      letterSpacing: 1,
+                    }}
+                  >
+                    {errors.end_odometer.message}
+                  </div>
+                )}
+              </div>
             </div>
           </div>
-        </div>
-      )}
+        )}
 
-      {/* Location (GPS + map) */}
-      <div style={{ padding: "4px 14px 4px" }}>
-        <span style={{ ...lbl, marginBottom: 6 }}>
-          {mono ? t("form.parking_short") : t("form.where_parked")}
-        </span>
-        <Controller
-          name="location"
-          control={control}
-          render={({ field: addrField }) => (
-            <Controller
-              name="gps_coords"
-              control={control}
-              render={({ field: coordsField }) => (
-                <LocationPicker
-                  address={addrField.value ?? null}
-                  coords={coordsField.value ?? null}
-                  onAddressChange={(v) => addrField.onChange(v ?? null)}
-                  onCoordsChange={(v) => coordsField.onChange(v ?? null)}
-                  autoGps={isAddMode}
-                />
-              )}
-            />
-          )}
-        />
-      </div>
-
-      {/* Parking note */}
-      <div style={{ padding: "8px 14px 4px" }}>
-        <span style={{ ...lbl, marginBottom: 6 }}>{t("form.parking_note")}</span>
-        <div
-          style={
-            mono
-              ? { border: `1px solid ${paper.paperDark}`, borderRadius: "var(--radius-sm, 6px)", padding: "10px 14px" }
-              : { ...dashedBox, padding: "10px 14px" }
-          }
-        >
-          <input
-            {...register("parking")}
-            type="text"
-            placeholder={t("form.parking_placeholder")}
-            style={{
-              fontFamily: fontSerif,
-              fontSize: 16,
-              fontWeight: 500,
-              color: paper.ink,
-              background: "transparent",
-              border: "none",
-              outline: "none",
-              width: "100%",
-              padding: 0,
-            }}
+        {/* Location (GPS + map) */}
+        <div style={{ padding: "4px 14px 4px" }}>
+          <span style={{ ...lbl, marginBottom: 6 }}>
+            {mono ? t("form.parking_short") : t("form.where_parked")}
+          </span>
+          <Controller
+            name="location"
+            control={control}
+            render={({ field: addrField }) => (
+              <Controller
+                name="gps_coords"
+                control={control}
+                render={({ field: coordsField }) => (
+                  <LocationPicker
+                    address={addrField.value ?? null}
+                    coords={coordsField.value ?? null}
+                    onAddressChange={(v) => addrField.onChange(v ?? null)}
+                    onCoordsChange={(v) => coordsField.onChange(v ?? null)}
+                    autoGps={isAddMode}
+                  />
+                )}
+              />
+            )}
           />
         </div>
-      </div>
 
-      {/* Breakdown / overzicht — always visible to prevent layout jump */}
-      <div
-        style={
-          mono
-            ? { margin: "12px 14px", border: `1px solid ${paper.paperDark}`, borderRadius: "var(--radius-md, 10px)", padding: "12px 14px" }
-            : { margin: "12px 14px", ...dashedBox }
-        }
-      >
+        {/* Parking note */}
+        <div style={{ padding: "8px 14px 4px" }}>
+          <span style={{ ...lbl, marginBottom: 6 }}>{t("form.parking_note")}</span>
+          <div
+            style={
+              mono
+                ? {
+                    border: `1px solid ${paper.paperDark}`,
+                    borderRadius: "var(--radius-sm, 6px)",
+                    padding: "10px 14px",
+                  }
+                : { ...dashedBox, padding: "10px 14px" }
+            }
+          >
+            <input
+              {...register("parking")}
+              type="text"
+              placeholder={t("form.parking_placeholder")}
+              style={{
+                fontFamily: fontSerif,
+                fontSize: 16,
+                fontWeight: 500,
+                color: paper.ink,
+                background: "transparent",
+                border: "none",
+                outline: "none",
+                width: "100%",
+                padding: 0,
+              }}
+            />
+          </div>
+        </div>
+
+        {/* Breakdown / overzicht — always visible to prevent layout jump */}
         <div
           style={
             mono
               ? {
-                  fontFamily: fontSerif,
-                  fontSize: 13,
-                  fontWeight: 600,
-                  color: paper.inkMute,
-                  marginBottom: 10,
+                  margin: "12px 14px",
+                  border: `1px solid ${paper.paperDark}`,
+                  borderRadius: "var(--radius-md, 10px)",
+                  padding: "12px 14px",
                 }
-              : {
-                  textAlign: "center",
-                  fontFamily: fontMono,
-                  fontSize: 9,
-                  fontWeight: 700,
-                  letterSpacing: 3,
-                  color: paper.inkDim,
-                  textTransform: "uppercase",
-                  marginBottom: 10,
-                }
+              : { margin: "12px 14px", ...dashedBox }
           }
         >
-          {mono ? t("form.breakdown") : `— ${t("form.breakdown")} —`}
-        </div>
-        <BreakdownRow
-          label={t("form.rate")}
-          value={car ? `€ ${car.price_per_km.toFixed(2).replace(".", ",")} / km` : "—"}
-          mono={mono}
-          muted={!car}
-        />
-        <BreakdownRow
-          label={t("form.tier_short", { km: String(shortKm), pct: String(pctShort) })}
-          value={shortKm > 0 ? fmtMoney(shortAmount) : "—"}
-          mono={mono}
-          muted={shortKm === 0}
-        />
-        {longKm > 0 && (
+          <div
+            style={
+              mono
+                ? {
+                    fontFamily: fontSerif,
+                    fontSize: 13,
+                    fontWeight: 600,
+                    color: paper.inkMute,
+                    marginBottom: 10,
+                  }
+                : {
+                    textAlign: "center",
+                    fontFamily: fontMono,
+                    fontSize: 9,
+                    fontWeight: 700,
+                    letterSpacing: 3,
+                    color: paper.inkDim,
+                    textTransform: "uppercase",
+                    marginBottom: 10,
+                  }
+            }
+          >
+            {mono ? t("form.breakdown") : `— ${t("form.breakdown")} —`}
+          </div>
           <BreakdownRow
-            label={t("form.tier_long", { km: String(longKm), pct: String(pctLong) })}
-            value={fmtMoney(longAmount)}
+            label={t("form.rate")}
+            value={car ? `€ ${car.price_per_km.toFixed(2).replace(".", ",")} / km` : "—"}
             mono={mono}
+            muted={!car}
           />
-        )}
-        <div style={{ borderTop: mono ? `1px solid ${paper.paperDark}` : `1px dashed ${paper.paperDark}`, margin: "8px 0" }} />
-        <BreakdownRow
-          label={`${mono ? "Totaal" : "TOTAL"} (${km} km)`}
-          value={fmtMoney(amount)}
-          valueStyle={{ color: paper.accent, fontSize: mono ? 16 : 15, fontWeight: 700 }}
-          mono={mono}
-        />
-        {car && shortAmount + longAmount < car.price_per_km * km && km > 0 && (
+          <BreakdownRow
+            label={t("form.tier_short", { km: String(shortKm), pct: String(pctShort) })}
+            value={shortKm > 0 ? fmtMoney(shortAmount) : "—"}
+            mono={mono}
+            muted={shortKm === 0}
+          />
+          {longKm > 0 && (
+            <BreakdownRow
+              label={t("form.tier_long", { km: String(longKm), pct: String(pctLong) })}
+              value={fmtMoney(longAmount)}
+              mono={mono}
+            />
+          )}
           <div
             style={{
-              textAlign: "right",
-              fontFamily: fontMono,
-              fontSize: mono ? 11 : 9,
-              color: paper.inkMute,
-              letterSpacing: mono ? 0 : 1,
-              marginTop: 2,
+              borderTop: mono ? `1px solid ${paper.paperDark}` : `1px dashed ${paper.paperDark}`,
+              margin: "8px 0",
             }}
-          >
-            − {fmtMoney(car.price_per_km * km - amount)} {t("form.total_discount").toLowerCase()}
+          />
+          <BreakdownRow
+            label={`${mono ? "Totaal" : "TOTAL"} (${km} km)`}
+            value={fmtMoney(amount)}
+            valueStyle={{ color: paper.accent, fontSize: mono ? 16 : 15, fontWeight: 700 }}
+            mono={mono}
+          />
+          {car && shortAmount + longAmount < car.price_per_km * km && km > 0 && (
+            <div
+              style={{
+                textAlign: "right",
+                fontFamily: fontMono,
+                fontSize: mono ? 11 : 9,
+                color: paper.inkMute,
+                letterSpacing: mono ? 0 : 1,
+                marginTop: 2,
+              }}
+            >
+              − {fmtMoney(car.price_per_km * km - amount)} {t("form.total_discount").toLowerCase()}
+            </div>
+          )}
+        </div>
+
+        {onDelete && (
+          <div style={{ padding: "0 14px 24px" }}>
+            <button
+              type="button"
+              onClick={onDelete}
+              style={{
+                width: "100%",
+                padding: "10px",
+                background: "transparent",
+                border: mono ? `1px solid ${paper.accent}` : `1.5px solid ${paper.accent}`,
+                borderRadius: mono ? "var(--radius-pill, 999px)" : 0,
+                color: paper.accent,
+                fontFamily: mono ? fontSerif : fontMono,
+                fontSize: mono ? 13 : 10,
+                fontWeight: 700,
+                letterSpacing: mono ? 0 : 2,
+                textTransform: mono ? "none" : "uppercase",
+                cursor: "pointer",
+              }}
+            >
+              {t("action.delete")}
+            </button>
           </div>
         )}
-      </div>
-
-      {onDelete && (
-        <div style={{ padding: "0 14px 24px" }}>
-          <button
-            type="button"
-            onClick={onDelete}
-            style={{
-              width: "100%",
-              padding: "10px",
-              background: "transparent",
-              border: mono ? `1px solid ${paper.accent}` : `1.5px solid ${paper.accent}`,
-              borderRadius: mono ? "var(--radius-pill, 999px)" : 0,
-              color: paper.accent,
-              fontFamily: mono ? fontSerif : fontMono,
-              fontSize: mono ? 13 : 10,
-              fontWeight: 700,
-              letterSpacing: mono ? 0 : 2,
-              textTransform: mono ? "none" : "uppercase",
-              cursor: "pointer",
-            }}
-          >
-            {t("action.delete")}
-          </button>
-        </div>
-      )}
+      </fieldset>
       <div style={{ height: 32 }} />
     </form>
   );
@@ -722,7 +837,13 @@ function BreakdownRow({
         style={
           mono
             ? { fontFamily: fontMono, fontSize: 11, color: paper.inkMute }
-            : { fontFamily: fontMono, fontSize: 9, color: paper.inkDim, letterSpacing: 1.5, textTransform: "uppercase" }
+            : {
+                fontFamily: fontMono,
+                fontSize: 9,
+                color: paper.inkDim,
+                letterSpacing: 1.5,
+                textTransform: "uppercase",
+              }
         }
       >
         {lbl}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -2,7 +2,13 @@ import { NextRequest, NextResponse } from "next/server";
 import { z, ZodError, type ZodSchema } from "zod";
 import { validateCsrfToken } from "./csrf";
 import { checkRateLimit } from "./rate-limit";
+import { canEdit } from "./permissions";
 import type { SessionData } from "./session";
+
+// Re-export the pure permission helper so existing call sites that import it
+// from "./api" keep working. The single source of truth lives in
+// ./permissions (importable from both backend and frontend).
+export { canEdit };
 
 export class HttpError extends Error {
   constructor(
@@ -76,19 +82,6 @@ export async function requireAdminOrOwner(req: Request) {
   const { isOwner } = await import("./queries/people");
   if (!isOwner(getDb(), personId)) forbidden();
   return session;
-}
-
-/** Pure function. Returns true if the person may edit/delete the given record. */
-export function canEdit(
-  personId: number,
-  isAdmin: boolean,
-  record: { person_id: number; car_id: number },
-  carOwnerPersonId: number | null
-): boolean {
-  if (isAdmin) return true;
-  if (record.person_id === personId) return true;
-  if (carOwnerPersonId !== null && carOwnerPersonId === personId) return true;
-  return false;
 }
 
 /**

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -124,6 +124,8 @@ export const en: Messages = {
   "form.select_person_placeholder": "Select member",
   "form.driver": "Driver",
   "form.driver_locked_hint": "Your name — only admins can log on behalf of others",
+  "form.read_only": "Read-only",
+  "form.read_only_hint": "Read-only — you cannot edit this",
   "form.pick_dates_first": "Pick a period first",
   "form.fill_required": "Fill in required fields",
   "field.car": "car",

--- a/lib/i18n/messages/nl.ts
+++ b/lib/i18n/messages/nl.ts
@@ -123,6 +123,8 @@ export const nl = {
   "form.select_person_placeholder": "Selecteer persoon",
   "form.driver": "Bestuurder",
   "form.driver_locked_hint": "Jouw naam — enkel admins kunnen voor anderen loggen",
+  "form.read_only": "Alleen-lezen",
+  "form.read_only_hint": "Alleen-lezen — je kan dit niet bewerken",
   "form.pick_dates_first": "Kies eerst een periode",
   "form.fill_required": "Vul verplichte velden in",
   "field.car": "wagen",

--- a/lib/permissions.test.ts
+++ b/lib/permissions.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { canEdit } from "./permissions";
+
+describe("canEdit", () => {
+  // Record authored by Alice (person 2) on Car JF (car 10).
+  // Car JF is owned by Owner A (person 5).
+  const record = { person_id: 2, car_id: 10 };
+  const carOwner = 5;
+
+  // Identities used in the truth table below:
+  const ADMIN = 99; // an admin who is neither author nor owner
+  const ALICE = 2; // the record's author
+  const OWNER_A = 5; // the car owner
+  const BOB = 7; // unrelated member (neither admin, author, nor owner)
+
+  describe("admin", () => {
+    it("allows an admin who is unrelated to the record", () => {
+      expect(canEdit(ADMIN, true, record, carOwner)).toBe(true);
+    });
+    it("allows an admin even when the car has no owner", () => {
+      expect(canEdit(ADMIN, true, record, null)).toBe(true);
+    });
+  });
+
+  describe("author", () => {
+    it("allows the author of the record", () => {
+      expect(canEdit(ALICE, false, record, carOwner)).toBe(true);
+    });
+    it("allows the author even when the car has no owner", () => {
+      expect(canEdit(ALICE, false, record, null)).toBe(true);
+    });
+  });
+
+  describe("car owner", () => {
+    it("allows the car owner who did not author the record", () => {
+      expect(canEdit(OWNER_A, false, record, carOwner)).toBe(true);
+    });
+  });
+
+  describe("unrelated member", () => {
+    it("rejects a member who is neither admin, author, nor owner", () => {
+      expect(canEdit(BOB, false, record, carOwner)).toBe(false);
+    });
+    it("rejects an unrelated member when the car has no owner", () => {
+      expect(canEdit(BOB, false, record, null)).toBe(false);
+    });
+  });
+
+  describe("owner self-match guard", () => {
+    it("does not treat a null car owner as a match for person 0-like ids", () => {
+      // carOwnerPersonId === null must never short-circuit to true.
+      expect(canEdit(BOB, false, record, null)).toBe(false);
+    });
+  });
+});

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -1,0 +1,37 @@
+/**
+ * Pure permission helpers shared by the backend (API route guards) and the
+ * frontend (rendering edit forms read-only). This module has NO server
+ * dependencies so it can be imported from client components.
+ */
+
+/** A record that can be edited/deleted: its author (`person_id`) and car (`car_id`). */
+export interface EditableRecord {
+  person_id: number;
+  car_id: number;
+}
+
+/**
+ * Pure function. Returns true if the person may edit/delete the given record.
+ *
+ * Allowed when the person is:
+ * - an admin, or
+ * - the author of the record (`record.person_id`), or
+ * - the owner of the record's car (`carOwnerPersonId`, i.e. the car's
+ *   `owner_person_id`).
+ *
+ * @param personId - The acting person's id.
+ * @param isAdmin - Whether the acting person is an admin.
+ * @param record - The record being edited (author + car).
+ * @param carOwnerPersonId - The `owner_person_id` of the record's car, or null.
+ */
+export function canEdit(
+  personId: number,
+  isAdmin: boolean,
+  record: EditableRecord,
+  carOwnerPersonId: number | null
+): boolean {
+  if (isAdmin) return true;
+  if (record.person_id === personId) return true;
+  if (carOwnerPersonId !== null && carOwnerPersonId === personId) return true;
+  return false;
+}


### PR DESCRIPTION
Closes #172.

When a user opened an edit form for a record they couldn't edit, the form looked editable but save returned 403. Now it renders read-only.

## Changes
- **`lib/permissions.ts`** (new) — single source of truth for the pure `canEdit(personId, isAdmin, record, carOwnerPersonId)`.
- **`lib/api.ts`** — imports/re-exports `canEdit` from `lib/permissions.ts` (no behaviour change; backend 403 guard untouched).
- **trips / fuel / expenses / calendar** pages derive the viewer's permission via `useMe()` + `useCars()` and pass a `readOnly` prop to their edit forms.
- Read-only forms: all inputs disabled (`fieldset disabled`), save/delete hidden, lock badge + hint banner shown.
- New i18n keys `form.read_only` / `form.read_only_hint`.

## Tests
- `lib/permissions.test.ts` — `canEdit` truth table (admin / author / car owner / unrelated member).
- Full suite: 530 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)