### PR TITLE
security(api): strip email + bank account from GET /api/people/[id] for non-owners

### DIFF
--- a/app/api/people/[id]/route.test.ts
+++ b/app/api/people/[id]/route.test.ts
@@ -80,12 +80,45 @@ beforeEach(() => {
 });
 
 describe("GET /api/people/[id]", () => {
-  it("returns the person for a valid id", async () => {
+  it("returns the full row (incl. email + bank_account) for an admin", async () => {
+    mockSession.isAdmin = true;
+    mockSession.personId = 99; // not the record owner, but admin
     const res = await GET(new Request("http://localhost/api/people/5"), makeCtx("5"));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toMatchObject({ id: 5, first_name: "Alice" });
+    expect(body.email).toBe("alice@example.com");
+    expect(body).toHaveProperty("bank_account");
     expect(mockGetPersonById).toHaveBeenCalledWith({}, 5);
+  });
+
+  it("returns the full row for a member requesting their OWN id", async () => {
+    mockSession.isAdmin = false;
+    mockSession.personId = 5; // owns record 5
+    const res = await GET(new Request("http://localhost/api/people/5"), makeCtx("5"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.email).toBe("alice@example.com");
+    expect(body).toHaveProperty("bank_account");
+  });
+
+  it("strips email + bank_account for a member requesting ANOTHER id", async () => {
+    mockSession.isAdmin = false;
+    mockSession.personId = 2; // different person
+    const res = await GET(new Request("http://localhost/api/people/5"), makeCtx("5"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).not.toHaveProperty("email");
+    expect(body).not.toHaveProperty("bank_account");
+    expect(body).toMatchObject({ id: 5, first_name: "Alice" });
+  });
+
+  it("returns 403 when unauthenticated", async () => {
+    mockSession.authenticated = false;
+    mockSession.personId = undefined;
+    mockSession.isAdmin = false;
+    const res = await GET(new Request("http://localhost/api/people/5"), makeCtx("5"));
+    expect(res.status).toBe(403);
   });
 
   it("returns 404 when the person does not exist", async () => {

--- a/app/api/people/[id]/route.ts
+++ b/app/api/people/[id]/route.ts
@@ -1,11 +1,19 @@
 import { getDb } from "@/lib/db";
 import { getPersonById, updatePerson } from "@/lib/queries/people";
-import { json, readBody, readId, notFound, requireAdmin } from "@/lib/api";
+import { json, readBody, readId, notFound, requireAdmin, requireSession } from "@/lib/api";
 import { personSchema } from "@/lib/schemas/person";
 
-export const GET = json(async (_req, ctx) => {
-  const person = getPersonById(getDb(), await readId(ctx));
+export const GET = json(async (req, ctx) => {
+  const session = await requireSession(req);
+  const id = await readId(ctx);
+  const person = getPersonById(getDb(), id);
   if (!person) notFound();
+  // Contact and banking details are private: only the record's owner or an
+  // admin may see them. Mirror the strip logic of the collection route.
+  if (!session.isAdmin && session.personId !== id) {
+    const { email: _e, bank_account: _b, ...rest } = person;
+    return rest;
+  }
   return person;
 });
 


### PR DESCRIPTION
Closes #307

## The leak

`GET /api/people/[id]` (`app/api/people/[id]/route.ts`) returned the **full** person row — including `email` and `bank_account` — to **any** authenticated member, regardless of whose record it was. (`password_hash` and `session_epoch` were already stripped inside `getPersonById`.)

This is a field-level authorization leak: the collection route `GET /api/people` already strips these PII fields for non-admins, but the single-record route was missed, so any member could read another member's contact and banking details by hitting `/api/people/{otherId}`.

## The fix

The `GET` handler now:

- Requires an authenticated session via `requireSession` (from `@/lib/api`).
- Returns the full row when the caller is the record's **owner** (`session.personId === id`) **or** an **admin**.
- Otherwise strips `email` and `bank_account`, mirroring the list-route logic.

`PUT` is unchanged. Known consumers stay correct: `app/user/[id]/edit/page.tsx` fetches the caller's own profile (owner branch) and `app/admin/members/page.tsx` is admin-only.

## Tests

Extended `app/api/people/[id]/route.test.ts` (vitest + iron-session mock, matching existing patterns):

1. **admin** → sees full row incl. `email` + `bank_account`
2. **member requesting their OWN id** → sees full row
3. **member requesting ANOTHER id** → `email` + `bank_account` stripped (non-sensitive fields still present)
4. **unauthenticated** → 403

(plus the existing 404 / 400-invalid-id coverage retained)

## Verification

- `npx tsc --noEmit`: no new errors introduced (36 pre-existing errors in unrelated test files, identical count on `origin/main` baseline; the changed files are type-clean).
- `npm run lint`: 0 errors (only pre-existing warnings).
- `npm test`: all **760** tests pass across 93 files (the `app/api/people/[id]/route.test.ts` file: 11 passing).

https://claude.ai/code/session_01EvJThHe6obwJKjS5cnPLv8

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvJThHe6obwJKjS5cnPLv8)_