### PR TITLE
test(db): targeted migration tests + forward-migration test

### DIFF
--- a/lib/__tests__/migration_0006_to_0010.test.ts
+++ b/lib/__tests__/migration_0006_to_0010.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../db/migrate";
+
+function makeDb() {
+  const db = new Database(":memory:");
+  runMigrations(db);
+  return db;
+}
+
+describe("migration 0006 — settings table", () => {
+  it("creates the settings table", () => {
+    const db = makeDb();
+    const tables = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table'")
+      .all() as { name: string }[];
+    expect(tables.map((t) => t.name)).toContain("settings");
+  });
+
+  it("settings table has key and value columns", () => {
+    const db = makeDb();
+    const cols = db.prepare("PRAGMA table_info(settings)").all() as {
+      name: string;
+      type: string;
+      dflt_value: string | null;
+    }[];
+    const names = cols.map((c) => c.name);
+    expect(names).toContain("key");
+    expect(names).toContain("value");
+  });
+
+  it("value column defaults to empty string", () => {
+    const db = makeDb();
+    const col = (
+      db.prepare("PRAGMA table_info(settings)").all() as {
+        name: string;
+        dflt_value: string | null;
+      }[]
+    ).find((c) => c.name === "value");
+    expect(col!.dflt_value).toBe("''");
+  });
+
+  it("seeds coop_bank_account row", () => {
+    const db = makeDb();
+    const row = db
+      .prepare("SELECT value FROM settings WHERE key = 'coop_bank_account'")
+      .get() as { value: string } | undefined;
+    expect(row).toBeTruthy();
+    expect(row!.value).toBe("");
+  });
+
+  it("running migration again does not duplicate the seed row", () => {
+    const db = makeDb();
+    runMigrations(db); // second run — idempotent
+    const rows = db
+      .prepare("SELECT COUNT(*) as cnt FROM settings WHERE key = 'coop_bank_account'")
+      .get() as { cnt: number };
+    expect(rows.cnt).toBe(1);
+  });
+});
+
+describe("migration 0007 — settled_outside flag", () => {
+  it("adds settled_outside to fuel_fillups", () => {
+    const db = makeDb();
+    const cols = db.prepare("PRAGMA table_info(fuel_fillups)").all() as {
+      name: string;
+      dflt_value: string | null;
+    }[];
+    const col = cols.find((c) => c.name === "settled_outside");
+    expect(col).toBeTruthy();
+    expect(col!.dflt_value).toBe("0");
+  });
+
+  it("adds settled_outside to expenses", () => {
+    const db = makeDb();
+    const cols = db.prepare("PRAGMA table_info(expenses)").all() as {
+      name: string;
+      dflt_value: string | null;
+    }[];
+    const col = cols.find((c) => c.name === "settled_outside");
+    expect(col).toBeTruthy();
+    expect(col!.dflt_value).toBe("0");
+  });
+
+  it("settled_outside defaults to 0 on insert", () => {
+    const db = makeDb();
+    db.exec("INSERT INTO people (id, first_name, active) VALUES (1, 'Alice', 1)");
+    db.exec("INSERT INTO cars (id, short, name, price_per_km) VALUES (1, 'X', 'Car', 0.3)");
+    db.prepare(
+      "INSERT INTO fuel_fillups (person_id, car_id, date, amount, liters, price_per_liter) VALUES (?,?,?,?,?,?)"
+    ).run(1, 1, "2026-01-01", 50, 30, 1.65);
+    const row = db.prepare("SELECT settled_outside FROM fuel_fillups LIMIT 1").get() as {
+      settled_outside: number;
+    };
+    expect(row.settled_outside).toBe(0);
+  });
+});
+
+describe("migration 0008 — drop fixed_costs_json from cars", () => {
+  it("fixed_costs_json column no longer exists on cars", () => {
+    const db = makeDb();
+    const cols = db.prepare("PRAGMA table_info(cars)").all() as { name: string }[];
+    const names = cols.map((c) => c.name);
+    expect(names).not.toContain("fixed_costs_json");
+  });
+
+  it("cars table still has expected core columns after drop", () => {
+    const db = makeDb();
+    const cols = db.prepare("PRAGMA table_info(cars)").all() as { name: string }[];
+    const names = cols.map((c) => c.name);
+    expect(names).toContain("id");
+    expect(names).toContain("short");
+    expect(names).toContain("name");
+    expect(names).toContain("price_per_km");
+  });
+});
+
+describe("migration 0009 — updated_at on admin tables", () => {
+  it("adds updated_at to payments", () => {
+    const db = makeDb();
+    const cols = db.prepare("PRAGMA table_info(payments)").all() as {
+      name: string;
+      dflt_value: string | null;
+    }[];
+    const col = cols.find((c) => c.name === "updated_at");
+    expect(col).toBeTruthy();
+    expect(col!.dflt_value).toBe("'1970-01-01 00:00:00'");
+  });
+
+  it("adds updated_at to cars", () => {
+    const db = makeDb();
+    const cols = db.prepare("PRAGMA table_info(cars)").all() as {
+      name: string;
+      dflt_value: string | null;
+    }[];
+    const col = cols.find((c) => c.name === "updated_at");
+    expect(col).toBeTruthy();
+    expect(col!.dflt_value).toBe("'1970-01-01 00:00:00'");
+  });
+
+  it("adds updated_at to people", () => {
+    const db = makeDb();
+    const cols = db.prepare("PRAGMA table_info(people)").all() as {
+      name: string;
+      dflt_value: string | null;
+    }[];
+    const col = cols.find((c) => c.name === "updated_at");
+    expect(col).toBeTruthy();
+    expect(col!.dflt_value).toBe("'1970-01-01 00:00:00'");
+  });
+
+  it("adds updated_at to settlements", () => {
+    const db = makeDb();
+    const cols = db.prepare("PRAGMA table_info(settlements)").all() as {
+      name: string;
+      dflt_value: string | null;
+    }[];
+    const col = cols.find((c) => c.name === "updated_at");
+    expect(col).toBeTruthy();
+    expect(col!.dflt_value).toBe("'1970-01-01 00:00:00'");
+  });
+
+  it("adds updated_at to settings", () => {
+    const db = makeDb();
+    const cols = db.prepare("PRAGMA table_info(settings)").all() as {
+      name: string;
+      dflt_value: string | null;
+    }[];
+    const col = cols.find((c) => c.name === "updated_at");
+    expect(col).toBeTruthy();
+    expect(col!.dflt_value).toBe("'1970-01-01 00:00:00'");
+  });
+
+  it("AFTER UPDATE trigger bumps updated_at on cars", () => {
+    const db = makeDb();
+    db.exec("INSERT INTO people (id, first_name, active) VALUES (1, 'Alice', 1)");
+    db.exec("INSERT INTO cars (id, short, name, price_per_km) VALUES (1, 'X', 'Car', 0.3)");
+    // Set a known sentinel value then update
+    db.exec("UPDATE cars SET updated_at = '1970-01-01 00:00:00' WHERE id = 1");
+    db.exec("UPDATE cars SET price_per_km = 0.4 WHERE id = 1");
+    const row = db.prepare("SELECT updated_at FROM cars WHERE id = 1").get() as {
+      updated_at: string;
+    };
+    expect(row.updated_at).not.toBe("1970-01-01 00:00:00");
+  });
+
+  it("AFTER UPDATE trigger bumps updated_at on people", () => {
+    const db = makeDb();
+    db.exec("INSERT INTO people (id, first_name, active) VALUES (1, 'Alice', 1)");
+    db.exec("UPDATE people SET updated_at = '1970-01-01 00:00:00' WHERE id = 1");
+    db.exec("UPDATE people SET discount = 0.1 WHERE id = 1");
+    const row = db.prepare("SELECT updated_at FROM people WHERE id = 1").get() as {
+      updated_at: string;
+    };
+    expect(row.updated_at).not.toBe("1970-01-01 00:00:00");
+  });
+});
+
+describe("migration 0010 — people bank_account", () => {
+  it("adds bank_account column to people", () => {
+    const db = makeDb();
+    const cols = db.prepare("PRAGMA table_info(people)").all() as {
+      name: string;
+      dflt_value: string | null;
+    }[];
+    const col = cols.find((c) => c.name === "bank_account");
+    expect(col).toBeTruthy();
+    expect(col!.dflt_value).toBe("''");
+  });
+
+  it("bank_account defaults to empty string on insert", () => {
+    const db = makeDb();
+    db.exec("INSERT INTO people (id, first_name, active) VALUES (1, 'Alice', 1)");
+    const row = db.prepare("SELECT bank_account FROM people WHERE id = 1").get() as {
+      bank_account: string;
+    };
+    expect(row.bank_account).toBe("");
+  });
+
+  it("bank_account accepts a value", () => {
+    const db = makeDb();
+    db.exec("INSERT INTO people (id, first_name, active) VALUES (1, 'Alice', 1)");
+    db.exec("UPDATE people SET bank_account = 'BE68539007547034' WHERE id = 1");
+    const row = db.prepare("SELECT bank_account FROM people WHERE id = 1").get() as {
+      bank_account: string;
+    };
+    expect(row.bank_account).toBe("BE68539007547034");
+  });
+});

