### PR TITLE
feat(owner): collapsible coverage card + costs/fuel as negative red

### DIFF
--- a/app/admin/vehicles/page.tsx
+++ b/app/admin/vehicles/page.tsx
@@ -239,7 +239,16 @@ function CarAccordion({
             whiteSpace: "nowrap",
           }}
         >
-          {car.owner_person_id ? (displayName(people.find((p) => p.id === car.owner_person_id) ?? { first_name: "?", username: null })) : <span style={{ color: paper.inkDim, fontStyle: "italic" }}>—</span>}
+          {car.owner_person_id ? (
+            displayName(
+              people.find((p) => p.id === car.owner_person_id) ?? {
+                first_name: "?",
+                username: null,
+              }
+            )
+          ) : (
+            <span style={{ color: paper.inkDim, fontStyle: "italic" }}>—</span>
+          )}
         </div>
         <div
           style={{
@@ -334,7 +343,14 @@ function CarAccordion({
                   cursor: "default",
                 }}
               >
-                {car.owner_person_id ? displayName(people.find((p) => p.id === car.owner_person_id) ?? { first_name: "?", username: null }) : "—"}
+                {car.owner_person_id
+                  ? displayName(
+                      people.find((p) => p.id === car.owner_person_id) ?? {
+                        first_name: "?",
+                        username: null,
+                      }
+                    )
+                  : "—"}
               </div>
             )}
           </div>
