### PR TITLE
feat(pwa): pull-to-refresh hard reload when installed as a PWA

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -9,6 +9,7 @@ import { useSyncEngine } from "@/lib/offline/sync-engine";
 import { useT } from "@/components/locale-provider";
 import { ThemeProvider, useTheme } from "@/lib/theme-context";
 import { useMe } from "@/hooks/use-me";
+import PullToRefresh from "@/components/pull-to-refresh";
 
 function BootPrewarm() {
   // useMe is the auth signal. Read it here so prewarm gates on auth.
@@ -61,6 +62,8 @@ export function Providers({ children }: { children: React.ReactNode }) {
           <BootPrewarm />
           <ThemeSync />
           <ConflictListener />
+          {/* No-op in a normal browser tab; active only when installed as a PWA. */}
+          <PullToRefresh />
           {children}
           <Toaster position="bottom-center" />
         </ThemeProvider>

--- a/components/pull-to-refresh.tsx
+++ b/components/pull-to-refresh.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+// Pull-to-refresh for the INSTALLED PWA.
+//
+// When the app runs in standalone display mode there's no browser chrome, so
+// the user has no native pull-to-refresh and no Ctrl+R to pick up a freshly
+// deployed version. This component adds a pull-down-at-the-top gesture that
+// performs a *hard* refresh: it asks the Service Worker to update (and activate
+// any waiting worker) before reloading, so a new build is actually fetched —
+// equivalent to Ctrl+Shift+R.
+//
+// In a normal browser tab this renders null and attaches no listeners, so the
+// native gesture is left completely untouched.
+
+import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import { useOnlineState } from "@/lib/offline/online-state";
+import { useT } from "@/components/locale-provider";
+import {
+  decideRefresh,
+  isStandalone,
+  pullOffset,
+  PULL_THRESHOLD_PX,
+  PULL_MAX_PX,
+} from "@/lib/pwa/pull-to-refresh-logic";
+
+// Ignore horizontal-ish swipes so we don't hijack carousels / back gestures.
+const HORIZONTAL_TOLERANCE = 1.2;
+
+/**
+ * Ask the active Service Worker to update, activate any waiting worker, then
+ * reload. Resilient to having no SW at all (plain reload).
+ */
+async function hardRefresh(): Promise<void> {
+  try {
+    if (typeof navigator !== "undefined" && "serviceWorker" in navigator) {
+      const reg = await navigator.serviceWorker.getRegistration();
+      if (reg) {
+        // Pull the newest SW from the network.
+        await reg.update().catch(() => {});
+        const waiting = reg.waiting;
+        if (waiting) {
+          // next-pwa's runtime handles SKIP_WAITING; also post a generic skip.
+          try {
+            waiting.postMessage({ type: "SKIP_WAITING" });
+          } catch {
+            /* ignore */
+          }
+          // Give the new worker a moment to take control before reloading.
+          await new Promise<void>((resolve) => {
+            const done = () => resolve();
+            navigator.serviceWorker.addEventListener("controllerchange", done, { once: true });
+            setTimeout(done, 800);
+          });
+        }
+      }
+    }
+  } catch {
+    /* fall through to reload */
+  }
+  // Reload from the (now-updated) SW / network.
+  window.location.reload();
+}
+
+export default function PullToRefresh() {
+  const { online, pendingCount } = useOnlineState();
+  const t = useT();
+
+  const [enabled, setEnabled] = useState(false);
+  const [offset, setOffset] = useState(0);
+  const [refreshing, setRefreshing] = useState(false);
+
+  // Latest values mirrored into refs so the (stable) event handlers can read
+  // them without being re-bound on every render. Synced in an effect because
+  // writing refs during render is disallowed by the React compiler.
+  const stateRef = useRef({ online, pendingCount });
+  const offsetRef = useRef(offset);
+  const refreshingRef = useRef(refreshing);
+  useEffect(() => {
+    stateRef.current = { online, pendingCount };
+    offsetRef.current = offset;
+    refreshingRef.current = refreshing;
+  });
+
+  // Decide once on mount whether we're an installed PWA. In a browser tab this
+  // stays false and we never attach listeners → complete no-op.
+  useEffect(() => {
+    setEnabled(isStandalone());
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let startY = 0;
+    let startX = 0;
+    let tracking = false;
+    let triggered = false;
+
+    const atTop = () => (window.scrollY || document.documentElement.scrollTop || 0) <= 0;
+
+    const onTouchStart = (e: TouchEvent) => {
+      if (refreshingRef.current) return;
+      if (e.touches.length !== 1) return;
+      if (!atTop()) return;
+      startY = e.touches[0].clientY;
+      startX = e.touches[0].clientX;
+      tracking = true;
+      triggered = false;
+    };
+
+    const onTouchMove = (e: TouchEvent) => {
+      if (!tracking || refreshingRef.current) return;
+      const dy = e.touches[0].clientY - startY;
+      const dx = e.touches[0].clientX - startX;
+      // Only react to downward, mostly-vertical drags that begin at the top.
+      if (dy <= 0 || Math.abs(dx) > Math.abs(dy) * HORIZONTAL_TOLERANCE) {
+        if (offsetRef.current !== 0) setOffset(0);
+        return;
+      }
+      if (!atTop()) {
+        tracking = false;
+        setOffset(0);
+        return;
+      }
+      triggered = true;
+      setOffset(pullOffset(dy));
+      // Prevent the browser/document from also scrolling/over-scrolling.
+      if (e.cancelable) e.preventDefault();
+    };
+
+    const endDrag = () => {
+      if (!tracking) return;
+      tracking = false;
+      const dragged = offsetRef.current;
+      setOffset(0);
+      if (!triggered) return;
+
+      const decision = decideRefresh({
+        dragDistance: dragged,
+        threshold: PULL_THRESHOLD_PX,
+        online: stateRef.current.online,
+        outboxCount: stateRef.current.pendingCount,
+      });
+
+      if (decision.action === "blocked-offline") {
+        toast.error(t("pwa.refresh_blocked_offline"));
+        return;
+      }
+      if (decision.action === "refresh") {
+        setRefreshing(true);
+        refreshingRef.current = true;
+        toast.loading(t("pwa.refreshing"));
+        hardRefresh();
+      }
+    };
+
+    // passive:false on move so preventDefault works.
+    window.addEventListener("touchstart", onTouchStart, { passive: true });
+    window.addEventListener("touchmove", onTouchMove, { passive: false });
+    window.addEventListener("touchend", endDrag, { passive: true });
+    window.addEventListener("touchcancel", endDrag, { passive: true });
+    return () => {
+      window.removeEventListener("touchstart", onTouchStart);
+      window.removeEventListener("touchmove", onTouchMove);
+      window.removeEventListener("touchend", endDrag);
+      window.removeEventListener("touchcancel", endDrag);
+    };
+    // offset/refreshing/state are read via refs to keep handlers stable.
+  }, [enabled, t]);
+
+  if (!enabled) return null;
+
+  const progress = Math.min(offset / PULL_THRESHOLD_PX, 1);
+  const visible = offset > 0 || refreshing;
+  const ready = offset >= PULL_THRESHOLD_PX;
+
+  return (
+    <div
+      aria-hidden={!visible}
+      style={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        right: 0,
+        display: "flex",
+        justifyContent: "center",
+        pointerEvents: "none",
+        zIndex: 1000,
+        transform: `translateY(${(refreshing ? PULL_THRESHOLD_PX : offset) - PULL_MAX_PX}px)`,
+        transition: offset === 0 && !refreshing ? "transform 0.2s ease" : "none",
+        opacity: visible ? 1 : 0,
+      }}
+    >
+      <div
+        role="status"
+        style={{
+          marginTop: "calc(env(safe-area-inset-top, 0px) + 12px)",
+          width: 32,
+          height: 32,
+          borderRadius: "50%",
+          background: "var(--paper)",
+          boxShadow: "0 1px 6px rgba(0,0,0,0.15)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <span
+          style={{
+            display: "block",
+            width: 18,
+            height: 18,
+            borderRadius: "50%",
+            border: "2px solid var(--ink-mute)",
+            borderTopColor: ready || refreshing ? "var(--accent)" : "var(--ink-mute)",
+            // Spin while refreshing; otherwise rotate proportionally to the pull.
+            transform: refreshing ? undefined : `rotate(${progress * 270}deg)`,
+            animation: refreshing ? "ptr-spin 0.7s linear infinite" : undefined,
+          }}
+        />
+      </div>
+      <style>{`@keyframes ptr-spin { to { transform: rotate(360deg); } }`}</style>
+    </div>
+  );
+}

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -591,7 +591,8 @@ export const en: Messages = {
   "admin.invite_copied": "Link copied!",
   "admin.invite_send": "Send invite link",
   "admin.invite_sent": "Invite sent!",
-  "admin.invite_needs_username": "Set a username first — the invite lets the member set a password, not a username.",
+  "admin.invite_needs_username":
+    "Set a username first — the invite lets the member set a password, not a username.",
   "admin.username_label": "Username",
   "admin.is_admin_label": "Admin",
   "admin.no_username": "No login yet",
@@ -642,6 +643,8 @@ export const en: Messages = {
   "offline.queued_suffix": "{count} pending",
   "offline.tooltip_syncing": "Syncing…",
   "offline.conflict_toast": "Edit conflict — refresh and retry.",
+  "pwa.refreshing": "Refreshing…",
+  "pwa.refresh_blocked_offline": "Can't refresh — you're offline with unsynced changes.",
 
   // Owner dashboard
   "owner.title": "My cars",

--- a/lib/i18n/messages/nl.ts
+++ b/lib/i18n/messages/nl.ts
@@ -590,7 +590,8 @@ export const nl = {
   "admin.invite_copied": "Link gekopieerd!",
   "admin.invite_send": "Stuur uitnodigingslink",
   "admin.invite_sent": "Uitnodiging verstuurd!",
-  "admin.invite_needs_username": "Stel eerst een gebruikersnaam in — via de uitnodiging stelt het lid een wachtwoord in, geen gebruikersnaam.",
+  "admin.invite_needs_username":
+    "Stel eerst een gebruikersnaam in — via de uitnodiging stelt het lid een wachtwoord in, geen gebruikersnaam.",
   "admin.username_label": "Gebruikersnaam",
   "admin.is_admin_label": "Admin",
   "admin.no_username": "Nog geen login",
@@ -641,6 +642,9 @@ export const nl = {
   "offline.queued_suffix": "{count} wachten",
   "offline.tooltip_syncing": "Synchroniseren…",
   "offline.conflict_toast": "Bewerkingsconflict — ververs en probeer opnieuw.",
+  "pwa.refreshing": "Verversen…",
+  "pwa.refresh_blocked_offline":
+    "Verversen kan niet — je bent offline met niet-gesynchroniseerde wijzigingen.",
 
   // Owner dashboard
   "owner.title": "Mijn wagens",

--- a/lib/pwa/pull-to-refresh-logic.test.ts
+++ b/lib/pwa/pull-to-refresh-logic.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import {
+  decideRefresh,
+  pullOffset,
+  isStandalone,
+  PULL_THRESHOLD_PX,
+  PULL_MAX_PX,
+} from "./pull-to-refresh-logic";
+
+describe("decideRefresh", () => {
+  const base = { threshold: PULL_THRESHOLD_PX, online: true, outboxCount: 0 };
+
+  it("cancels when released before the threshold", () => {
+    expect(decideRefresh({ ...base, dragDistance: PULL_THRESHOLD_PX - 1 })).toEqual({
+      action: "cancel",
+    });
+  });
+
+  it("refreshes when past threshold and online", () => {
+    expect(decideRefresh({ ...base, dragDistance: PULL_THRESHOLD_PX })).toEqual({
+      action: "refresh",
+    });
+    expect(decideRefresh({ ...base, dragDistance: PULL_THRESHOLD_PX + 50 })).toEqual({
+      action: "refresh",
+    });
+  });
+
+  it("refreshes when online even with a non-empty outbox (outbox is persisted)", () => {
+    expect(
+      decideRefresh({ ...base, dragDistance: PULL_THRESHOLD_PX + 10, outboxCount: 3 })
+    ).toEqual({ action: "refresh" });
+  });
+
+  it("refreshes when offline but the outbox is empty", () => {
+    expect(
+      decideRefresh({
+        ...base,
+        dragDistance: PULL_THRESHOLD_PX + 10,
+        online: false,
+        outboxCount: 0,
+      })
+    ).toEqual({ action: "refresh" });
+  });
+
+  it("blocks when offline with unsynced mutations to avoid stranding data", () => {
+    expect(
+      decideRefresh({
+        ...base,
+        dragDistance: PULL_THRESHOLD_PX + 10,
+        online: false,
+        outboxCount: 2,
+      })
+    ).toEqual({ action: "blocked-offline" });
+  });
+
+  it("prioritises the cancel decision below threshold even when offline with a queue", () => {
+    expect(decideRefresh({ ...base, dragDistance: 5, online: false, outboxCount: 2 })).toEqual({
+      action: "cancel",
+    });
+  });
+});
+
+describe("pullOffset", () => {
+  it("returns 0 for non-positive deltas", () => {
+    expect(pullOffset(0)).toBe(0);
+    expect(pullOffset(-20)).toBe(0);
+  });
+
+  it("tracks 1:1 below the threshold", () => {
+    expect(pullOffset(40)).toBe(40);
+    expect(pullOffset(PULL_THRESHOLD_PX)).toBe(PULL_THRESHOLD_PX);
+  });
+
+  it("applies resistance past the threshold", () => {
+    // 70 + (170-70)*0.5 = 120, clamped at PULL_MAX_PX
+    expect(pullOffset(PULL_THRESHOLD_PX + 20)).toBeLessThan(PULL_THRESHOLD_PX + 20);
+    expect(pullOffset(PULL_THRESHOLD_PX + 20)).toBeGreaterThan(PULL_THRESHOLD_PX);
+  });
+
+  it("never exceeds the max travel", () => {
+    expect(pullOffset(10_000)).toBe(PULL_MAX_PX);
+  });
+});
+
+describe("isStandalone", () => {
+  function fakeWin(opts: { display?: boolean; iosStandalone?: boolean }): Window {
+    return {
+      matchMedia: (q: string) => ({ matches: q.includes("standalone") ? !!opts.display : false }),
+      navigator: { standalone: opts.iosStandalone },
+    } as unknown as Window;
+  }
+
+  it("is true when display-mode is standalone", () => {
+    expect(isStandalone(fakeWin({ display: true }))).toBe(true);
+  });
+
+  it("is true on iOS standalone navigator flag", () => {
+    expect(isStandalone(fakeWin({ display: false, iosStandalone: true }))).toBe(true);
+  });
+
+  it("is false in a normal browser tab", () => {
+    expect(isStandalone(fakeWin({ display: false }))).toBe(false);
+  });
+
+  it("does not throw if matchMedia is missing", () => {
+    expect(isStandalone({ navigator: {} } as unknown as Window)).toBe(false);
+  });
+});

--- a/lib/pwa/pull-to-refresh-logic.ts
+++ b/lib/pwa/pull-to-refresh-logic.ts
@@ -1,0 +1,69 @@
+// Pure, framework-free logic for the PWA pull-to-refresh gesture.
+// Kept separate from the React component so it can be unit-tested without
+// needing real touch events / a DOM.
+
+export const PULL_THRESHOLD_PX = 70;
+// How much the indicator resists the drag past the threshold (rubber-banding).
+export const PULL_RESISTANCE = 0.5;
+// Maximum visual travel of the indicator regardless of how far the user drags.
+export const PULL_MAX_PX = 120;
+
+/**
+ * Detects whether the app is running as an installed PWA (standalone display
+ * mode). In a normal browser tab this returns false so the gesture is a no-op.
+ */
+export function isStandalone(win: Window = window): boolean {
+  try {
+    const mql = win.matchMedia?.("(display-mode: standalone)");
+    if (mql?.matches) return true;
+  } catch {
+    /* matchMedia may be unavailable */
+  }
+  // iOS Safari exposes navigator.standalone instead of display-mode.
+  return (win.navigator as unknown as { standalone?: boolean })?.standalone === true;
+}
+
+/**
+ * Translates a raw vertical drag distance (px the finger has moved down) into
+ * the indicator's visual offset, applying rubber-band resistance past the
+ * threshold and clamping to a maximum.
+ */
+export function pullOffset(rawDelta: number): number {
+  if (rawDelta <= 0) return 0;
+  if (rawDelta <= PULL_THRESHOLD_PX) return rawDelta;
+  const extra = (rawDelta - PULL_THRESHOLD_PX) * PULL_RESISTANCE;
+  return Math.min(PULL_THRESHOLD_PX + extra, PULL_MAX_PX);
+}
+
+export interface RefreshDecisionInput {
+  /** Vertical px the finger moved down (>= 0). */
+  dragDistance: number;
+  /** Trigger threshold in px. */
+  threshold: number;
+  /** Whether the app currently has connectivity. */
+  online: boolean;
+  /** Number of mutations still waiting in the offline outbox. */
+  outboxCount: number;
+}
+
+export type RefreshDecision =
+  | { action: "refresh" }
+  | { action: "cancel" } // released before threshold
+  | { action: "blocked-offline" }; // would lose unsynced offline data
+
+/**
+ * Decides what should happen when the user releases a pull-to-refresh drag.
+ *
+ * - Below threshold -> "cancel" (snap back, do nothing).
+ * - Past threshold but OFFLINE with queued mutations -> "blocked-offline".
+ *   A hard reload while offline could strand the user on a stale/empty cache
+ *   and is pointless (no new version to fetch), so we refuse and warn instead.
+ *   The outbox itself is IndexedDB-backed and survives reloads, but blocking is
+ *   the safest, clearest UX.
+ * - Otherwise -> "refresh".
+ */
+export function decideRefresh(input: RefreshDecisionInput): RefreshDecision {
+  if (input.dragDistance < input.threshold) return { action: "cancel" };
+  if (!input.online && input.outboxCount > 0) return { action: "blocked-offline" };
+  return { action: "refresh" };
+}


### PR DESCRIPTION
Closes #302

## What & why
When the app runs **installed as a PWA** (`display-mode: standalone`) there is no browser chrome, so the user has no native pull-to-refresh and no Ctrl+R to pick up a freshly deployed build. This adds a pull-down-at-the-top gesture that performs a **hard refresh** (SW update + reload), without dropping unsynced offline data.

## Standalone guard (no-op in a normal tab)
`components/pull-to-refresh.tsx` decides on mount via `isStandalone()` — `window.matchMedia('(display-mode: standalone)').matches || navigator.standalone`. In a normal browser tab `enabled` stays `false`: the component renders `null` and attaches **no** touch listeners, so the native gesture is left completely untouched.

## Gesture
- Touch-drag down that starts at `scrollTop === 0`, mostly-vertical (horizontal swipes ignored).
- A spinner indicator follows the drag with rubber-band resistance past a ~70px threshold (`pullOffset`).
- Release past threshold → refresh; release early → cancel (snap back). `touchmove` is registered `passive:false` so the drag can `preventDefault` the document's own overscroll.

## Hard-refresh + SW-update mechanism
On trigger, `hardRefresh()`:
1. `navigator.serviceWorker.getRegistration()` → `registration.update()` to pull the newest SW from the network.
2. If a `waiting` worker exists, `postMessage({ type: 'SKIP_WAITING' })` and wait for `controllerchange` (800ms cap) so the new build activates.
3. `window.location.reload()`.

Resilient when no SW is present (plain reload). Net effect is equivalent to Ctrl+Shift+R.

## Offline-data safety
The decision is centralised in the pure `decideRefresh({ dragDistance, threshold, online, outboxCount })`:
- **Offline + non-empty outbox →** `blocked-offline`: shows a toast ("can't refresh — offline with unsynced changes") and does **not** reload.
- **Online (even with a queue) →** `refresh`: safe because the outbox is **IndexedDB-backed** (`lib/offline/outbox.ts`, db `autodelen-outbox`) and survives reloads; the sync engine re-drains on boot (`useSyncEngine` drains on mount/online).
- Below threshold → `cancel`.

`pendingCount` is read from the existing `useOnlineState()` (kept current by the sync engine's 3s poll of the outbox `count()`).

`app/globals.css` was **not** changed: `overscroll-behavior: none` is already set on `html, body`.

## Files changed
- `components/pull-to-refresh.tsx` (new) — client component, mounted in `app/providers.tsx` inside `OnlineStateProvider`.
- `lib/pwa/pull-to-refresh-logic.ts` (new) — pure helpers (`decideRefresh`, `pullOffset`, `isStandalone`).
- `lib/pwa/pull-to-refresh-logic.test.ts` (new) — unit tests for the pure logic.
- `app/providers.tsx` — mount `<PullToRefresh/>`.
- `lib/i18n/messages/{en,nl}.ts` — `pwa.refreshing`, `pwa.refresh_blocked_offline`.

## Verification (all clean)
- `npm ci` ✓
- `npx tsc -p tsconfig.build.json --noEmit` ✓ (CI gate)
- `npm run lint` ✓ 0 errors (only pre-existing warnings remain)
- `npm test` ✓ 819 tests pass (incl. 15 new pure-logic tests)
- `npm run build` ✓ next-pwa still generates `public/sw.js` + `workbox-*.js`

## Manual validation checklist (cannot be tested in CI)
- [ ] Install the app as a PWA (Add to Home Screen / Install).
- [ ] At the top of a scroll view, pull down → indicator appears and follows the drag.
- [ ] Release past threshold → spinner spins, app reloads and picks up a newly-deployed `/api/health` `version`.
- [ ] Release before threshold → snaps back, no reload.
- [ ] In a **normal browser tab**, the gesture is unaffected (native behaviour, no custom indicator).
- [ ] **Offline with pending outbox**: pull-to-refresh is blocked with a toast; queued mutations are NOT lost and sync once back online.
- [ ] Online with a pending outbox: reload is allowed and the queue drains after boot (no data loss).

https://claude.ai/code/session_01EvJThHe6obwJKjS5cnPLv8

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvJThHe6obwJKjS5cnPLv8)_