### PR TITLE
feat(auth): inline request-reset-link on /login (#281)

### DIFF
--- a/app/login/__tests__/login-form.test.tsx
+++ b/app/login/__tests__/login-form.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import LoginForm from "../login-form";
 
@@ -34,5 +34,66 @@ describe("LoginForm", () => {
     // Magic mode shows an email input and the send button.
     expect(screen.getByLabelText("auth.email")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "auth.send_magic_link" })).toBeInTheDocument();
+  });
+
+  it("does not offer the inline reset affordance when mail is disabled", () => {
+    render(<LoginForm mailEnabled={false} />);
+    // The inline reset toggle should not appear; only the link to /forgot remains.
+    expect(screen.queryByRole("button", { name: "auth.forgot_password" })).toBeNull();
+    // The fallback link to /forgot is shown instead.
+    expect(screen.getByRole("link", { name: "auth.forgot_password" })).toBeInTheDocument();
+  });
+
+  it("shows the inline reset toggle when mail is enabled", () => {
+    render(<LoginForm mailEnabled={true} />);
+    // Inline button (not a link) is shown.
+    expect(screen.getByRole("button", { name: "auth.forgot_password" })).toBeInTheDocument();
+    // The /forgot link is NOT shown.
+    expect(screen.queryByRole("link", { name: "auth.forgot_password" })).toBeNull();
+  });
+
+  it("reveals email field and send-reset-link button when switching to reset mode", () => {
+    render(<LoginForm mailEnabled={true} />);
+
+    const toggle = screen.getByRole("button", { name: "auth.forgot_password" });
+    fireEvent.click(toggle);
+
+    // Reset mode shows an email input labelled auth.email.
+    expect(screen.getByLabelText("auth.email")).toBeInTheDocument();
+    // And the send reset link button.
+    expect(screen.getByRole("button", { name: "auth.send_reset_link" })).toBeInTheDocument();
+    // The "use password instead" back button is present.
+    expect(screen.getByRole("button", { name: "auth.use_password" })).toBeInTheDocument();
+  });
+
+  it("calls fetch to /api/auth/forgot when submitting reset email", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    render(<LoginForm mailEnabled={true} />);
+
+    // Switch to reset mode.
+    fireEvent.click(screen.getByRole("button", { name: "auth.forgot_password" }));
+
+    // Fill in email.
+    const emailInput = screen.getByLabelText("auth.email");
+    fireEvent.change(emailInput, { target: { value: "user@example.com" } });
+
+    // Submit.
+    fireEvent.click(screen.getByRole("button", { name: "auth.send_reset_link" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/auth/forgot",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ email: "user@example.com" }),
+        }),
+      );
+    });
+
+    // Confirmation message is shown.
+    expect(screen.getByRole("status")).toHaveTextContent("auth.forgot_sent");
+
+    fetchSpy.mockRestore();
   });
 });