@@ -714,6 +730,10 @@ function OwnerFleet() {
 
   const [expandedId, setExpandedId] = useState<number | null>(null);
 
+  // Coverage-card collapse, kept here (parent survives year switches, which
+  // remount CostCoverageScreen via its key) and keyed per car. Absent = expanded.
+  const [coverageExpanded, setCoverageExpanded] = useState<Record<number, boolean>>({});
+
   const goToFleet = () => {
     const p = new URLSearchParams();
     if (year !== currentYear) p.set("year", String(year));
@@ -852,6 +872,10 @@ function OwnerFleet() {
           priceHistory={priceHistory.filter((h) => h.car_id === screenCarId)}
           rollingFuelPerKm={carRollingFuel?.fuel_per_km ?? 0}
           year={year}
+          expanded={coverageExpanded[screenCarId] ?? true}
+          onToggleExpanded={() =>
+            setCoverageExpanded((m) => ({ ...m, [screenCarId]: !(m[screenCarId] ?? true) }))
+          }
         />
       </div>
     );
@@ -947,7 +971,11 @@ function OwnerFleet() {
 }
 
 // ── Page ──────────────────────────────────────────────────────
-function displayName(p: { first_name?: string | null; last_name?: string | null; username?: string | null }): string {
+function displayName(p: {
+  first_name?: string | null;
+  last_name?: string | null;
+  username?: string | null;
+}): string {
   return shortNameOf(p) || "?";
 }
 

--- a/components/__tests__/cost-coverage-screen.test.tsx
+++ b/components/__tests__/cost-coverage-screen.test.tsx
@@ -1,0 +1,224 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import type { CarPnL } from "@/lib/queries/admin";
+
+// --- module mocks ---
+
+// Translate keys to the human labels we assert on; unknown keys fall through.
+vi.mock("@/components/locale-provider", () => ({
+  useT: () => (key: string, vars?: Record<string, string | number>) => {
+    const messages: Record<string, string> = {
+      "breakeven.revenue": "Trip revenue",
+      "breakeven.expenses": "Variable costs",
+      "breakeven.net": "Net",
+      "coverage.title": "Cost coverage",
+      "coverage.projection.title": "Projection",
+      "coverage.projection.others_contribution": "Others' contribution",
+      "coverage.projection.expenses": "Costs to cover",
+      "coverage.projection.owner_fuel": "Own fuel",
+      "coverage.projection.net": "Owner net",
+      "coverage.zone.dark_green": "Fuel also covered",
+      "coverage.zone.light_green": "Costs covered",
+      "coverage.zone.orange": "Costs not covered",
+      "coverage.zone.red": "Loss per trip",
+      "coverage.ytd": "This year",
+      "coverage.exact": "exact",
+      "coverage.default_current": "current",
+      "coverage.slider.fuel_per_km": "Fuel / km",
+      "coverage.slider.total_km": "Total km / year",
+      "coverage.slider.pct_others": "% others",
+      "coverage.slider.expenses": "Expected costs",
+      "coverage.slider.price": "Price / km",
+      "coverage.save": "Save price",
+      "action.collapse": "Collapse",
+      "action.expand": "Expand",
+      "stats.trips": "trips",
+      "stats.trips_short": "tr.",
+      "stats.fillups": "fill-ups",
+      "stats.fillups_short": "fu.",
+      "stats.expenses": "expenses",
+      "stats.expenses_short": "ex.",
+      "stats.others": "Others",
+      "stats.own": "Own",
+    };
+    void vars;
+    return messages[key] ?? key;
+  },
+}));
+
+vi.mock("@/hooks/use-vehicles", () => ({
+  useUpdateCar: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+import { CostCoverageScreen } from "../cost-coverage-screen";
+
+// --- fixture ---
+
+const HISTORIC_YEAR = new Date().getFullYear() - 1;
+
+function makeCar(overrides: Partial<CarPnL> = {}): CarPnL {
+  return {
+    car_id: 1,
+    car_short: "JF",
+    car_name: "Car JF",
+    car_price_per_km: 0.35,
+    owner_name: "Owner A",
+    long_threshold: 100,
+    expected_km: 14000,
+    trip_count: 40,
+    trip_km: 12000,
+    trip_revenue: 4200,
+    owner_trip_count: 10,
+    owner_trip_km: 3000,
+    owner_trip_amount: 1050,
+    fuel_count: 20,
+    fuel_amount: 1500,
+    fuel_liters: 900,
+    owner_fuel_count: 5,
+    owner_fuel_amount: 400,
+    owner_fuel_liters: 240,
+    expense_count: 6,
+    expense_amount: 288.24,
+    owner_expense_count: 1,
+    owner_expense_amount: 50,
+    variable_total: 1788.24,
+    net: 2411.76,
+    cost_per_km: 0.149,
+    prev_year_trip_km: 11000,
+    ...overrides,
+  };
+}
+
+function renderScreen(carOverrides: Partial<CarPnL> = {}) {
+  // Use a historic year so all slider values are derived from exact actuals
+  // (no async data needed) and the layout is deterministic.
+  return render(
+    <CostCoverageScreen
+      car={makeCar(carOverrides)}
+      fullCar={undefined}
+      historicalKm={[]}
+      ownerSplit={[]}
+      historicalExpenses={[]}
+      priceHistory={[]}
+      rollingFuelPerKm={0}
+      year={HISTORIC_YEAR}
+    />
+  );
+}
+
+describe("CostCoverageScreen — collapse toggle", () => {
+  it("defaults to expanded: shows the trips/fill-ups/expenses breakdown", () => {
+    renderScreen();
+    expect(screen.getByText("Car JF")).toBeInTheDocument();
+    // breakdown sub-rows only render when expanded
+    expect(screen.getAllByText("Others").length).toBeGreaterThan(0);
+    expect(screen.getByText("Trip revenue")).toBeInTheDocument();
+  });
+
+  it("collapsing hides the breakdown but keeps car name, year and NET visible", async () => {
+    const user = userEvent.setup();
+    renderScreen();
+
+    await user.click(screen.getByRole("button", { name: "Collapse" }));
+
+    // breakdown + revenue line are hidden
+    expect(screen.queryByText("Others")).not.toBeInTheDocument();
+    expect(screen.queryByText("Trip revenue")).not.toBeInTheDocument();
+    // car name, year and NET stay
+    expect(screen.getByText("Car JF")).toBeInTheDocument();
+    expect(screen.getByText(String(HISTORIC_YEAR))).toBeInTheDocument();
+    expect(screen.getByText("Net")).toBeInTheDocument();
+  });
+
+  it("toggles back to expanded on a second click", async () => {
+    const user = userEvent.setup();
+    renderScreen();
+    const toggle = screen.getByRole("button", { name: "Collapse" });
+
+    await user.click(toggle); // collapse
+    expect(screen.queryByText("Trip revenue")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Expand" })); // expand
+    expect(screen.getByText("Trip revenue")).toBeInTheDocument();
+  });
+});
+
+describe("CostCoverageScreen — controlled collapse (survives year switch)", () => {
+  it("reflects the expanded prop instead of internal state", () => {
+    render(
+      <CostCoverageScreen
+        car={makeCar()}
+        fullCar={undefined}
+        historicalKm={[]}
+        ownerSplit={[]}
+        historicalExpenses={[]}
+        priceHistory={[]}
+        rollingFuelPerKm={0}
+        year={HISTORIC_YEAR}
+        expanded={false}
+        onToggleExpanded={() => {}}
+      />
+    );
+    // expanded=false → breakdown hidden, NET still shown
+    expect(screen.queryByText("Trip revenue")).not.toBeInTheDocument();
+    expect(screen.getByText("Net")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Expand" })).toBeInTheDocument();
+  });
+
+  it("calls onToggleExpanded (not internal state) when controlled", async () => {
+    const user = userEvent.setup();
+    const onToggleExpanded = vi.fn();
+    render(
+      <CostCoverageScreen
+        car={makeCar()}
+        fullCar={undefined}
+        historicalKm={[]}
+        ownerSplit={[]}
+        historicalExpenses={[]}
+        priceHistory={[]}
+        rollingFuelPerKm={0}
+        year={HISTORIC_YEAR}
+        expanded={true}
+        onToggleExpanded={onToggleExpanded}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: "Collapse" }));
+    expect(onToggleExpanded).toHaveBeenCalledTimes(1);
+    // stays expanded because the parent owns the state (prop unchanged)
+    expect(screen.getByText("Trip revenue")).toBeInTheDocument();
+  });
+});
+
+describe("CostCoverageScreen — costs shown as negative red", () => {
+  it("renders VARIABLE COSTS with a leading minus (U+2212)", () => {
+    renderScreen();
+    const label = screen.getByText("Variable costs");
+    const value = label.parentElement?.querySelector("span:last-child");
+    expect(value?.textContent?.startsWith("−")).toBe(true);
+  });
+
+  it("renders COSTS TO COVER and OWN FUEL with a leading minus (U+2212)", () => {
+    renderScreen();
+    for (const lbl of ["Costs to cover", "Own fuel"]) {
+      const label = screen.getByText(lbl);
+      const value = label.parentElement?.querySelector("span:last-child");
+      expect(value?.textContent?.startsWith("−")).toBe(true);
+    }
+  });
+
+  it("does NOT prepend a minus to the NET line (sign handled by NET itself)", () => {
+    renderScreen();
+    const net = screen.getByText("Net");
+    const value = net.parentElement?.querySelector("span:last-child");
+    expect(value?.textContent?.startsWith("−")).toBe(false);
+  });
+});

--- a/components/cost-coverage-screen.tsx
+++ b/components/cost-coverage-screen.tsx
@@ -1,12 +1,18 @@
 "use client";
 import { useState } from "react";
-import { paper, fontMono, fontSerif, fmtMoney } from "@/lib/paper-theme";
+import { paper, fontMono, fontSerif, fmtMoney, fmtMoneyOut } from "@/lib/paper-theme";
 import { useT } from "@/components/locale-provider";
 import { useUpdateCar } from "@/hooks/use-vehicles";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { Card, Row } from "@/app/admin/_shared";
-import type { CarPnL, CarYearKm, CarOwnerSplit, CarYearExpenses, CarPriceHistory } from "@/lib/queries/admin";
+import type {
+  CarPnL,
+  CarYearKm,
+  CarOwnerSplit,
+  CarYearExpenses,
+  CarPriceHistory,
+} from "@/lib/queries/admin";
 import type { Car } from "@/types";
 
 export interface CostCoverageScreenProps {
@@ -18,6 +24,9 @@ export interface CostCoverageScreenProps {
   priceHistory: CarPriceHistory[];
   rollingFuelPerKm: number; // 0 = no data
   year: number;
+  /** Controlled collapse state. When omitted, the card manages it internally. */
+  expanded?: boolean;
+  onToggleExpanded?: () => void;
 }
 
 // ── Zone bar ──────────────────────────────────────────────────
@@ -45,19 +54,56 @@ function ZoneBar({
 
   return (
     <div style={{ marginBottom: 16 }}>
-      <div style={{ position: "relative", height: 14, display: "flex", borderRadius: 2, overflow: "hidden", marginBottom: 20 }}>
+      <div
+        style={{
+          position: "relative",
+          height: 14,
+          display: "flex",
+          borderRadius: 2,
+          overflow: "hidden",
+          marginBottom: 20,
+        }}
+      >
         <div style={{ width: zone1W, background: paper.accent }} />
         <div style={{ width: zone2W, background: paper.amber }} />
         <div style={{ width: zone3W, background: paper.green, opacity: 0.55 }} />
         <div style={{ width: zone4W, background: paper.green }} />
-        <div style={{ position: "absolute", top: -3, left: markerLeft, transform: "translateX(-50%)", display: "flex", flexDirection: "column", alignItems: "center" }}>
+        <div
+          style={{
+            position: "absolute",
+            top: -3,
+            left: markerLeft,
+            transform: "translateX(-50%)",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+          }}
+        >
           <div style={{ width: 2, height: 20, background: paper.ink }} />
-          <div style={{ fontFamily: fontMono, fontSize: 7, fontWeight: 700, color: paper.ink, whiteSpace: "nowrap", marginTop: 2 }}>
+          <div
+            style={{
+              fontFamily: fontMono,
+              fontSize: 7,
+              fontWeight: 700,
+              color: paper.ink,
+              whiteSpace: "nowrap",
+              marginTop: 2,
+            }}
+          >
             € {currentPrice.toFixed(2)}
           </div>
         </div>
       </div>
-      <div style={{ display: "flex", justifyContent: "space-between", fontFamily: fontMono, fontSize: 7, color: paper.inkMute, letterSpacing: 0.5 }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          fontFamily: fontMono,
+          fontSize: 7,
+          color: paper.inkMute,
+          letterSpacing: 0.5,
+        }}
+      >
         <span>0</span>
         <span>€{fuelThreshold.toFixed(2)} brandstof</span>
         <span>€{expenseThreshold.toFixed(2)} kosten</span>
@@ -92,12 +138,31 @@ function SliderRow({
 }) {
   return (
     <div style={{ marginBottom: 14 }}>
-      <div style={{ display: "flex", justifyContent: "space-between", fontFamily: fontMono, fontSize: 8, color: paper.inkMute, letterSpacing: 0.8, marginBottom: 3 }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          fontFamily: fontMono,
+          fontSize: 8,
+          color: paper.inkMute,
+          letterSpacing: 0.8,
+          marginBottom: 3,
+        }}
+      >
         <span style={{ textTransform: "uppercase", letterSpacing: 1 }}>{label}</span>
         <span style={{ color: paper.inkDim }}>{hint}</span>
       </div>
       {readOnly ? (
-        <div style={{ fontFamily: fontMono, fontSize: 11, fontWeight: 700, textAlign: "center", color: paper.ink, padding: "6px 0" }}>
+        <div
+          style={{
+            fontFamily: fontMono,
+            fontSize: 11,
+            fontWeight: 700,
+            textAlign: "center",
+            color: paper.ink,
+            padding: "6px 0",
+          }}
+        >
           {format(value)}
         </div>
       ) : (
@@ -111,7 +176,15 @@ function SliderRow({
             onChange={(e) => onChange(parseFloat(e.target.value))}
             style={{ width: "100%", accentColor: paper.ink, marginBottom: 2 }}
           />
-          <div style={{ fontFamily: fontMono, fontSize: 11, fontWeight: 700, textAlign: "center", color: paper.ink }}>
+          <div
+            style={{
+              fontFamily: fontMono,
+              fontSize: 11,
+              fontWeight: 700,
+              textAlign: "center",
+              color: paper.ink,
+            }}
+          >
             {format(value)}
           </div>
         </>
@@ -130,7 +203,11 @@ function zoneColor(zone: Zone): string {
   return paper.green;
 }
 
-type ZoneKey = "coverage.zone.red" | "coverage.zone.orange" | "coverage.zone.light_green" | "coverage.zone.dark_green";
+type ZoneKey =
+  | "coverage.zone.red"
+  | "coverage.zone.orange"
+  | "coverage.zone.light_green"
+  | "coverage.zone.dark_green";
 
 function zoneKey(zone: Zone): ZoneKey {
   return `coverage.zone.${zone}` as ZoneKey;
@@ -157,6 +234,8 @@ export function CostCoverageScreen({
   priceHistory,
   rollingFuelPerKm,
   year,
+  expanded: expandedProp,
+  onToggleExpanded,
 }: CostCoverageScreenProps) {
   const t = useT();
   const qc = useQueryClient();
@@ -194,7 +273,9 @@ export function CostCoverageScreen({
 
   const avgExpenses =
     _historicalExpenses.length > 0
-      ? Math.round(_historicalExpenses.reduce((s, e) => s + e.amount, 0) / _historicalExpenses.length)
+      ? Math.round(
+          _historicalExpenses.reduce((s, e) => s + e.amount, 0) / _historicalExpenses.length
+        )
       : 0;
 
   const kmDataYears = historicalKm.length;
@@ -209,7 +290,7 @@ export function CostCoverageScreen({
   // For current year, initialize from rolling/historical averages.
 
   const [fuelPerKm, setFuelPerKm] = useState(
-    isHistoric ? exactFuelPerKm : (defaultFuelPerKm || 0.12)
+    isHistoric ? exactFuelPerKm : defaultFuelPerKm || 0.12
   );
   const [totalKm, setTotalKm] = useState(
     isHistoric ? car.trip_km : (car.expected_km ?? (avgHistKm || car.prev_year_trip_km || 14000))
@@ -218,11 +299,9 @@ export function CostCoverageScreen({
     isHistoric ? Math.round(exactPctOthers * 100) / 100 : Math.round(avgOthersPct * 100) / 100
   );
   const [expectedExpenses, setExpectedExpenses] = useState(
-    isHistoric ? exactExpenses : (avgExpenses || car.expense_amount || 0)
+    isHistoric ? exactExpenses : avgExpenses || car.expense_amount || 0
   );
-  const [pricePerKm, setPricePerKm] = useState(
-    isHistoric ? exactPrice : car.car_price_per_km
-  );
+  const [pricePerKm, setPricePerKm] = useState(isHistoric ? exactPrice : car.car_price_per_km);
 
   // ── Derived projections ───────────────────────────────────────
 
@@ -235,8 +314,7 @@ export function CostCoverageScreen({
   const fuelThreshold = fuelPerKm;
   const safeNonOwnerKm = Math.max(1, nonOwnerKm);
   const expenseThreshold = fuelPerKm + expectedExpenses / safeNonOwnerKm;
-  const fuelCoverThreshold =
-    fuelPerKm + (expectedExpenses + ownerFuelCost) / safeNonOwnerKm;
+  const fuelCoverThreshold = fuelPerKm + (expectedExpenses + ownerFuelCost) / safeNonOwnerKm;
 
   const zone: Zone =
     markupPerKm < 0
@@ -256,12 +334,22 @@ export function CostCoverageScreen({
   const othersRevenue = car.trip_revenue - car.owner_trip_amount;
   const ytdNet = othersRevenue - car.variable_total;
 
+  // ── Card collapse ─────────────────────────────────────────────
+  // Controlled by the parent when props are supplied (so the choice survives
+  // year switches that remount this component); otherwise managed locally.
+
+  const [expandedInternal, setExpandedInternal] = useState(true);
+  const expanded = expandedProp ?? expandedInternal;
+  const toggleExpanded = onToggleExpanded ?? (() => setExpandedInternal((v) => !v));
+
   // ── Save ──────────────────────────────────────────────────────
 
   function handleSave() {
     if (!fullCar) return;
     updateCar.mutate(
-      { ...fullCar, price_per_km: pricePerKm, expected_km: Math.round(totalKm) } as Car & { id: number },
+      { ...fullCar, price_per_km: pricePerKm, expected_km: Math.round(totalKm) } as Car & {
+        id: number;
+      },
       {
         onSuccess: () => {
           qc.invalidateQueries({ queryKey: ["admin-summary"] });
@@ -275,8 +363,8 @@ export function CostCoverageScreen({
   // ── Hint labels ───────────────────────────────────────────────
 
   const exactHint = t("coverage.exact");
-  const nYrHint = (n: number) => n > 0 ? t("coverage.default_avg_n", { n }) : "—";
-  const fuelHint = isHistoric ? exactHint : (rollingFuelPerKm > 0 ? t("coverage.default_12m") : "—");
+  const nYrHint = (n: number) => (n > 0 ? t("coverage.default_avg_n", { n }) : "—");
+  const fuelHint = isHistoric ? exactHint : rollingFuelPerKm > 0 ? t("coverage.default_12m") : "—";
   const kmHint = isHistoric ? exactHint : nYrHint(kmDataYears);
   const othersHint = isHistoric ? exactHint : nYrHint(othersDataYears);
   const expensesHint = isHistoric ? exactHint : nYrHint(expensesDataYears);
@@ -286,52 +374,180 @@ export function CostCoverageScreen({
     <div>
       {/* Header */}
       <Card style={{ marginBottom: 12 }}>
-        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            marginBottom: 8,
+          }}
+        >
           <div style={{ fontFamily: fontSerif, fontSize: 20, fontWeight: 700 }}>{car.car_name}</div>
-          <div style={{ fontFamily: fontMono, fontSize: 8, fontWeight: 700, letterSpacing: 1.5, color, border: `2px solid ${color}`, padding: "3px 8px", textTransform: "uppercase", transform: "rotate(-2deg)" }}>
-            {t(zoneKey(zone))}
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <div
+              style={{
+                fontFamily: fontMono,
+                fontSize: 8,
+                fontWeight: 700,
+                letterSpacing: 1.5,
+                color,
+                border: `2px solid ${color}`,
+                padding: "3px 8px",
+                textTransform: "uppercase",
+                transform: "rotate(-2deg)",
+              }}
+            >
+              {t(zoneKey(zone))}
+            </div>
+            <button
+              type="button"
+              onClick={toggleExpanded}
+              aria-expanded={expanded}
+              aria-label={expanded ? t("action.collapse") : t("action.expand")}
+              style={{
+                background: "transparent",
+                border: "none",
+                cursor: "pointer",
+                color: paper.inkDim,
+                fontFamily: fontMono,
+                fontSize: 13,
+                lineHeight: 1,
+                padding: "2px 4px",
+                transform: expanded ? "rotate(0deg)" : "rotate(-90deg)",
+                transition: "transform 0.15s",
+              }}
+            >
+              ▾
+            </button>
           </div>
         </div>
-        <div style={{ fontFamily: fontMono, fontSize: 9, color: paper.inkDim, letterSpacing: 1, textTransform: "uppercase" }}>
+        <div
+          style={{
+            fontFamily: fontMono,
+            fontSize: 9,
+            color: paper.inkDim,
+            letterSpacing: 1,
+            textTransform: "uppercase",
+          }}
+        >
           {isHistoric ? String(year) : t("coverage.ytd", { months: currentMonth })}
         </div>
 
         {/* General stats */}
-        {(() => {
-          const othersTrips = car.trip_count - car.owner_trip_count;
-          const othersKm = car.trip_km - car.owner_trip_km;
-          const othersFuelCnt = car.fuel_count - car.owner_fuel_count;
-          const othersFuelL = car.fuel_liters - car.owner_fuel_liters;
-          const othersFuelAmt = car.fuel_amount - car.owner_fuel_amount;
-          const sub: React.CSSProperties = { paddingLeft: 12, display: "flex", justifyContent: "space-between", fontFamily: fontMono, fontSize: 9, color: paper.inkDim, marginBottom: 1 };
-          const head: React.CSSProperties = { display: "flex", justifyContent: "space-between", fontFamily: fontMono, fontSize: 11, fontWeight: 700, color: paper.ink, marginBottom: 2 };
-          return (
-            <div style={{ marginTop: 10, borderTop: `1px dashed ${paper.paperDark}`, paddingTop: 10 }}>
-              <div style={head}>
-                <span>{car.trip_count} {t("stats.trips")} · {car.trip_km.toLocaleString("nl-BE")} km</span>
-              </div>
-              <div style={sub}><span>{t("stats.others")}</span><span>{othersTrips} {t("stats.trips_short")} · {othersKm.toLocaleString("nl-BE")} km · {fmtMoney(othersRevenue)}</span></div>
-              <div style={sub}><span>{t("stats.own")}</span><span>{car.owner_trip_count} {t("stats.trips_short")} · {car.owner_trip_km.toLocaleString("nl-BE")} km · {fmtMoney(car.owner_trip_amount)}</span></div>
+        {expanded &&
+          (() => {
+            const othersTrips = car.trip_count - car.owner_trip_count;
+            const othersKm = car.trip_km - car.owner_trip_km;
+            const othersFuelCnt = car.fuel_count - car.owner_fuel_count;
+            const othersFuelL = car.fuel_liters - car.owner_fuel_liters;
+            const othersFuelAmt = car.fuel_amount - car.owner_fuel_amount;
+            const sub: React.CSSProperties = {
+              paddingLeft: 12,
+              display: "flex",
+              justifyContent: "space-between",
+              fontFamily: fontMono,
+              fontSize: 9,
+              color: paper.inkDim,
+              marginBottom: 1,
+            };
+            const head: React.CSSProperties = {
+              display: "flex",
+              justifyContent: "space-between",
+              fontFamily: fontMono,
+              fontSize: 11,
+              fontWeight: 700,
+              color: paper.ink,
+              marginBottom: 2,
+            };
+            return (
+              <div
+                style={{
+                  marginTop: 10,
+                  borderTop: `1px dashed ${paper.paperDark}`,
+                  paddingTop: 10,
+                }}
+              >
+                <div style={head}>
+                  <span>
+                    {car.trip_count} {t("stats.trips")} · {car.trip_km.toLocaleString("nl-BE")} km
+                  </span>
+                </div>
+                <div style={sub}>
+                  <span>{t("stats.others")}</span>
+                  <span>
+                    {othersTrips} {t("stats.trips_short")} · {othersKm.toLocaleString("nl-BE")} km ·{" "}
+                    {fmtMoney(othersRevenue)}
+                  </span>
+                </div>
+                <div style={sub}>
+                  <span>{t("stats.own")}</span>
+                  <span>
+                    {car.owner_trip_count} {t("stats.trips_short")} ·{" "}
+                    {car.owner_trip_km.toLocaleString("nl-BE")} km ·{" "}
+                    {fmtMoney(car.owner_trip_amount)}
+                  </span>
+                </div>
 
-              <div style={{ ...head, marginTop: 8 }}>
-                <span>{car.fuel_count} {t("stats.fillups")} · {car.fuel_liters.toFixed(0)} L · {fmtMoney(car.fuel_amount)}</span>
-              </div>
-              <div style={sub}><span>{t("stats.others")}</span><span>{othersFuelCnt} {t("stats.fillups_short")} · {othersFuelL.toFixed(0)} L · {fmtMoney(othersFuelAmt)}</span></div>
-              <div style={sub}><span>{t("stats.own")}</span><span>{car.owner_fuel_count} {t("stats.fillups_short")} · {car.owner_fuel_liters.toFixed(0)} L · {fmtMoney(car.owner_fuel_amount)}</span></div>
+                <div style={{ ...head, marginTop: 8 }}>
+                  <span>
+                    {car.fuel_count} {t("stats.fillups")} · {car.fuel_liters.toFixed(0)} L ·{" "}
+                    {fmtMoney(car.fuel_amount)}
+                  </span>
+                </div>
+                <div style={sub}>
+                  <span>{t("stats.others")}</span>
+                  <span>
+                    {othersFuelCnt} {t("stats.fillups_short")} · {othersFuelL.toFixed(0)} L ·{" "}
+                    {fmtMoney(othersFuelAmt)}
+                  </span>
+                </div>
+                <div style={sub}>
+                  <span>{t("stats.own")}</span>
+                  <span>
+                    {car.owner_fuel_count} {t("stats.fillups_short")} ·{" "}
+                    {car.owner_fuel_liters.toFixed(0)} L · {fmtMoney(car.owner_fuel_amount)}
+                  </span>
+                </div>
 
-              <div style={{ ...head, marginTop: 8 }}>
-                <span>{car.expense_count} {t("stats.expenses")} · {fmtMoney(car.expense_amount)}</span>
+                <div style={{ ...head, marginTop: 8 }}>
+                  <span>
+                    {car.expense_count} {t("stats.expenses")} · {fmtMoney(car.expense_amount)}
+                  </span>
+                </div>
+                <div style={sub}>
+                  <span>{t("stats.others")}</span>
+                  <span>
+                    {car.expense_count - car.owner_expense_count} {t("stats.expenses_short")} ·{" "}
+                    {fmtMoney(car.expense_amount - car.owner_expense_amount)}
+                  </span>
+                </div>
+                <div style={sub}>
+                  <span>{t("stats.own")}</span>
+                  <span>
+                    {car.owner_expense_count} {t("stats.expenses_short")} ·{" "}
+                    {fmtMoney(car.owner_expense_amount)}
+                  </span>
+                </div>
               </div>
-              <div style={sub}><span>{t("stats.others")}</span><span>{car.expense_count - car.owner_expense_count} {t("stats.expenses_short")} · {fmtMoney(car.expense_amount - car.owner_expense_amount)}</span></div>
-              <div style={sub}><span>{t("stats.own")}</span><span>{car.owner_expense_count} {t("stats.expenses_short")} · {fmtMoney(car.owner_expense_amount)}</span></div>
-            </div>
-          );
-        })()}
+            );
+          })()}
 
-        {/* YTD / year actuals */}
+        {/* YTD / year actuals — NET always visible; revenue & costs only when expanded */}
         <div style={{ marginTop: 10, borderTop: `1px dashed ${paper.paperDark}`, paddingTop: 10 }}>
-          <Row label={t("breakeven.revenue")} value={fmtMoney(othersRevenue)} color={paper.green} />
-          <Row label={t("breakeven.expenses")} value={fmtMoney(car.variable_total)} />
+          {expanded && (
+            <>
+              <Row
+                label={t("breakeven.revenue")}
+                value={fmtMoney(othersRevenue)}
+                color={paper.green}
+              />
+              <Row
+                label={t("breakeven.expenses")}
+                value={fmtMoneyOut(car.variable_total)}
+                color={paper.accent}
+              />
+            </>
+          )}
           <Row
             label={t("breakeven.net")}
             value={fmtMoney(Math.abs(ytdNet))}
@@ -343,7 +559,17 @@ export function CostCoverageScreen({
 
       {/* Zone bar + sliders */}
       <Card>
-        <div style={{ fontFamily: fontMono, fontSize: 9, letterSpacing: 2, textTransform: "uppercase", color: paper.inkDim, fontWeight: 700, marginBottom: 12 }}>
+        <div
+          style={{
+            fontFamily: fontMono,
+            fontSize: 9,
+            letterSpacing: 2,
+            textTransform: "uppercase",
+            color: paper.inkDim,
+            fontWeight: 700,
+            marginBottom: 12,
+          }}
+        >
           {t("coverage.title")}
         </div>
         <ZoneBar
@@ -411,13 +637,37 @@ export function CostCoverageScreen({
         />
 
         {/* Projection / actuals summary */}
-        <div style={{ background: paper.paperDeep, padding: "12px", marginTop: 8, marginBottom: 12 }}>
-          <div style={{ fontFamily: fontMono, fontSize: 8, letterSpacing: 1.5, textTransform: "uppercase", color: paper.inkDim, fontWeight: 700, marginBottom: 8 }}>
+        <div
+          style={{ background: paper.paperDeep, padding: "12px", marginTop: 8, marginBottom: 12 }}
+        >
+          <div
+            style={{
+              fontFamily: fontMono,
+              fontSize: 8,
+              letterSpacing: 1.5,
+              textTransform: "uppercase",
+              color: paper.inkDim,
+              fontWeight: 700,
+              marginBottom: 8,
+            }}
+          >
             {t("coverage.projection.title")}
           </div>
-          <Row label={t("coverage.projection.others_contribution")} value={fmtMoney(nonOwnerMarkup)} color={nonOwnerMarkup >= 0 ? paper.green : paper.accent} />
-          <Row label={t("coverage.projection.expenses")} value={fmtMoney(expectedExpenses)} />
-          <Row label={t("coverage.projection.owner_fuel")} value={fmtMoney(ownerFuelCost)} />
+          <Row
+            label={t("coverage.projection.others_contribution")}
+            value={fmtMoney(nonOwnerMarkup)}
+            color={nonOwnerMarkup >= 0 ? paper.green : paper.accent}
+          />
+          <Row
+            label={t("coverage.projection.expenses")}
+            value={fmtMoneyOut(expectedExpenses)}
+            color={paper.accent}
+          />
+          <Row
+            label={t("coverage.projection.owner_fuel")}
+            value={fmtMoneyOut(ownerFuelCost)}
+            color={paper.accent}
+          />
           <div style={{ height: 0, borderTop: `1px dashed ${paper.inkMute}`, margin: "6px 0" }} />
           <Row
             label={t("coverage.projection.net")}

--- a/lib/__tests__/paper_theme.test.ts
+++ b/lib/__tests__/paper_theme.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect } from "vitest";
 import {
   fmtMoney,
+  fmtMoneyOut,
   fmtKm,
   fmtDate,
   fmtYearMonth,
@@ -47,6 +48,24 @@ describe("fmtMoney", () => {
     const pos = fmtMoney(50);
     const neg = fmtMoney(-50);
     expect(pos).toBe(neg);
+  });
+});
+
+describe("fmtMoneyOut", () => {
+  it("prepends a minus sign (U+2212) to a positive cost", () => {
+    const result = fmtMoneyOut(1788.24);
+    expect(result.startsWith("− ")).toBe(true);
+    expect(result).toContain("€");
+    expect(result).toContain("1.788,24");
+  });
+
+  it("never double-negates: a negative input still yields a single leading minus", () => {
+    expect(fmtMoneyOut(50)).toBe(fmtMoneyOut(-50));
+  });
+
+  it("renders zero as a negative-prefixed amount", () => {
+    expect(fmtMoneyOut(0).startsWith("− ")).toBe(true);
+    expect(fmtMoneyOut(0)).toContain("0,00");
   });
 });
 

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -65,6 +65,8 @@ export const en: Messages = {
   "action.copied": "Copied!",
   "action.cancel": "Cancel",
   "action.close": "Close",
+  "action.collapse": "Collapse",
+  "action.expand": "Expand",
   "action.show_password": "Show password",
   "action.hide_password": "Hide password",
   "action.delete": "Delete",

--- a/lib/i18n/messages/nl.ts
+++ b/lib/i18n/messages/nl.ts
@@ -63,6 +63,8 @@ export const nl = {
   "action.copied": "Gekopieerd!",
   "action.cancel": "Annuleer",
   "action.close": "Sluiten",
+  "action.collapse": "Inklappen",
+  "action.expand": "Uitklappen",
   "action.show_password": "Wachtwoord tonen",
   "action.hide_password": "Wachtwoord verbergen",
   "action.delete": "Verwijderen",

--- a/lib/paper-theme.ts
+++ b/lib/paper-theme.ts
@@ -18,8 +18,7 @@ export const fontSerif = "var(--font-serif)";
 export const fontSans = "var(--font-sans)";
 
 /** Signed color: positive → green, negative → accent, zero → inkMute */
-export const amtColor = (n: number) =>
-  n > 0 ? paper.green : n < 0 ? paper.accent : paper.inkMute;
+export const amtColor = (n: number) => (n > 0 ? paper.green : n < 0 ? paper.accent : paper.inkMute);
 
 /** Sign prefix string: +, −, or empty */
 export const signPrefix = (n: number) => (n > 0 ? "+" : n < 0 ? "−" : "");
@@ -30,6 +29,15 @@ export function fmtMoney(n: number): string {
     "€\u00a0" +
     Math.abs(n).toLocaleString("nl-BE", { minimumFractionDigits: 2, maximumFractionDigits: 2 })
   );
+}
+
+/**
+ * Format a cost / outgoing amount as a negative euro value: − € 1.234,56
+ * Always prepends the minus sign (U+2212), regardless of the input's sign,
+ * so callers can pass the stored (positive) cost value directly.
+ */
+export function fmtMoneyOut(n: number): string {
+  return "− " + fmtMoney(n);
 }
 
 /** Format km with thousands separator */


### PR DESCRIPTION
Closes #182.

Two UX improvements to the car coverage card on the owner page.

## 1. Collapsible card
- Per-card collapse toggle, default expanded; collapsed shows car name, year and NET only.
- Collapse state is **controlled by the parent** (`app/admin/vehicles`), keyed by `car_id`, so the choice survives the year switch that remounts the card. The component keeps an internal-state fallback when the props are omitted.

## 2. Costs/fuel as negative red
- COSTS TO COVER, OWN FUEL and VARIABLE COSTS now render as negative values in red (`− € …`) via a new `fmtMoneyOut` helper.
- Presentation only — underlying calculations untouched; NET sign/color unchanged.

## Tests
- `paper_theme.test.ts` — `fmtMoneyOut`.
- `cost-coverage-screen.test.tsx` — collapse toggle, controlled mode (survives year switch), negative-red rendering, NET unchanged.
- Full suite: 533 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)