### PR TITLE
security(api): require a session on reservation-create and the unauthenticated GET reads

### DIFF
--- a/app/api/people/route.test.ts
+++ b/app/api/people/route.test.ts
@@ -117,14 +117,11 @@ describe("GET /api/people", () => {
     expect(body[1]).toHaveProperty("first_name", "Bob");
   });
 
-  it("returns list even when not authenticated (unauthenticated session has isAdmin=false by default)", async () => {
+  it("returns 403 for an unauthenticated request", async () => {
     mockSession.isAdmin = false;
     mockSession.personId = undefined;
     const res = await GET(new Request("http://localhost/api/people"), ctx);
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    // Stripped of contacts
-    expect(body[0]).not.toHaveProperty("email");
+    expect(res.status).toBe(403);
   });
 });
 

--- a/app/api/people/route.ts
+++ b/app/api/people/route.ts
@@ -1,13 +1,11 @@
 import { NextResponse } from "next/server";
-import { getIronSession } from "iron-session";
-import { sessionOptions, type SessionData } from "@/lib/session";
 import { getDb } from "@/lib/db";
 import { getPeople, insertPerson } from "@/lib/queries/people";
-import { json, readBody, requireAdmin } from "@/lib/api";
+import { json, readBody, requireAdmin, requireSession } from "@/lib/api";
 import { personSchema } from "@/lib/schemas/person";
 
 export const GET = json(async (req) => {
-  const session = await getIronSession<SessionData>(req, NextResponse.next(), sessionOptions);
+  const session = await requireSession(req);
   const people = getPeople(getDb());
   // The people list is consumed by forms across the app (driver/owner pickers),
   // so it stays readable by any authenticated user — but contact and banking

--- a/app/api/reservations/[id]/route.test.ts
+++ b/app/api/reservations/[id]/route.test.ts
@@ -55,9 +55,7 @@ function putReq(body: unknown, withCsrf = true) {
     method: "PUT",
     headers: {
       "Content-Type": "application/json",
-      ...(withCsrf
-        ? { Cookie: `csrf-token=${CSRF}`, "x-csrf-token": CSRF }
-        : {}),
+      ...(withCsrf ? { Cookie: `csrf-token=${CSRF}`, "x-csrf-token": CSRF } : {}),
       "x-forwarded-for": `198.51.100.${++ip}`,
     },
     body: JSON.stringify(body),
@@ -67,9 +65,7 @@ function deleteReq(withCsrf = true) {
   return new Request("http://localhost/api/reservations/5", {
     method: "DELETE",
     headers: {
-      ...(withCsrf
-        ? { Cookie: `csrf-token=${CSRF}`, "x-csrf-token": CSRF }
-        : {}),
+      ...(withCsrf ? { Cookie: `csrf-token=${CSRF}`, "x-csrf-token": CSRF } : {}),
       "x-forwarded-for": `198.51.100.${++ip}`,
     },
   });
@@ -92,7 +88,14 @@ beforeEach(() => {
 });
 
 describe("GET /api/reservations/[id]", () => {
-  it("returns the reservation for any request (no auth guard on GET)", async () => {
+  it("returns 403 for an unauthenticated request", async () => {
+    mockSession.personId = undefined as unknown as number;
+    const res = await GET(getReq(), ctx);
+    expect(res.status).toBe(403);
+    expect(mockGetReservationById).not.toHaveBeenCalled();
+  });
+
+  it("returns the reservation for an authenticated request", async () => {
     const res = await GET(getReq(), ctx);
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({ id: 5 });

--- a/app/api/reservations/[id]/route.ts
+++ b/app/api/reservations/[id]/route.ts
@@ -6,11 +6,12 @@ import {
   deleteReservation,
   ConflictError,
 } from "@/lib/queries/reservations";
-import { json, readBody, readId, notFound, requireCanEdit } from "@/lib/api";
+import { json, readBody, readId, notFound, requireCanEdit, requireSession } from "@/lib/api";
 import { reservationSchema } from "@/lib/schemas/reservation";
 import { syncReservationUpdate, syncReservationDelete } from "@/lib/reservation-sync";
 
-export const GET = json(async (_req, ctx) => {
+export const GET = json(async (req, ctx) => {
+  await requireSession(req);
   const id = await readId(ctx);
   const row = getReservationById(getDb(), id);
   if (!row) notFound();

--- a/app/api/reservations/route.test.ts
+++ b/app/api/reservations/route.test.ts
@@ -25,8 +25,9 @@ vi.mock("@/lib/queries/reservations", () => ({
   getReservationById: (...a: unknown[]) => mockGetReservationById(...a),
 }));
 
+const mockSyncReservationCreate = vi.fn(() => Promise.resolve());
 vi.mock("@/lib/reservation-sync", () => ({
-  syncReservationCreate: vi.fn(() => Promise.resolve()),
+  syncReservationCreate: () => mockSyncReservationCreate(),
 }));
 
 import { GET, POST } from "./route";
@@ -43,9 +44,7 @@ function postReq(body: unknown, withCsrf = true) {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      ...(withCsrf
-        ? { Cookie: `csrf-token=${CSRF}`, "x-csrf-token": CSRF }
-        : {}),
+      ...(withCsrf ? { Cookie: `csrf-token=${CSRF}`, "x-csrf-token": CSRF } : {}),
       "x-forwarded-for": `198.51.100.${++ip}`,
     },
     body: JSON.stringify(body),
@@ -83,6 +82,14 @@ describe("GET /api/reservations", () => {
 });
 
 describe("POST /api/reservations", () => {
+  it("returns 403 for an unauthenticated request before any insert or sync", async () => {
+    mockSession.personId = undefined as unknown as number;
+    const res = await POST(postReq(validReservation), ctx);
+    expect(res.status).toBe(403);
+    expect(mockInsertReservation).not.toHaveBeenCalled();
+    expect(mockSyncReservationCreate).not.toHaveBeenCalled();
+  });
+
   it("creates a reservation with a valid body", async () => {
     const res = await POST(postReq(validReservation), ctx);
     expect(res.status).toBe(201);

--- a/app/api/reservations/route.ts
+++ b/app/api/reservations/route.ts
@@ -11,6 +11,7 @@ export const GET = json(async (req) => {
 });
 
 export const POST = json(async (req) => {
+  await requireSession(req);
   const raw = await req.json();
   const body = reservationSchema.parse(raw);
   const client_id = typeof raw.client_id === "string" ? raw.client_id : null;

--- a/app/api/vehicles/[id]/route.test.ts
+++ b/app/api/vehicles/[id]/route.test.ts
@@ -45,9 +45,7 @@ function putReq(body: unknown, withCsrf = true) {
     method: "PUT",
     headers: {
       "Content-Type": "application/json",
-      ...(withCsrf
-        ? { Cookie: `csrf-token=${CSRF}`, "x-csrf-token": CSRF }
-        : {}),
+      ...(withCsrf ? { Cookie: `csrf-token=${CSRF}`, "x-csrf-token": CSRF } : {}),
       "x-forwarded-for": `198.51.100.${++ip}`,
     },
     body: JSON.stringify(body),
@@ -57,9 +55,7 @@ function deleteReq(withCsrf = true) {
   return new Request("http://localhost/api/vehicles/5", {
     method: "DELETE",
     headers: {
-      ...(withCsrf
-        ? { Cookie: `csrf-token=${CSRF}`, "x-csrf-token": CSRF }
-        : {}),
+      ...(withCsrf ? { Cookie: `csrf-token=${CSRF}`, "x-csrf-token": CSRF } : {}),
       "x-forwarded-for": `198.51.100.${++ip}`,
     },
   });
@@ -102,7 +98,14 @@ beforeEach(() => {
 });
 
 describe("GET /api/vehicles/[id]", () => {
-  it("returns the car without any auth check", async () => {
+  it("returns 403 for an unauthenticated request", async () => {
+    mockSession.personId = undefined;
+    const res = await GET(getReq(), ctx);
+    expect(res.status).toBe(403);
+    expect(mockGetCarById).not.toHaveBeenCalled();
+  });
+
+  it("returns the car for an authenticated request", async () => {
     const res = await GET(getReq(), ctx);
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({ id: 5 });
@@ -133,7 +136,18 @@ describe("PUT /api/vehicles/[id]", () => {
 
   it("returns 403 when owner tries to update a car they do not own", async () => {
     mockIsOwner.mockReturnValue(true);
-    mockGetCarById.mockReturnValue({ id: 5, owner_person_id: 99, short: "XX", name: "Other", price_per_km: 0.2, brand: null, color: null, long_threshold: 500, active: 1, expected_km: null });
+    mockGetCarById.mockReturnValue({
+      id: 5,
+      owner_person_id: 99,
+      short: "XX",
+      name: "Other",
+      price_per_km: 0.2,
+      brand: null,
+      color: null,
+      long_threshold: 500,
+      active: 1,
+      expected_km: null,
+    });
     const res = await PUT(putReq(ownerPatch), ctx);
     expect(res.status).toBe(403);
     expect(mockUpdateCar).not.toHaveBeenCalled();

--- a/app/api/vehicles/[id]/route.ts
+++ b/app/api/vehicles/[id]/route.ts
@@ -9,9 +9,11 @@ import {
   forbidden,
   conflict,
   requireAdminOrOwner,
+  requireSession,
 } from "@/lib/api";
 
-export const GET = json(async (_req, ctx) => {
+export const GET = json(async (req, ctx) => {
+  await requireSession(req);
   const car = getCarById(getDb(), await readId(ctx));
   if (!car) notFound();
   return car;

--- a/app/api/vehicles/route.test.ts
+++ b/app/api/vehicles/route.test.ts
@@ -41,9 +41,7 @@ function postReq(body: unknown, withCsrf = true) {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      ...(withCsrf
-        ? { Cookie: `csrf-token=${CSRF}`, "x-csrf-token": CSRF }
-        : {}),
+      ...(withCsrf ? { Cookie: `csrf-token=${CSRF}`, "x-csrf-token": CSRF } : {}),
       "x-forwarded-for": `198.51.100.${++ip}`,
     },
     body: JSON.stringify(body),
@@ -65,7 +63,14 @@ beforeEach(() => {
 });
 
 describe("GET /api/vehicles", () => {
-  it("returns the car list without any auth check", async () => {
+  it("returns 403 for an unauthenticated request", async () => {
+    mockSession.personId = undefined;
+    const res = await GET(getReq(), ctx);
+    expect(res.status).toBe(403);
+    expect(mockGetCars).not.toHaveBeenCalled();
+  });
+
+  it("returns the car list for an authenticated user", async () => {
     const res = await GET(getReq(), ctx);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual([{ id: 1, short: "AA" }]);

--- a/app/api/vehicles/route.ts
+++ b/app/api/vehicles/route.ts
@@ -2,9 +2,12 @@ import { NextResponse } from "next/server";
 import { getCars, insertCar } from "@/lib/queries/cars";
 import { carSchema } from "@/lib/schemas/car";
 import { getDb } from "@/lib/db";
-import { json, readBody, requireAdminOrOwner } from "@/lib/api";
+import { json, readBody, requireAdminOrOwner, requireSession } from "@/lib/api";
 
-export const GET = json(async () => getCars(getDb()));
+export const GET = json(async (req) => {
+  await requireSession(req);
+  return getCars(getDb());
+});
 
 export const POST = json(async (req) => {
   const session = await requireAdminOrOwner(req);


### PR DESCRIPTION
Closes #306

Several API routes had no server-side authentication guard. The `json()` wrapper's CSRF check is a double-submit (the caller controls both the cookie and the header), so it is **not** an auth barrier — only `requireSession` / `requireAdmin` / etc. are. This adds `await requireSession(req)` to the unguarded routes, matching the style of the already-guarded ones.

## Routes fixed
- **`POST /api/reservations`** (HIGH) — now rejects unauthenticated callers **before** any DB insert or `syncReservationCreate()` call. Previously anyone could create a reservation, which writes to the shared Google Calendar.
- **`GET /api/reservations/[id]`** — now requires a session.
- **`GET /api/vehicles`** — now requires a session.
- **`GET /api/vehicles/[id]`** — now requires a session.
- **`GET /api/people`** — replaced the inline `getIronSession` read with `requireSession`, so unauthenticated callers get 403. The existing admin-vs-stripped logic (email/bank_account stripped for non-admins) is unchanged.

`app/api/people/[id]/route.ts` was intentionally left untouched (handled separately in #307).

## Tests
Flipped the route tests added in #305 that asserted the insecure behavior so they now assert **403** for the no-session case, keeping the authenticated-path assertions:
- `app/api/reservations/route.test.ts` — added an unauthenticated `POST` test asserting 403 and that neither `insertReservation` nor `syncReservationCreate` is called.
- `app/api/reservations/[id]/route.test.ts` — `GET` no-auth test flipped to 403.
- `app/api/vehicles/route.test.ts` — `GET` no-auth test flipped to 403.
- `app/api/vehicles/[id]/route.test.ts` — `GET` no-auth test flipped to 403.
- `app/api/people/route.test.ts` — the "returns list even when not authenticated" test flipped to assert 403.

## Verification
- `npx tsc --noEmit` — no new errors in the edited files (the 36 remaining errors are pre-existing test-typing issues in the #305 suite, identical on `main`).
- `npm run lint` — 0 errors (7 pre-existing warnings in unrelated files).
- `npm test` — 761 passed (93 files).

https://claude.ai/code/session_01EvJThHe6obwJKjS5cnPLv8

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvJThHe6obwJKjS5cnPLv8)_