--- a/app/login/login-form.tsx
+++ b/app/login/login-form.tsx
@@ -16,9 +16,30 @@ export default function LoginForm({ mailEnabled }: { mailEnabled: boolean }) {
   const [error, setError] = useState<string | null>(null);
   const [showPassword, setShowPassword] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [mode, setMode] = useState<"password" | "magic">("password");
+  const [mode, setMode] = useState<"password" | "magic" | "reset">("password");
   const [magicEmail, setMagicEmail] = useState("");
   const [magicSent, setMagicSent] = useState(false);
+  const [resetEmail, setResetEmail] = useState("");
+  const [resetSent, setResetSent] = useState(false);
+
+  const submitReset = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      // Always 200 (no account enumeration); show the same confirmation regardless.
+      await fetch("/api/auth/forgot", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: resetEmail }),
+      });
+      setResetSent(true);
+    } catch {
+      setError(t("auth.forgot_error"));
+    } finally {
+      setLoading(false);
+    }
+  };
 
   const submitMagic = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -42,6 +63,10 @@ export default function LoginForm({ mailEnabled }: { mailEnabled: boolean }) {
   const handleSubmit = async (e: React.FormEvent) => {
     if (mode === "magic") {
       await submitMagic(e);
+      return;
+    }
+    if (mode === "reset") {
+      await submitReset(e);
       return;
     }
     e.preventDefault();
@@ -262,7 +287,7 @@ export default function LoginForm({ mailEnabled }: { mailEnabled: boolean }) {
             </>
           )}
 
-          {mode === "password" && (
+          {mode === "password" && !mailEnabled && (
             <a
               href="/forgot"
               style={{
@@ -281,25 +306,46 @@ export default function LoginForm({ mailEnabled }: { mailEnabled: boolean }) {
           )}
 
           {mailEnabled && mode === "password" && (
-            <button
-              type="button"
-              onClick={() => setMode("magic")}
-              style={{
-                display: "block",
-                width: "100%",
-                marginTop: 12,
-                background: "none",
-                border: "none",
-                fontFamily: fontMono,
-                fontSize: 10,
-                letterSpacing: 1,
-                textTransform: "uppercase",
-                color: paper.inkDim,
-                cursor: "pointer",
-              }}
-            >
-              {t("auth.use_magic_link")}
-            </button>
+            <>
+              <button
+                type="button"
+                onClick={() => setMode("reset")}
+                style={{
+                  display: "block",
+                  width: "100%",
+                  marginTop: 16,
+                  background: "none",
+                  border: "none",
+                  fontFamily: fontMono,
+                  fontSize: 10,
+                  letterSpacing: 1,
+                  textTransform: "uppercase",
+                  color: paper.inkDim,
+                  cursor: "pointer",
+                }}
+              >
+                {t("auth.forgot_password")}
+              </button>
+              <button
+                type="button"
+                onClick={() => setMode("magic")}
+                style={{
+                  display: "block",
+                  width: "100%",
+                  marginTop: 12,
+                  background: "none",
+                  border: "none",
+                  fontFamily: fontMono,
+                  fontSize: 10,
+                  letterSpacing: 1,
+                  textTransform: "uppercase",
+                  color: paper.inkDim,
+                  cursor: "pointer",
+                }}
+              >
+                {t("auth.use_magic_link")}
+              </button>
+            </>
           )}
 
           {mode === "magic" && (
@@ -375,6 +421,113 @@ export default function LoginForm({ mailEnabled }: { mailEnabled: boolean }) {
                 onClick={() => {
                   setMode("password");
                   setMagicSent(false);
+                  setError(null);
+                }}
+                style={{
+                  display: "block",
+                  width: "100%",
+                  marginTop: 16,
+                  background: "none",
+                  border: "none",
+                  fontFamily: fontMono,
+                  fontSize: 10,
+                  letterSpacing: 1,
+                  textTransform: "uppercase",
+                  color: paper.inkDim,
+                  cursor: "pointer",
+                }}
+              >
+                {t("auth.use_password")}
+              </button>
+            </div>
+          )}
+
+          {mode === "reset" && (
+            <div>
+              {resetSent ? (
+                <p
+                  role="status"
+                  style={{ fontFamily: fontMono, fontSize: 12, color: paper.ink, lineHeight: 1.6 }}
+                >
+                  {t("auth.forgot_sent")}
+                </p>
+              ) : (
+                <div>
+                  <div style={{ marginBottom: 20 }}>
+                    <label
+                      htmlFor="login-reset-email"
+                      style={{
+                        display: "block",
+                        fontFamily: fontMono,
+                        fontSize: 10,
+                        letterSpacing: 1.5,
+                        textTransform: "uppercase",
+                        color: paper.inkDim,
+                        marginBottom: 6,
+                      }}
+                    >
+                      {t("auth.email")}
+                    </label>
+                    <input
+                      id="login-reset-email"
+                      type="email"
+                      autoComplete="email"
+                      value={resetEmail}
+                      onChange={(e) => setResetEmail(e.target.value)}
+                      required
+                      style={{
+                        width: "100%",
+                        padding: "10px 12px",
+                        border: "1px solid " + paper.paperDark,
+                        background: paper.paperDeep,
+                        fontFamily: fontMono,
+                        fontSize: 13,
+                        color: paper.ink,
+                        outline: "none",
+                        appearance: "none",
+                        boxSizing: "border-box",
+                      }}
+                    />
+                  </div>
+                  {error && (
+                    <p
+                      style={{
+                        fontFamily: fontMono,
+                        fontSize: 11,
+                        color: "#c0392b",
+                        marginBottom: 16,
+                        marginTop: 0,
+                      }}
+                    >
+                      {error}
+                    </p>
+                  )}
+                  <button
+                    type="button"
+                    disabled={loading || !resetEmail}
+                    onClick={submitReset}
+                    style={{
+                      width: "100%",
+                      background: loading ? paper.inkDim : paper.ink,
+                      color: paper.paper,
+                      fontFamily: fontMono,
+                      fontSize: 10,
+                      letterSpacing: 2,
+                      textTransform: "uppercase",
+                      padding: "14px",
+                      border: "none",
+                      cursor: loading || !resetEmail ? "not-allowed" : "pointer",
+                    }}
+                  >
+                    {t("auth.send_reset_link")}
+                  </button>
+                </div>
+              )}
+              <button
+                type="button"
+                onClick={() => {
+                  setMode("password");
+                  setResetSent(false);
                   setError(null);
                 }}
                 style={{


### PR DESCRIPTION
Closes #281

Lets a user request a password-reset link **inline on `/login`** without navigating to `/forgot`.

- Adds a `"reset"` mode to the login form: **"Forgot password?"** → email field + **"Send reset link"** → posts `{ email }` to the existing `POST /api/auth/forgot` → neutral **"if an account exists…"** confirmation (no enumeration). "Use a password instead" returns.
- Gated by `mailEnabled` (alongside the existing magic-link toggle); the old `<a href="/forgot">` link is kept only as a fallback when mail is off.
- No new i18n keys (reuses `auth.forgot_password / send_reset_link / forgot_sent / email / use_password`, en + nl).
- `+4` tests in `login-form.test.tsx` (6/6 pass); lint clean; build ok.

Follow-up: a Playwright e2e for the inline reset flow on `/login` (not added here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)