### PR TITLE
test(e2e): hermetic per-run seeded DB + fix 2 regressions

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,40 @@
+/**
+ * Playwright globalSetup — runs once before all tests in a run.
+ *
+ * Seeds a dedicated e2e DB (data/e2e.db) from scratch on every invocation.
+ * This guarantees a clean, reproducible baseline:
+ *   - No residue from previous runs (E2E* members, trips, etc.)
+ *   - No dependency on a pre-existing demo.db
+ *   - Idempotent: running twice gives the same result
+ *
+ * The webServer block in playwright.config.ts boots the app with
+ * DB_PATH=data/e2e.db so it reads from this fresh database.
+ */
+
+import { execSync } from "child_process";
+import path from "path";
+import fs from "fs";
+
+export default async function globalSetup(): Promise<void> {
+  const root = path.resolve(__dirname, "..");
+  const e2eDb = path.join(root, "data", "e2e.db");
+
+  // Remove stale e2e DB files so the seed always starts from scratch.
+  for (const suffix of ["", "-shm", "-wal"]) {
+    const f = e2eDb + suffix;
+    if (fs.existsSync(f)) fs.unlinkSync(f);
+  }
+
+  // Ensure the data/ directory exists (it may not if the worktree has no symlink).
+  fs.mkdirSync(path.join(root, "data"), { recursive: true });
+
+  console.log("[e2e globalSetup] Seeding data/e2e.db …");
+
+  execSync("npx tsx scripts/seed-demo.ts", {
+    cwd: root,
+    env: { ...process.env, DB_PATH: e2eDb },
+    stdio: "inherit",
+  });
+
+  console.log("[e2e globalSetup] data/e2e.db ready.");
+}

--- a/e2e/invite.spec.ts
+++ b/e2e/invite.spec.ts
@@ -36,7 +36,12 @@ test.describe("invite flow", () => {
     csrf = session.csrf;
     api = makeApi(request, csrf);
 
-    const res = await api.post<{ id: number }>("/api/people", personData);
+    // Invite generation requires a username (the invite flow only sets a password).
+    // Unique per insert so the repeated beforeEach creations don't collide.
+    const res = await api.post<{ id: number }>("/api/people", {
+      ...personData,
+      username: `invite-${Date.now()}-${Math.floor(Math.random() * 1e6)}`,
+    });
     personId = res.id;
   });
 

--- a/e2e/members.spec.ts
+++ b/e2e/members.spec.ts
@@ -7,16 +7,21 @@ import { loginAndGetSession, loginAndGetCsrf, makeApi, scrollToLoadAll } from ".
  * No DELETE endpoint exists — deactivation is done via PUT with active=0.
  *
  * Strategy:
- * - Admin creates a person via API in beforeEach.
+ * - Admin creates a person via API in beforeEach with a unique per-test name
+ *   (timestamp suffix) so tests that run sequentially never see each other's
+ *   rows in the people list.
  * - Deactivate via PUT (active=0), verify absence from /people list.
- * - Reactivate in afterEach (active=1), then final delete not possible — we
- *   leave the inactive test person in place (demo.db only, not production).
+ * - Reactivate in afterEach (active=1) to avoid low-contrast a11y failures on
+ *   /admin/members.  No DELETE endpoint exists, so the row remains — but
+ *   globalSetup reseeds data/e2e.db before every run, so no row accumulates
+ *   across runs.
  *
- * Cleanup: set active=0 is permanent for the test record since there is no
- * DELETE endpoint. Tests are run against demo.db which is reset between runs.
+ * Cleanup guarantee: globalSetup (see playwright.config.ts) seeds a fresh
+ * data/e2e.db on every `npx playwright test` invocation, so stale E2E* rows
+ * from a previous run are never present when tests start.
  */
 
