### PR TITLE
fix(api): require authentication on reservation create + public GET endpoints

### DIFF
--- a/app/api/people/route.test.ts
+++ b/app/api/people/route.test.ts
@@ -90,6 +90,13 @@ beforeEach(() => {
 });
 
 describe("GET /api/people", () => {
+  it("returns 403 for an unauthenticated request", async () => {
+    mockSession.isAdmin = false;
+    mockSession.personId = undefined;
+    const res = await GET(new Request("http://localhost/api/people"), ctx);
+    expect(res.status).toBe(403);
+  });
+
   it("returns full list including email and bank_account for admins", async () => {
     const res = await GET(new Request("http://localhost/api/people"), ctx);
     expect(res.status).toBe(200);
@@ -101,7 +108,7 @@ describe("GET /api/people", () => {
     expect(body[1]).toHaveProperty("email", "bob@example.com");
   });
 
-  it("strips email and bank_account for non-admin users", async () => {
+  it("strips email and bank_account for non-admin authenticated users", async () => {
     mockSession.isAdmin = false;
     const res = await GET(new Request("http://localhost/api/people"), ctx);
     expect(res.status).toBe(200);
@@ -115,16 +122,6 @@ describe("GET /api/people", () => {
     // But other fields are still present
     expect(body[0]).toHaveProperty("first_name", "Alice");
     expect(body[1]).toHaveProperty("first_name", "Bob");
-  });
-
-  it("returns list even when not authenticated (unauthenticated session has isAdmin=false by default)", async () => {
-    mockSession.isAdmin = false;
-    mockSession.personId = undefined;
-    const res = await GET(new Request("http://localhost/api/people"), ctx);
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    // Stripped of contacts
-    expect(body[0]).not.toHaveProperty("email");
   });
 });
 

--- a/app/api/people/route.ts
+++ b/app/api/people/route.ts
@@ -3,10 +3,11 @@ import { getIronSession } from "iron-session";
 import { sessionOptions, type SessionData } from "@/lib/session";
 import { getDb } from "@/lib/db";
 import { getPeople, insertPerson } from "@/lib/queries/people";
-import { json, readBody, requireAdmin } from "@/lib/api";
+import { json, readBody, requireAdmin, requireSession } from "@/lib/api";
 import { personSchema } from "@/lib/schemas/person";
 
 export const GET = json(async (req) => {
+  await requireSession(req);
   const session = await getIronSession<SessionData>(req, NextResponse.next(), sessionOptions);
   const people = getPeople(getDb());
   // The people list is consumed by forms across the app (driver/owner pickers),

--- a/app/api/reservations/[id]/route.test.ts
+++ b/app/api/reservations/[id]/route.test.ts
@@ -92,7 +92,14 @@ beforeEach(() => {
 });
 
 describe("GET /api/reservations/[id]", () => {
-  it("returns the reservation for any request (no auth guard on GET)", async () => {
+  it("returns 403 for an unauthenticated request", async () => {
+    mockSession.personId = undefined as unknown as number;
+    const res = await GET(getReq(), ctx);
+    expect(res.status).toBe(403);
+    expect(mockGetReservationById).not.toHaveBeenCalled();
+  });
+
+  it("returns the reservation for an authenticated user", async () => {
     const res = await GET(getReq(), ctx);
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({ id: 5 });

--- a/app/api/reservations/[id]/route.ts
+++ b/app/api/reservations/[id]/route.ts
@@ -6,11 +6,12 @@ import {
   deleteReservation,
   ConflictError,
 } from "@/lib/queries/reservations";
-import { json, readBody, readId, notFound, requireCanEdit } from "@/lib/api";
+import { json, readBody, readId, notFound, requireCanEdit, requireSession } from "@/lib/api";
 import { reservationSchema } from "@/lib/schemas/reservation";
 import { syncReservationUpdate, syncReservationDelete } from "@/lib/reservation-sync";
 
-export const GET = json(async (_req, ctx) => {
+export const GET = json(async (req, ctx) => {
+  await requireSession(req);
   const id = await readId(ctx);
   const row = getReservationById(getDb(), id);
   if (!row) notFound();

--- a/app/api/reservations/route.test.ts
+++ b/app/api/reservations/route.test.ts
@@ -83,6 +83,15 @@ describe("GET /api/reservations", () => {
 });
 
 describe("POST /api/reservations", () => {
+  it("returns 403 for an unauthenticated request (no insert, no sync)", async () => {
+    mockSession.personId = undefined as unknown as number;
+    const { syncReservationCreate } = await import("@/lib/reservation-sync");
+    const res = await POST(postReq(validReservation), ctx);
+    expect(res.status).toBe(403);
+    expect(mockInsertReservation).not.toHaveBeenCalled();
+    expect(syncReservationCreate).not.toHaveBeenCalled();
+  });
+
   it("creates a reservation with a valid body", async () => {
     const res = await POST(postReq(validReservation), ctx);
     expect(res.status).toBe(201);

--- a/app/api/reservations/route.ts
+++ b/app/api/reservations/route.ts
@@ -11,6 +11,7 @@ export const GET = json(async (req) => {
 });
 
 export const POST = json(async (req) => {
+  await requireSession(req);
   const raw = await req.json();
   const body = reservationSchema.parse(raw);
   const client_id = typeof raw.client_id === "string" ? raw.client_id : null;

--- a/app/api/vehicles/[id]/route.test.ts
+++ b/app/api/vehicles/[id]/route.test.ts
@@ -102,7 +102,14 @@ beforeEach(() => {
 });
 
 describe("GET /api/vehicles/[id]", () => {
-  it("returns the car without any auth check", async () => {
+  it("returns 403 for an unauthenticated request", async () => {
+    mockSession.personId = undefined;
+    const res = await GET(getReq(), ctx);
+    expect(res.status).toBe(403);
+    expect(mockGetCarById).not.toHaveBeenCalled();
+  });
+
+  it("returns the car for an authenticated user", async () => {
     const res = await GET(getReq(), ctx);
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({ id: 5 });

--- a/app/api/vehicles/[id]/route.ts
+++ b/app/api/vehicles/[id]/route.ts
@@ -9,9 +9,11 @@ import {
   forbidden,
   conflict,
   requireAdminOrOwner,
+  requireSession,
 } from "@/lib/api";
 
-export const GET = json(async (_req, ctx) => {
+export const GET = json(async (req, ctx) => {
+  await requireSession(req);
   const car = getCarById(getDb(), await readId(ctx));
   if (!car) notFound();
   return car;

--- a/app/api/vehicles/route.test.ts
+++ b/app/api/vehicles/route.test.ts
@@ -65,7 +65,14 @@ beforeEach(() => {
 });
 
 describe("GET /api/vehicles", () => {
-  it("returns the car list without any auth check", async () => {
+  it("returns 403 for an unauthenticated request", async () => {
+    mockSession.personId = undefined;
+    const res = await GET(getReq(), ctx);
+    expect(res.status).toBe(403);
+    expect(mockGetCars).not.toHaveBeenCalled();
+  });
+
+  it("returns the car list for an authenticated user", async () => {
     const res = await GET(getReq(), ctx);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual([{ id: 1, short: "AA" }]);

--- a/app/api/vehicles/route.ts
+++ b/app/api/vehicles/route.ts
@@ -2,9 +2,12 @@ import { NextResponse } from "next/server";
 import { getCars, insertCar } from "@/lib/queries/cars";
 import { carSchema } from "@/lib/schemas/car";
 import { getDb } from "@/lib/db";
-import { json, readBody, requireAdminOrOwner } from "@/lib/api";
+import { json, readBody, requireAdminOrOwner, requireSession } from "@/lib/api";
 
-export const GET = json(async () => getCars(getDb()));
+export const GET = json(async (req) => {
+  await requireSession(req);
+  return getCars(getDb());
+});
 
 export const POST = json(async (req) => {
   const session = await requireAdminOrOwner(req);


### PR DESCRIPTION
Closes #306

Adds `requireSession` to 5 routes that had no auth (the `json()` wrapper's CSRF double-submit is client-settable, not auth):

- **`POST /api/reservations`** — rejects unauthenticated callers **before** any DB insert or Google Calendar sync (high severity: unauth write + external side effect).
- **`GET /api/reservations/[id]`**, **`GET /api/vehicles`**, **`GET /api/vehicles/[id]`**, **`GET /api/people`** — now 403 for unauthenticated callers (the people list keeps its admin-only field strip for authenticated non-admins).

Route tests updated: happy paths run authenticated; new unauthenticated→403 cases assert no DB/side-effect work happens. 58 tests pass on the 5 files; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)