--- a/lib/__tests__/migration_0015_to_0017.test.ts
+++ b/lib/__tests__/migration_0015_to_0017.test.ts
@@ -1,0 +1,314 @@
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../db/migrate";
+
+function makeDb() {
+  const db = new Database(":memory:");
+  runMigrations(db);
+  return db;
+}
+
+/**
+ * Hand-rolled schema representing the state AFTER migration 0014 (before 0015).
+ * Columns added by 0015–0022 are intentionally absent so those migrations can run.
+ */
+function buildDbAt0014(): Database.Database {
+  const db = new Database(":memory:");
+
+  db.exec(`
+    CREATE TABLE _migrations (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      filename TEXT NOT NULL UNIQUE,
+      applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    -- people: has name (pre-0015), no first_name/last_name, no email, no theme_preference,
+    --         no session_epoch (those come in 0011, 0015, 0018, 0021)
+    CREATE TABLE people (
+      id            INTEGER PRIMARY KEY AUTOINCREMENT,
+      name          TEXT    NOT NULL DEFAULT '',
+      discount      REAL    NOT NULL DEFAULT 0,
+      discount_long REAL    NOT NULL DEFAULT 0,
+      active        INTEGER NOT NULL DEFAULT 1,
+      username      TEXT    UNIQUE,
+      password_hash TEXT,
+      is_admin      INTEGER NOT NULL DEFAULT 0,
+      updated_at    TEXT    NOT NULL DEFAULT '1970-01-01 00:00:00',
+      bank_account  TEXT    NOT NULL DEFAULT '',
+      email         TEXT
+    );
+
+    -- invite_tokens: no purpose column yet (comes in 0022)
+    CREATE TABLE invite_tokens (
+      token      TEXT    PRIMARY KEY,
+      person_id  INTEGER NOT NULL REFERENCES people(id) ON DELETE CASCADE,
+      expires_at TEXT    NOT NULL
+    );
+
+    -- cars: still has owner_name (dropped in 0016), no owner_person_id yet (comes in 0012)
+    CREATE TABLE cars (
+      id               INTEGER PRIMARY KEY AUTOINCREMENT,
+      short            TEXT    NOT NULL UNIQUE,
+      name             TEXT    NOT NULL,
+      price_per_km     REAL    NOT NULL,
+      brand            TEXT,
+      color            TEXT,
+      owner_name       TEXT,
+      long_threshold   INTEGER NOT NULL DEFAULT 500,
+      active           INTEGER NOT NULL DEFAULT 1,
+      expected_km      INTEGER,
+      owner_from       TEXT,
+      owner_to         TEXT,
+      updated_at       TEXT    NOT NULL DEFAULT '1970-01-01 00:00:00',
+      owner_person_id  INTEGER REFERENCES people(id)
+    );
+
+    CREATE TABLE trips (
+      id             INTEGER PRIMARY KEY AUTOINCREMENT,
+      person_id      INTEGER NOT NULL REFERENCES people(id) ON DELETE RESTRICT,
+      car_id         INTEGER NOT NULL REFERENCES cars(id)   ON DELETE RESTRICT,
+      date           TEXT    NOT NULL,
+      start_odometer INTEGER NOT NULL,
+      end_odometer   INTEGER NOT NULL,
+      km             INTEGER NOT NULL,
+      amount         REAL    NOT NULL,
+      location       TEXT,
+      parking        TEXT,
+      gps_coords     TEXT,
+      client_id      TEXT    UNIQUE,
+      updated_at     TEXT    NOT NULL DEFAULT (CURRENT_TIMESTAMP)
+    );
+
+    CREATE TABLE fuel_fillups (
+      id              INTEGER PRIMARY KEY AUTOINCREMENT,
+      person_id       INTEGER NOT NULL REFERENCES people(id) ON DELETE RESTRICT,
+      car_id          INTEGER NOT NULL REFERENCES cars(id)   ON DELETE RESTRICT,
+      date            TEXT    NOT NULL,
+      amount          REAL    NOT NULL,
+      liters          REAL    NOT NULL,
+      price_per_liter REAL    NOT NULL,
+      odometer        INTEGER,
+      receipt         TEXT,
+      location        TEXT,
+      gps_coords      TEXT,
+      full_tank       INTEGER NOT NULL DEFAULT 0,
+      client_id       TEXT    UNIQUE,
+      updated_at      TEXT    NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+      settled_outside INTEGER NOT NULL DEFAULT 0
+    );
+
+    CREATE TABLE expenses (
+      id              INTEGER PRIMARY KEY AUTOINCREMENT,
+      person_id       INTEGER NOT NULL REFERENCES people(id) ON DELETE RESTRICT,
+      car_id          INTEGER NOT NULL REFERENCES cars(id)   ON DELETE RESTRICT,
+      date            TEXT    NOT NULL,
+      amount          REAL    NOT NULL,
+      description     TEXT,
+      category        TEXT,
+      client_id       TEXT    UNIQUE,
+      updated_at      TEXT    NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+      settled_outside INTEGER NOT NULL DEFAULT 0
+    );
+
+    CREATE TABLE reservations (
+      id                         INTEGER PRIMARY KEY AUTOINCREMENT,
+      person_id                  INTEGER NOT NULL REFERENCES people(id) ON DELETE RESTRICT,
+      car_id                     INTEGER NOT NULL REFERENCES cars(id)   ON DELETE RESTRICT,
+      start_date                 TEXT    NOT NULL,
+      end_date                   TEXT    NOT NULL,
+      status                     TEXT    NOT NULL DEFAULT 'pending',
+      note                       TEXT,
+      client_id                  TEXT    UNIQUE,
+      updated_at                 TEXT    NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+      google_event_id            TEXT,
+      last_synced_etag           TEXT,
+      last_app_write_nonce       TEXT,
+      last_known_response_status TEXT
+    );
+
+    CREATE TABLE payments (
+      id         INTEGER PRIMARY KEY AUTOINCREMENT,
+      person_id  INTEGER NOT NULL REFERENCES people(id) ON DELETE RESTRICT,
+      date       TEXT    NOT NULL,
+      amount     REAL    NOT NULL,
+      note       TEXT,
+      year       INTEGER NOT NULL,
+      updated_at TEXT    NOT NULL DEFAULT '1970-01-01 00:00:00'
+    );
+
+    CREATE TABLE settlements (
+      year       INTEGER PRIMARY KEY,
+      settled_at TEXT    NOT NULL,
+      settled_by TEXT    NOT NULL,
+      updated_at TEXT    NOT NULL DEFAULT '1970-01-01 00:00:00'
+    );
+
+    CREATE TABLE settings (
+      key        TEXT PRIMARY KEY,
+      value      TEXT NOT NULL DEFAULT '',
+      updated_at TEXT NOT NULL DEFAULT '1970-01-01 00:00:00'
+    );
+
+    CREATE TABLE car_price_history (
+      id             INTEGER PRIMARY KEY AUTOINCREMENT,
+      car_id         INTEGER NOT NULL REFERENCES cars(id) ON DELETE CASCADE,
+      price_per_km   REAL    NOT NULL,
+      effective_from TEXT    NOT NULL
+    );
+
+    CREATE TABLE calendar_sync_state (
+      id            INTEGER PRIMARY KEY CHECK (id = 1),
+      channel_id    TEXT NOT NULL,
+      resource_id   TEXT NOT NULL,
+      expiration_at TEXT NOT NULL,
+      sync_token    TEXT NOT NULL
+    );
+
+    -- Triggers as created by 0009 (the buggy versions referencing OLD.id for settlements/settings
+    -- are fine here; 0016 will fix them before doing the DROP COLUMN).
+    CREATE TRIGGER IF NOT EXISTS trg_payments_updated_at
+      AFTER UPDATE ON payments FOR EACH ROW
+      BEGIN UPDATE payments SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id; END;
+    CREATE TRIGGER IF NOT EXISTS trg_cars_updated_at
+      AFTER UPDATE ON cars FOR EACH ROW
+      BEGIN UPDATE cars SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id; END;
+    CREATE TRIGGER IF NOT EXISTS trg_people_updated_at
+      AFTER UPDATE ON people FOR EACH ROW
+      BEGIN UPDATE people SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id; END;
+    CREATE TRIGGER IF NOT EXISTS trg_settlements_updated_at
+      AFTER UPDATE ON settlements FOR EACH ROW
+      BEGIN UPDATE settlements SET updated_at = CURRENT_TIMESTAMP WHERE year = OLD.year; END;
+    CREATE TRIGGER IF NOT EXISTS trg_settings_updated_at
+      AFTER UPDATE ON settings FOR EACH ROW
+      BEGIN UPDATE settings SET updated_at = CURRENT_TIMESTAMP WHERE key = OLD.key; END;
+  `);
+
+  // Mark 0001–0014 as applied so only 0015+ run
+  const appliedUpTo0014 = [
+    "0001_initial_schema.sql",
+    "0002_data_corrections_trips.sql",
+    "0003_add_client_id_and_updated_at.sql",
+    "0004_add_car_owner_era.sql",
+    "0005_add_settlements_table.sql",
+    "0006_settings_table.sql",
+    "0007_settled_outside.sql",
+    "0008_drop_fixed_costs_json.sql",
+    "0009_updated_at_admin_tables.sql",
+    "0010_people_bank_account.sql",
+    "0011_people_email.sql",
+    "0012_cars_owner_person_id.sql",
+    "0013_reservation_calendar_columns.sql",
+    "0014_calendar_sync_state.sql",
+  ];
+  for (const f of appliedUpTo0014) {
+    db.prepare("INSERT INTO _migrations (filename) VALUES (?)").run(f);
+  }
+
+  return db;
+}
+
+describe("migration 0015 — first_name / last_name columns", () => {
+  it("adds first_name column to people", () => {
+    const db = makeDb();
+    const cols = db.prepare("PRAGMA table_info(people)").all() as {
+      name: string;
+      dflt_value: string | null;
+    }[];
+    const col = cols.find((c) => c.name === "first_name");
+    expect(col).toBeTruthy();
+    expect(col!.dflt_value).toBe("''");
+  });
+
+  it("adds last_name column to people", () => {
+    const db = makeDb();
+    const cols = db.prepare("PRAGMA table_info(people)").all() as {
+      name: string;
+      dflt_value: string | null;
+    }[];
+    const col = cols.find((c) => c.name === "last_name");
+    expect(col).toBeTruthy();
+    expect(col!.dflt_value).toBe("''");
+  });
+
+  it("backfills first_name and last_name by splitting name on first space", () => {
+    const db = buildDbAt0014();
+
+    // Insert people with two-word and one-word names
+    db.exec(`INSERT INTO people (id, name, active) VALUES (1, 'Alice Wonderland', 1)`);
+    db.exec(`INSERT INTO people (id, name, active) VALUES (2, 'Bob', 1)`);
+    db.exec(`INSERT INTO people (id, name, active) VALUES (3, 'Charlie De Bie', 1)`);
+
+    runMigrations(db);
+
+    const people = db
+      .prepare("SELECT id, first_name, last_name FROM people ORDER BY id")
+      .all() as { id: number; first_name: string; last_name: string }[];
+
+    // 'Alice Wonderland' → first_name='Alice', last_name='Wonderland'
+    expect(people[0].first_name).toBe("Alice");
+    expect(people[0].last_name).toBe("Wonderland");
+
+    // 'Bob' → first_name='Bob', last_name=''
+    expect(people[1].first_name).toBe("Bob");
+    expect(people[1].last_name).toBe("");
+
+    // 'Charlie De Bie' → split on FIRST space → first_name='Charlie', last_name='De Bie'
+    expect(people[2].first_name).toBe("Charlie");
+    expect(people[2].last_name).toBe("De Bie");
+  });
+});
+
+describe("migration 0016 — drop owner_name from cars", () => {
+  it("owner_name column no longer exists on cars", () => {
+    const db = makeDb();
+    const cols = db.prepare("PRAGMA table_info(cars)").all() as { name: string }[];
+    expect(cols.map((c) => c.name)).not.toContain("owner_name");
+  });
+
+  it("cars table still has short and name columns after drop", () => {
+    const db = makeDb();
+    const cols = db.prepare("PRAGMA table_info(cars)").all() as { name: string }[];
+    const names = cols.map((c) => c.name);
+    expect(names).toContain("short");
+    expect(names).toContain("name");
+  });
+
+  it("fixed settlements trigger fires correctly (uses year PK, not id)", () => {
+    const db = makeDb();
+    db.exec(
+      "INSERT INTO settlements (year, settled_at, settled_by) VALUES (2025, '2025-12-31', 'admin')"
+    );
+    db.exec("UPDATE settlements SET updated_at = '1970-01-01 00:00:00' WHERE year = 2025");
+    db.exec("UPDATE settlements SET settled_by = 'newadmin' WHERE year = 2025");
+    const row = db.prepare("SELECT updated_at FROM settlements WHERE year = 2025").get() as {
+      updated_at: string;
+    };
+    expect(row.updated_at).not.toBe("1970-01-01 00:00:00");
+  });
+
+  it("fixed settings trigger fires correctly (uses key PK, not id)", () => {
+    const db = makeDb();
+    db.exec("UPDATE settings SET updated_at = '1970-01-01 00:00:00' WHERE key = 'coop_bank_account'");
+    db.exec("UPDATE settings SET value = 'BE00000000000000' WHERE key = 'coop_bank_account'");
+    const row = db.prepare("SELECT updated_at FROM settings WHERE key = 'coop_bank_account'").get() as {
+      updated_at: string;
+    };
+    expect(row.updated_at).not.toBe("1970-01-01 00:00:00");
+  });
+});
+
+describe("migration 0017 — drop people name column", () => {
+  it("name column no longer exists on people after migration", () => {
+    const db = makeDb();
+    const cols = db.prepare("PRAGMA table_info(people)").all() as { name: string }[];
+    expect(cols.map((c) => c.name)).not.toContain("name");
+  });
+
+  it("first_name and last_name are the authoritative name columns", () => {
+    const db = makeDb();
+    const cols = db.prepare("PRAGMA table_info(people)").all() as { name: string }[];
+    const names = cols.map((c) => c.name);
+    expect(names).toContain("first_name");
+    expect(names).toContain("last_name");
+  });
+});

