### PR TITLE
fix(forms): open native date picker in mono theme date field (#328)

### DIFF
--- a/app/expenses/expense-form.tsx
+++ b/app/expenses/expense-form.tsx
@@ -476,6 +476,7 @@ export function ExpenseForm({
                 <input
                   {...register("date")}
                   type="date"
+                  onClick={(e) => e.currentTarget.showPicker?.()}
                   style={{
                     position: "absolute",
                     inset: 0,

--- a/app/fuel/fuel-form.tsx
+++ b/app/fuel/fuel-form.tsx
@@ -427,6 +427,7 @@ export function FuelForm({ defaultValues, onSubmit, onCancel, onDelete, readOnly
                 <input
                   {...register("date")}
                   type="date"
+                  onClick={(e) => e.currentTarget.showPicker?.()}
                   style={{
                     position: "absolute",
                     inset: 0,

--- a/app/trips/trip-form.tsx
+++ b/app/trips/trip-form.tsx
@@ -431,6 +431,7 @@ export function TripForm({ defaultValues, onSubmit, onCancel, onDelete, readOnly
                 <input
                   {...register("date")}
                   type="date"
+                  onClick={(e) => e.currentTarget.showPicker?.()}
                   style={{
                     position: "absolute",
                     inset: 0,


### PR DESCRIPTION
Closes #328

The mono-theme (default) date control overlays a transparent `<input type="date" opacity:0.001>` over the formatted value, with no handler to open the picker — so tapping it often did nothing and the date couldn't be changed in the trip / fuel / expense add & edit forms.

Fix: `onClick={(e) => e.currentTarget.showPicker?.()}` on the overlay input so the native picker opens on tap/click. Applied to all three forms; lint clean; prod build verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)