-const FIRST_NAME = "E2ETest";
+const FIRST_NAME_PREFIX = "E2ETest";
 const LAST_NAME = "Member";
 
 type PersonRow = {
@@ -31,10 +36,12 @@ test.describe("members deactivate", () => {
   let api: ReturnType<typeof makeApi>;
   let personId: number;
   let personData: ReturnType<typeof buildPersonData>;
+  // Unique suffix per test so the /people list can identify this specific row.
+  let uniqueFirstName: string;
 
-  function buildPersonData() {
+  function buildPersonData(firstName: string) {
     return {
-      first_name: FIRST_NAME,
+      first_name: firstName,
       last_name: LAST_NAME,
       discount: 0,
       discount_long: 0,
@@ -43,11 +50,15 @@ test.describe("members deactivate", () => {
     };
   }
 
-  test.beforeEach(async ({ request }) => {
+  test.beforeEach(async ({ request }, testInfo) => {
+    // Make the name unique per test (index + title hash) so the /people list
+    // never shows a sibling test's member when we assert HaveCount(0).
+    uniqueFirstName = `${FIRST_NAME_PREFIX}${testInfo.workerIndex}${Date.now()}`;
+
     const session = await loginAndGetSession(request, "admin", "admin");
     csrf = session.csrf;
     api = makeApi(request, csrf);
-    personData = buildPersonData();
+    personData = buildPersonData(uniqueFirstName);
 
     const res = await api.post<{ id: number }>("/api/people", personData);
     personId = res.id;
@@ -78,7 +89,7 @@ test.describe("members deactivate", () => {
     await page.waitForLoadState("networkidle");
     await scrollToLoadAll(page);
 
-    await expect(page.locator(`text=${FIRST_NAME}`).first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator(`text=${uniqueFirstName}`).first()).toBeVisible({ timeout: 10_000 });
   });
 
   test("deactivated member no longer appears in people list", async ({ page }) => {
@@ -96,8 +107,9 @@ test.describe("members deactivate", () => {
     await page.waitForLoadState("networkidle");
     await scrollToLoadAll(page);
 
-    // Active members list should not show the deactivated test member
-    await expect(page.getByText(`${FIRST_NAME} ${LAST_NAME}`, { exact: true })).toHaveCount(0);
+    // Active members list should not show the deactivated test member.
+    // The unique name guarantees no other test's member matches this assertion.
+    await expect(page.getByText(`${uniqueFirstName} ${LAST_NAME}`, { exact: true })).toHaveCount(0);
   });
 
   test("deactivated member still retrievable via API", async () => {
@@ -108,6 +120,6 @@ test.describe("members deactivate", () => {
 
     const person = await api.get<PersonRow>(`/api/people/${personId}`);
     expect(person.active).toBe(0);
-    expect(person.first_name).toBe(FIRST_NAME);
+    expect(person.first_name).toBe(uniqueFirstName);
   });
 });

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -28,8 +28,9 @@ test("login and view trips", async ({ page }) => {
   // Labels come from t("form.name") → "Naam *" / "Name *"
   await page.getByLabel(/naam|name/i).fill(process.env.TEST_EMAIL ?? "alice");
   await page.locator("#login-password").fill(process.env.TEST_PASSWORD ?? "alice");
-  // t("action.login") → "Inloggen" / "Log in"
-  await page.getByRole("button", { name: /inloggen|log\s*in/i }).click();
+  // The login form's submit button (the "sign in with a link instead" toggle also
+  // matches /inloggen/, so target the submit button specifically).
+  await page.locator('button[type="submit"]').click();
 
   // After login the app redirects to "/"
   await page.waitForURL(/trips|dashboard|\//);

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,6 +12,19 @@ export const E2E_SESSION_PASSWORD =
 
 export default defineConfig({
   testDir: "./e2e",
+
+  // ── Hermetic isolation ────────────────────────────────────────────────────
+  // globalSetup seeds data/e2e.db fresh on every run so no residue (E2E* rows,
+  // half-deleted records, etc.) carries over between runs.
+  globalSetup: "./e2e/global-setup.ts",
+
+  // SQLite is a single-file database shared by the one app-server process.
+  // Parallel Playwright workers would all write through the same server to the
+  // same WAL, causing lock contention and unpredictable test failures.
+  // workers: 1 is the correct constraint for a shared-SQLite test server.
+  workers: 1,
+  fullyParallel: false,
+
   use: {
     baseURL,
     screenshot: "only-on-failure",
@@ -27,6 +40,7 @@ export default defineConfig({
         // Pin the env the suite depends on so it doesn't rely on a local
         // .env.local. Kept identical across the e2e branches so the file never
         // conflicts on merge:
+        //   - DB_PATH           — dedicated e2e DB seeded fresh by globalSetup
         //   - SESSION_PASSWORD  — matches admin-skeleton's sealed cookie
         //   - NEXT_PUBLIC_BASE_URL — absolute redirects
         //   - DISABLE_RATE_LIMIT — the suite logs in many times from one host,
@@ -37,6 +51,7 @@ export default defineConfig({
         //     flow enabled (delivery fails silently, the route still returns ok).
         env: {
           ...process.env,
+          DB_PATH: "data/e2e.db",
           SESSION_PASSWORD: E2E_SESSION_PASSWORD,
           NEXT_PUBLIC_BASE_URL: baseURL,
           DISABLE_RATE_LIMIT: "1",


### PR DESCRIPTION
Closes #308

Makes the e2e suite isolated/repeatable:
- **`globalSetup`** reseeds a dedicated `data/e2e.db` fresh on every run (no residue carries over).
- **`workers: 1` + `fullyParallel: false`** — correct for a single shared-SQLite app server (parallel workers caused WAL lock contention).
- `DB_PATH=data/e2e.db` pinned in `webServer.env`; unique per-run member names.

Also fixes 2 pre-existing e2e failures it surfaced (regressions from earlier merges, missed because CI runs unit tests only):
- `invite.spec`: invite generation now requires a username (#299) — create the person with a unique username.
- `smoke.spec`: the magic-link toggle (#293) also matches `/inloggen/` — target the submit button.

Verified: full suite runs deterministically; the 2 fixed specs pass (5/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)