### PR TITLE
chore(ci): typecheck source in CI (tsconfig.build.json + typecheck step)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
       - run: npm ci
       - name: Lint
         run: npm run lint
+      - name: Typecheck (source only)
+        run: npm run typecheck
       - name: Unit tests with coverage
         run: npm run test:coverage
       - name: Check coverage threshold

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build --webpack",
     "start": "next start",
     "lint": "eslint .",
+    "typecheck": "tsc -p tsconfig.build.json --noEmit",
     "format": "prettier --write .",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "node_modules",
+    "docs",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__/**",
+    "**/*.spec.ts",
+    "e2e/**"
+  ]
+}


### PR DESCRIPTION
Closes #318

## Problem
CI's `quality` job runs lint + `test:coverage` but **never runs `tsc`**, so a type error in **source** could land silently. `next build` does typecheck, but only files reachable from the app's module graph — so test-only type errors are invisible to it, and source type errors would only surface at build time (not in the `quality` gate).

Meanwhile `tsc --noEmit` reports **36 errors today — all in `*.test.ts` files** (loosely-typed `vi.fn()` mocks: 21× TS2554, 8× TS2556, rest fixtures). Those are intentionally tolerated (prior decision to keep test-double typing loose). **Zero source files have a type error.**

## Fix (Option 1 from the issue)
Typecheck **source only**, leaving the test-mock types untouched:

- **`tsconfig.build.json`** — extends `tsconfig.json`, excludes `**/*.test.ts(x)`, `**/__tests__/**`, `**/*.spec.ts`, `e2e/**`.
- **`npm run typecheck`** → `tsc -p tsconfig.build.json --noEmit` (**0 errors** today).
- **CI** — a `Typecheck (source only)` step in the `quality` job, after lint.

## Why this changes no existing behaviour
- `tsconfig.json` is **untouched** → IDE typechecking and `next build` are identical to before.
- **vitest** transpiles via esbuild (no typecheck) with its own include/exclude — unaffected.
- **eslint** (`eslint-config-next`) has no typed-linting `project` — doesn't read a tsconfig graph.
- Nothing globs `tsconfig.*.json`, so the new file is inert to every tool except the explicit `npm run typecheck`.
- The 36 pre-existing test-mock errors stay tolerated — this PR does **not** touch them.

## Verification
- `npm run typecheck` → **exit 0** (source clean).
- Plain `npx tsc --noEmit` → still 36 (test files), confirming the base config is unchanged.
- Net effect: CI now fails on a **new source type error**; everything else behaves exactly as today.

> Optional future hardening (deliberately out of scope, conflicts with the loose-mock approach): tighten `vi.fn()` generics so full `tsc` is clean across tests too.

https://claude.ai/code/session_01EvJThHe6obwJKjS5cnPLv8

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvJThHe6obwJKjS5cnPLv8)_