--- a/lib/__tests__/migration_0019_to_0022.test.ts
+++ b/lib/__tests__/migration_0019_to_0022.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../db/migrate";
+
+function makeDb() {
+  const db = new Database(":memory:");
+  runMigrations(db);
+  return db;
+}
+
+describe("migration 0019 — default theme mono", () => {
+  it("changes existing 'paper' theme_preference rows to 'mono'", () => {
+    // Build a DB up to just before 0019, seed a person with theme='paper', then let 0019 run.
+    const db = new Database(":memory:");
+
+    // Apply all migrations up to 0018 by running full runMigrations, then manually
+    // insert a person, then run 0019 SQL directly (since we can't slice runMigrations).
+    // Strategy: run full migrations (0019 already converts paper→mono on any existing rows),
+    // then insert a fresh row with theme_preference='paper' and re-run the 0019 SQL to
+    // verify the UPDATE semantics.
+
+    // Instead: use the fake _migrations approach to run only 0018+0019 on a seeded DB.
+    db.exec(`
+      CREATE TABLE _migrations (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        filename TEXT NOT NULL UNIQUE,
+        applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      CREATE TABLE people (
+        id               INTEGER PRIMARY KEY AUTOINCREMENT,
+        discount         REAL    NOT NULL DEFAULT 0,
+        discount_long    REAL    NOT NULL DEFAULT 0,
+        active           INTEGER NOT NULL DEFAULT 1,
+        username         TEXT    UNIQUE,
+        password_hash    TEXT,
+        is_admin         INTEGER NOT NULL DEFAULT 0,
+        updated_at       TEXT    NOT NULL DEFAULT '1970-01-01 00:00:00',
+        bank_account     TEXT    NOT NULL DEFAULT '',
+        email            TEXT,
+        first_name       TEXT    NOT NULL DEFAULT '',
+        last_name        TEXT    NOT NULL DEFAULT '',
+        theme_preference TEXT    NOT NULL DEFAULT 'paper',
+        session_epoch    INTEGER NOT NULL DEFAULT 0
+      );
+      CREATE TABLE invite_tokens (
+        token      TEXT    PRIMARY KEY,
+        person_id  INTEGER NOT NULL REFERENCES people(id) ON DELETE CASCADE,
+        expires_at TEXT    NOT NULL,
+        purpose    TEXT    NOT NULL DEFAULT 'invite'
+      );
+      CREATE TABLE cars (
+        id               INTEGER PRIMARY KEY AUTOINCREMENT,
+        short            TEXT    NOT NULL UNIQUE,
+        name             TEXT    NOT NULL,
+        price_per_km     REAL    NOT NULL,
+        brand            TEXT,
+        color            TEXT,
+        long_threshold   INTEGER NOT NULL DEFAULT 500,
+        active           INTEGER NOT NULL DEFAULT 1,
+        expected_km      INTEGER,
+        owner_from       TEXT,
+        owner_to         TEXT,
+        updated_at       TEXT    NOT NULL DEFAULT '1970-01-01 00:00:00',
+        owner_person_id  INTEGER REFERENCES people(id)
+      );
+      CREATE TABLE trips (
+        id             INTEGER PRIMARY KEY AUTOINCREMENT,
+        person_id      INTEGER NOT NULL REFERENCES people(id) ON DELETE RESTRICT,
+        car_id         INTEGER NOT NULL REFERENCES cars(id)   ON DELETE RESTRICT,
+        date           TEXT    NOT NULL,
+        start_odometer INTEGER NOT NULL,
+        end_odometer   INTEGER NOT NULL,
+        km             INTEGER NOT NULL,
+        amount         REAL    NOT NULL,
+        location       TEXT,
+        parking        TEXT,
+        gps_coords     TEXT,
+        client_id      TEXT    UNIQUE,
+        updated_at     TEXT    NOT NULL DEFAULT (CURRENT_TIMESTAMP)
+      );
+      CREATE TABLE fuel_fillups (
+        id              INTEGER PRIMARY KEY AUTOINCREMENT,
+        person_id       INTEGER NOT NULL REFERENCES people(id) ON DELETE RESTRICT,
+        car_id          INTEGER NOT NULL REFERENCES cars(id)   ON DELETE RESTRICT,
+        date            TEXT    NOT NULL,
+        amount          REAL    NOT NULL,
+        liters          REAL    NOT NULL,
+        price_per_liter REAL    NOT NULL,
+        odometer        INTEGER,
+        receipt         TEXT,
+        location        TEXT,
+        gps_coords      TEXT,
+        full_tank       INTEGER NOT NULL DEFAULT 0,
+        client_id       TEXT    UNIQUE,
+        updated_at      TEXT    NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+        settled_outside INTEGER NOT NULL DEFAULT 0
+      );
+      CREATE TABLE expenses (
+        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+        person_id   INTEGER NOT NULL REFERENCES people(id) ON DELETE RESTRICT,
+        car_id      INTEGER NOT NULL REFERENCES cars(id)   ON DELETE RESTRICT,
+        date        TEXT    NOT NULL,
+        amount      REAL    NOT NULL,
+        description TEXT,
+        category    TEXT,
+        client_id   TEXT    UNIQUE,
+        updated_at  TEXT    NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+        settled_outside INTEGER NOT NULL DEFAULT 0
+      );
+      CREATE TABLE reservations (
+        id                         INTEGER PRIMARY KEY AUTOINCREMENT,
+        person_id                  INTEGER NOT NULL REFERENCES people(id) ON DELETE RESTRICT,
+        car_id                     INTEGER NOT NULL REFERENCES cars(id)   ON DELETE RESTRICT,
+        start_date                 TEXT    NOT NULL,
+        end_date                   TEXT    NOT NULL,
+        status                     TEXT    NOT NULL DEFAULT 'pending',
+        note                       TEXT,
+        client_id                  TEXT    UNIQUE,
+        updated_at                 TEXT    NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+        google_event_id            TEXT,
+        last_synced_etag           TEXT,
+        last_app_write_nonce       TEXT,
+        last_known_response_status TEXT
+      );
+      CREATE TABLE payments (
+        id         INTEGER PRIMARY KEY AUTOINCREMENT,
+        person_id  INTEGER NOT NULL REFERENCES people(id) ON DELETE RESTRICT,
+        date       TEXT    NOT NULL,
+        amount     REAL    NOT NULL,
+        note       TEXT,
+        year       INTEGER NOT NULL,
+        updated_at TEXT    NOT NULL DEFAULT '1970-01-01 00:00:00'
+      );
+      CREATE TABLE settlements (
+        year       INTEGER PRIMARY KEY,
+        settled_at TEXT    NOT NULL,
+        settled_by TEXT    NOT NULL,
+        updated_at TEXT    NOT NULL DEFAULT '1970-01-01 00:00:00'
+      );
+      CREATE TABLE settings (
+        key        TEXT PRIMARY KEY,
+        value      TEXT NOT NULL DEFAULT '',
+        updated_at TEXT NOT NULL DEFAULT '1970-01-01 00:00:00'
+      );
+      CREATE TABLE car_price_history (
+        id             INTEGER PRIMARY KEY AUTOINCREMENT,
+        car_id         INTEGER NOT NULL REFERENCES cars(id) ON DELETE CASCADE,
+        price_per_km   REAL    NOT NULL,
+        effective_from TEXT    NOT NULL
+      );
+      CREATE TABLE calendar_sync_state (
+        id            INTEGER PRIMARY KEY CHECK (id = 1),
+        channel_id    TEXT NOT NULL,
+        resource_id   TEXT NOT NULL,
+        expiration_at TEXT NOT NULL,
+        sync_token    TEXT NOT NULL
+      );
+      CREATE TRIGGER IF NOT EXISTS trg_settlements_updated_at
+        AFTER UPDATE ON settlements FOR EACH ROW
+        BEGIN UPDATE settlements SET updated_at = CURRENT_TIMESTAMP WHERE year = OLD.year; END;
+      CREATE TRIGGER IF NOT EXISTS trg_settings_updated_at
+        AFTER UPDATE ON settings FOR EACH ROW
+        BEGIN UPDATE settings SET updated_at = CURRENT_TIMESTAMP WHERE key = OLD.key; END;
+    `);
+
+    // Seed people with theme_preference 'paper' (the pre-0019 default)
+    db.exec(`INSERT INTO people (id, first_name, active, theme_preference) VALUES (1, 'Alice', 1, 'paper')`);
+    db.exec(`INSERT INTO people (id, first_name, active, theme_preference) VALUES (2, 'Bob',   1, 'paper')`);
+
+    // Mark all migrations except 0019 as applied
+    const skip = [
+      "0001_initial_schema.sql",
+      "0002_data_corrections_trips.sql",
+      "0003_add_client_id_and_updated_at.sql",
+      "0004_add_car_owner_era.sql",
+      "0005_add_settlements_table.sql",
+      "0006_settings_table.sql",
+      "0007_settled_outside.sql",
+      "0008_drop_fixed_costs_json.sql",
+      "0009_updated_at_admin_tables.sql",
+      "0010_people_bank_account.sql",
+      "0011_people_email.sql",
+      "0012_cars_owner_person_id.sql",
+      "0013_reservation_calendar_columns.sql",
+      "0014_calendar_sync_state.sql",
+      "0015_people_first_last_name.sql",
+      "0016_cars_drop_owner_name.sql",
+      "0017_drop_people_name.sql",
+      "0018_people_theme_preference.sql",
+      "0020_date_indexes.sql",
+      "0021_people_session_epoch.sql",
+      "0022_invite_tokens_purpose.sql",
+    ];
+    for (const f of skip) {
+      db.prepare("INSERT INTO _migrations (filename) VALUES (?)").run(f);
+    }
+
+    runMigrations(db);
+
+    const people = db
+      .prepare("SELECT id, theme_preference FROM people ORDER BY id")
+      .all() as { id: number; theme_preference: string }[];
+
+    expect(people[0].theme_preference).toBe("mono");
+    expect(people[1].theme_preference).toBe("mono");
+  });
+
+  it("theme_preference 'paper' default in 0018 is overwritten to 'mono' by 0019 for fresh inserts via column default", () => {
+    // After full migration run, the column default for theme_preference is still 'paper'
+    // (0019 only updates existing rows, it does not change the column DEFAULT).
+    // New inserts will still get 'paper' unless 0018 default is changed.
+    // This test documents the current behaviour: new rows get 'paper' from the column DEFAULT.
+    const db = makeDb();
+    db.exec("INSERT INTO people (first_name, active) VALUES ('Charlie', 1)");
+    const row = db.prepare("SELECT theme_preference FROM people WHERE first_name = 'Charlie'").get() as {
+      theme_preference: string;
+    };
+    // The column DEFAULT remains 'paper'; 0019 only UPDATEs existing rows.
+    expect(row.theme_preference).toBe("paper");
+  });
+});
+
+describe("migration 0020 — date indexes", () => {
+  it("creates idx_trips_date index", () => {
+    const db = makeDb();
+    const indexes = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='trips'")
+      .all() as { name: string }[];
+    expect(indexes.map((i) => i.name)).toContain("idx_trips_date");
+  });
+
+  it("creates idx_fuel_fillups_date index", () => {
+    const db = makeDb();
+    const indexes = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='fuel_fillups'"
+      )
+      .all() as { name: string }[];
+    expect(indexes.map((i) => i.name)).toContain("idx_fuel_fillups_date");
+  });
+
+  it("indexes are on the date column (DESC)", () => {
+    const db = makeDb();
+    const tripIdx = db
+      .prepare("SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_trips_date'")
+      .get() as { sql: string };
+    expect(tripIdx.sql).toMatch(/date/i);
+    expect(tripIdx.sql).toMatch(/DESC/i);
+  });
+});
+
+describe("migration 0021 — people session_epoch", () => {
+  it("adds session_epoch column to people", () => {
+    const db = makeDb();
+    const cols = db.prepare("PRAGMA table_info(people)").all() as {
+      name: string;
+      dflt_value: string | null;
+    }[];
+    const col = cols.find((c) => c.name === "session_epoch");
+    expect(col).toBeTruthy();
+    expect(col!.dflt_value).toBe("0");
+  });
+
+  it("session_epoch defaults to 0 on new inserts", () => {
+    const db = makeDb();
+    db.exec("INSERT INTO people (first_name, active) VALUES ('Alice', 1)");
+    const row = db.prepare("SELECT session_epoch FROM people WHERE first_name = 'Alice'").get() as {
+      session_epoch: number;
+    };
+    expect(row.session_epoch).toBe(0);
+  });
+
+  it("session_epoch can be incremented", () => {
+    const db = makeDb();
+    db.exec("INSERT INTO people (id, first_name, active) VALUES (1, 'Alice', 1)");
+    db.exec("UPDATE people SET session_epoch = session_epoch + 1 WHERE id = 1");
+    const row = db.prepare("SELECT session_epoch FROM people WHERE id = 1").get() as {
+      session_epoch: number;
+    };
+    expect(row.session_epoch).toBe(1);
+  });
+});
+
+describe("migration 0022 — invite_tokens purpose column", () => {
+  it("adds purpose column to invite_tokens", () => {
+    const db = makeDb();
+    const cols = db.prepare("PRAGMA table_info(invite_tokens)").all() as {
+      name: string;
+      dflt_value: string | null;
+    }[];
+    const col = cols.find((c) => c.name === "purpose");
+    expect(col).toBeTruthy();
+    expect(col!.dflt_value).toBe("'invite'");
+  });
+
+  it("existing invite_token rows get purpose='invite' by default", () => {
+    // Insert a token before the column existed would require pre-migration state.
+    // Instead verify a freshly inserted token gets the default.
+    const db = makeDb();
+    db.exec("INSERT INTO people (id, first_name, active) VALUES (1, 'Alice', 1)");
+    db.prepare(
+      "INSERT INTO invite_tokens (token, person_id, expires_at) VALUES (?,?,?)"
+    ).run("tok-abc", 1, "2099-01-01");
+    const row = db.prepare("SELECT purpose FROM invite_tokens WHERE token = 'tok-abc'").get() as {
+      purpose: string;
+    };
+    expect(row.purpose).toBe("invite");
+  });
+
+  it("purpose can be set to other values like 'reset'", () => {
+    const db = makeDb();
+    db.exec("INSERT INTO people (id, first_name, active) VALUES (1, 'Alice', 1)");
+    db.prepare(
+      "INSERT INTO invite_tokens (token, person_id, expires_at, purpose) VALUES (?,?,?,?)"
+    ).run("tok-reset", 1, "2099-01-01", "reset");
+    const row = db.prepare("SELECT purpose FROM invite_tokens WHERE token = 'tok-reset'").get() as {
+      purpose: string;
+    };
+    expect(row.purpose).toBe("reset");
+  });
+});

