### PR TITLE
fix(auth): stable CSRF token (don't rotate on every /api/me) (#333)

### DIFF
--- a/app/api/me/route.test.ts
+++ b/app/api/me/route.test.ts
@@ -156,4 +156,18 @@ describe("GET /api/me", () => {
     expect(body.personId).toBe(1);
     expect(mockSession.destroy).not.toHaveBeenCalled();
   });
+
+  // #333: the csrf token must be stable (issued once, reused) — not rotated on
+  // every call, which raced with refetch-on-focus and broke save with invalid_csrf.
+  it("issues a csrf-token cookie when the request has none", async () => {
+    const res = await GET(new Request("http://localhost/api/me"));
+    expect(res.cookies.get("csrf-token")?.value).toBe("mock-csrf-token");
+  });
+
+  it("does NOT rotate the csrf-token when the request already has one", async () => {
+    const res = await GET(
+      new Request("http://localhost/api/me", { headers: { cookie: "csrf-token=existing-abc" } })
+    );
+    expect(res.cookies.get("csrf-token")).toBeUndefined();
+  });
 });

--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -27,13 +27,18 @@ function getPersonFields(personId: number): {
   };
 }
 
-function withCsrfCookie(response: NextResponse): NextResponse {
-  const token = generateCsrfToken();
-  response.cookies.set("csrf-token", token, {
-    httpOnly: false,
-    sameSite: "strict",
-    path: "/",
-  });
+function withCsrfCookie(req: Request, response: NextResponse): NextResponse {
+  // Issue the double-submit CSRF token once and reuse it. Rotating it on every
+  // /api/me call races with React Query's refetch-on-focus (e.g. after a file
+  // picker), breaking validation on the next save with invalid_csrf (#333).
+  const hasToken = /(?:^|;\s*)csrf-token=/.test(req.headers.get("cookie") ?? "");
+  if (!hasToken) {
+    response.cookies.set("csrf-token", generateCsrfToken(), {
+      httpOnly: false,
+      sameSite: "strict",
+      path: "/",
+    });
+  }
   return response;
 }
 
@@ -42,7 +47,7 @@ export async function GET(req: Request) {
   const out = NextResponse.json(null);
   const session = await getIronSession<SessionData>(req, out, sessionOptions);
   if (!session.authenticated) {
-    return withCsrfCookie(out);
+    return withCsrfCookie(req, out);
   }
 
   // Reject phantom sessions — person deleted, deactivated, or missing after cookie was issued.
@@ -50,7 +55,7 @@ export async function GET(req: Request) {
   if (!session.personId || !isActivePerson(getDb(), session.personId)) {
     session.destroy();
     await session.save();
-    return withCsrfCookie(out);
+    return withCsrfCookie(req, out);
   }
 
   // Honour server-side session revocation ("log out everywhere"): if this
@@ -58,7 +63,7 @@ export async function GET(req: Request) {
   if (session.epoch !== undefined && session.personId !== undefined) {
     if (getSessionEpoch(getDb(), session.personId) !== session.epoch) {
       session.destroy();
-      return withCsrfCookie(NextResponse.json(null));
+      return withCsrfCookie(req, NextResponse.json(null));
     }
   }
 
@@ -70,6 +75,7 @@ export async function GET(req: Request) {
     const cloakedOwner = isOwner(getDb(), cloaked.personId);
     const { shortName: cloakedShortName, themePreference } = getPersonFields(cloaked.personId);
     return withCsrfCookie(
+      req,
       NextResponse.json({
         personId: cloaked.personId,
         shortName: cloakedShortName ?? cloaked.shortName,
@@ -91,6 +97,7 @@ export async function GET(req: Request) {
     ? getPersonFields(session.personId)
     : { shortName: session.shortName ?? null, themePreference: null };
   return withCsrfCookie(
+    req,
     NextResponse.json({
       personId: session.personId ?? null,
       shortName: fields.shortName,


### PR DESCRIPTION
Closes #333

`withCsrfCookie` in `app/api/me/route.ts` regenerated the `csrf-token` cookie on **every** `/api/me` response. With React Query's `refetchOnWindowFocus` (default on), a window blur/focus — e.g. the OS file picker when attaching a receipt (#329) — rotated the token right before a save, so the `x-csrf-token` header (read from `document.cookie`) no longer matched the cookie the browser sent → **`invalid_csrf`**.

Fix: only set the cookie when the request **doesn't already have one** (stable double-submit token; reused across calls).

Verified:
- New unit tests in `app/api/me/route.test.ts`: issues a token when absent; **does not rotate** when one exists. (10/10 pass.)
- Curl e2e: two `/api/me` calls keep the **same** csrf cookie; a save after them passes CSRF (no 403).

Unblocks #329 (receipt save was hitting this on every file-picker save).

🤖 Generated with [Claude Code](https://claude.com/claude-code)