### PR TITLE
chore(api): drop redundant double session read in GET /api/people

### DIFF
--- a/app/api/people/route.ts
+++ b/app/api/people/route.ts
@@ -1,14 +1,11 @@
 import { NextResponse } from "next/server";
-import { getIronSession } from "iron-session";
-import { sessionOptions, type SessionData } from "@/lib/session";
 import { getDb } from "@/lib/db";
 import { getPeople, insertPerson } from "@/lib/queries/people";
 import { json, readBody, requireAdmin, requireSession } from "@/lib/api";
 import { personSchema } from "@/lib/schemas/person";
 
 export const GET = json(async (req) => {
-  await requireSession(req);
-  const session = await getIronSession<SessionData>(req, NextResponse.next(), sessionOptions);
+  const session = await requireSession(req);
   const people = getPeople(getDb());
   // The people list is consumed by forms across the app (driver/owner pickers),
   // so it stays readable by any authenticated user — but contact and banking


### PR DESCRIPTION
Closes #319

`GET /api/people` read the iron-session twice — `requireSession(req)` then a second `getIronSession(...)` just for `isAdmin`. `requireSession` already returns the session, so use it and drop the redundant read + now-unused imports (`getIronSession`, `sessionOptions`, `SessionData`).

Captures the one real improvement from the closed duplicate PR #313 (the rest was superseded by #314). Behaviour unchanged; `app/api/people/route.test.ts` passes (7), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)