--- a/lib/__tests__/migration_forward.test.ts
+++ b/lib/__tests__/migration_forward.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Forward-migration test.
+ *
+ * Approach: build a DB at the state of migrations 0001–0010 by running
+ * runMigrations with 0011–0022 pre-marked as "applied" (so they are skipped),
+ * seed representative rows that match the schema AT THAT POINT, then clear the
+ * fakes and run runMigrations again so 0011–0022 execute for real.
+ *
+ * This verifies:
+ *   (a) seeded rows survive all later migrations
+ *   (b) newly added columns appear with correct defaults / backfill
+ *   (c) the _migrations log lists all 22 migrations
+ *   (d) running runMigrations a third time is a no-op
+ */
+
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../db/migrate";
+
+// All 22 migration filenames in order
+const ALL_MIGRATIONS = [
+  "0001_initial_schema.sql",
+  "0002_data_corrections_trips.sql",
+  "0003_add_client_id_and_updated_at.sql",
+  "0004_add_car_owner_era.sql",
+  "0005_add_settlements_table.sql",
+  "0006_settings_table.sql",
+  "0007_settled_outside.sql",
+  "0008_drop_fixed_costs_json.sql",
+  "0009_updated_at_admin_tables.sql",
+  "0010_people_bank_account.sql",
+  "0011_people_email.sql",
+  "0012_cars_owner_person_id.sql",
+  "0013_reservation_calendar_columns.sql",
+  "0014_calendar_sync_state.sql",
+  "0015_people_first_last_name.sql",
+  "0016_cars_drop_owner_name.sql",
+  "0017_drop_people_name.sql",
+  "0018_people_theme_preference.sql",
+  "0019_default_theme_mono.sql",
+  "0020_date_indexes.sql",
+  "0021_people_session_epoch.sql",
+  "0022_invite_tokens_purpose.sql",
+];
+
+const LATER_MIGRATIONS = ALL_MIGRATIONS.slice(10); // 0011–0022
+
+function buildDbAt0010(): Database.Database {
+  const db = new Database(":memory:");
+
+  // Phase 1: pre-mark 0011–0022 as applied so runMigrations only runs 0001–0010.
+  // We must create the _migrations table first.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS _migrations (
+      id         INTEGER PRIMARY KEY AUTOINCREMENT,
+      filename   TEXT NOT NULL UNIQUE,
+      applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+  `);
+  for (const f of LATER_MIGRATIONS) {
+    db.prepare("INSERT INTO _migrations (filename) VALUES (?)").run(f);
+  }
+
+  // Now run migrations — only 0001–0010 will execute.
+  runMigrations(db);
+
+  return db;
+}
+
+describe("forward migration — 0001–0010 → 0011–0022", () => {
+  it("seeds survive all later migrations", () => {
+    const db = buildDbAt0010();
+
+    // Seed a person (no first_name/last_name yet — those come in 0015).
+    // At 0010 the people schema has: id, name, discount, discount_long, active,
+    // username, password_hash, is_admin, updated_at, bank_account
+    db.exec(
+      "INSERT INTO people (id, name, discount, discount_long, active, bank_account) " +
+        "VALUES (1, 'Alice Wonderland', 0, 0, 1, 'BE00000000000001')"
+    );
+    db.exec(
+      "INSERT INTO people (id, name, discount, discount_long, active, bank_account) " +
+        "VALUES (2, 'Bob', 0, 0, 1, '')"
+    );
+
+    // Seed a car (at 0010: no owner_person_id yet; owner_name still present)
+    db.exec(
+      "INSERT INTO cars (id, short, name, price_per_km, owner_name) " +
+        "VALUES (1, 'XX', 'Test Car', 0.30, 'Alice Wonderland')"
+    );
+
+    // Seed a trip
+    db.prepare(
+      "INSERT INTO trips (person_id, car_id, date, start_odometer, end_odometer, km, amount) " +
+        "VALUES (?,?,?,?,?,?,?)"
+    ).run(1, 1, "2024-06-01", 10000, 10150, 150, 45.0);
+
+    // Seed a fuel fill-up
+    db.prepare(
+      "INSERT INTO fuel_fillups (person_id, car_id, date, amount, liters, price_per_liter) " +
+        "VALUES (?,?,?,?,?,?)"
+    ).run(1, 1, "2024-06-05", 60.0, 40.0, 1.5);
+
+    // Seed a payment
+    db.prepare(
+      "INSERT INTO payments (person_id, date, amount, year) VALUES (?,?,?,?)"
+    ).run(1, "2024-12-31", 500.0, 2024);
+
+    // Now remove the fake _migrations entries so the real 0011–0022 execute.
+    for (const f of LATER_MIGRATIONS) {
+      db.prepare("DELETE FROM _migrations WHERE filename = ?").run(f);
+    }
+
+    // Run migrations 0011–0022
+    runMigrations(db);
+
+    // (a) Seeded person survived
+    const person = db
+      .prepare("SELECT id, first_name, last_name, bank_account FROM people WHERE id = 1")
+      .get() as { id: number; first_name: string; last_name: string; bank_account: string };
+    expect(person).toBeTruthy();
+    expect(person.id).toBe(1);
+
+    // (b) first_name / last_name backfilled from name (migration 0015)
+    expect(person.first_name).toBe("Alice");
+    expect(person.last_name).toBe("Wonderland");
+
+    // bank_account preserved
+    expect(person.bank_account).toBe("BE00000000000001");
+
+    // Bob: single name → first_name='Bob', last_name=''
+    const bob = db
+      .prepare("SELECT first_name, last_name FROM people WHERE id = 2")
+      .get() as { first_name: string; last_name: string };
+    expect(bob.first_name).toBe("Bob");
+    expect(bob.last_name).toBe("");
+
+    // (b) name column is gone after 0017
+    const peopleCols = db.prepare("PRAGMA table_info(people)").all() as { name: string }[];
+    expect(peopleCols.map((c) => c.name)).not.toContain("name");
+
+    // (b) email defaults to NULL (migration 0011)
+    const emailRow = db
+      .prepare("SELECT email FROM people WHERE id = 1")
+      .get() as { email: string | null };
+    expect(emailRow.email).toBeNull();
+
+    // (b) theme_preference defaulted to 'paper' (0018), then updated to 'mono' (0019)
+    // Rows that existed BEFORE 0018 had no theme_preference column; after 0018 they get
+    // the column default 'paper'. 0019 then updates all 'paper' → 'mono'.
+    const themeRow = db
+      .prepare("SELECT theme_preference FROM people WHERE id = 1")
+      .get() as { theme_preference: string };
+    expect(themeRow.theme_preference).toBe("mono");
+
+    // (b) session_epoch defaults to 0 (migration 0021)
+    const epochRow = db
+      .prepare("SELECT session_epoch FROM people WHERE id = 1")
+      .get() as { session_epoch: number };
+    expect(epochRow.session_epoch).toBe(0);
+
+    // Seeded trip survived
+    const trip = db.prepare("SELECT km, amount FROM trips WHERE car_id = 1").get() as {
+      km: number;
+      amount: number;
+    };
+    expect(trip).toBeTruthy();
+    expect(trip.km).toBe(150);
+    expect(trip.amount).toBe(45.0);
+
+    // Seeded fuel fill-up survived
+    const fuel = db.prepare("SELECT amount FROM fuel_fillups WHERE car_id = 1").get() as {
+      amount: number;
+    };
+    expect(fuel.amount).toBe(60.0);
+
+    // Seeded payment survived
+    const payment = db.prepare("SELECT amount, year FROM payments WHERE person_id = 1").get() as {
+      amount: number;
+      year: number;
+    };
+    expect(payment.amount).toBe(500.0);
+    expect(payment.year).toBe(2024);
+
+    // (b) owner_name dropped from cars (migration 0016)
+    const carCols = db.prepare("PRAGMA table_info(cars)").all() as { name: string }[];
+    expect(carCols.map((c) => c.name)).not.toContain("owner_name");
+
+    // (b) owner_person_id added to cars (migration 0012)
+    expect(carCols.map((c) => c.name)).toContain("owner_person_id");
+
+    // (c) _migrations log lists all 22 migrations
+    const applied = db
+      .prepare("SELECT filename FROM _migrations ORDER BY filename")
+      .pluck()
+      .all() as string[];
+    expect(applied).toHaveLength(22);
+    for (const f of ALL_MIGRATIONS) {
+      expect(applied).toContain(f);
+    }
+
+    // (d) running runMigrations again is a no-op
+    expect(() => runMigrations(db)).not.toThrow();
+    const appliedAfter = db
+      .prepare("SELECT filename FROM _migrations ORDER BY filename")
+      .pluck()
+      .all() as string[];
+    expect(appliedAfter).toHaveLength(22);
+  });
+});


### PR DESCRIPTION
Closes #309

Adds targeted tests for previously-implicit migrations **0006–0010, 0015–0017, 0019–0022** (asserting each migration's specific schema delta / backfill), plus a **forward-migration test** (seed a DB at 0010 with representative rows → run 0011–0022 → assert data survives, columns backfilled, `_migrations` log correct, re-run is a no-op). 4 new files, 57 migration tests total, lint clean.

Only `0002` (pure data-correction, no schema change) is left without a targeted test. Also documents the 0009 trigger bug (wrong PK in settlements/settings triggers) that 0016 fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)