### PR TITLE
feat(pwa): elastic pull-to-refresh — gear indicator + fixed header (#332)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -72,6 +72,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <LocaleProvider>
           <Providers>
             <div
+              data-ptr-content
               style={{
                 minHeight: "100dvh",
                 width: "100%",

--- a/components/pull-to-refresh.tsx
+++ b/components/pull-to-refresh.tsx
@@ -41,6 +41,53 @@ const HORIZONTAL_TOLERANCE = 1.2;
 // CSS transition applied to content on release (snap-back or settle).
 const SNAP_TRANSITION = "transform 0.28s cubic-bezier(0.25, 0.46, 0.45, 0.94)";
 
+// A single cog (Material "settings" gear) for the gear-powered indicator.
+const GEAR_PATH =
+  "M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94L14.4 2.81c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41L9.25 5.35C8.66 5.59 8.12 5.92 7.63 6.29L5.24 5.33c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.07.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z";
+
+/** One rotating cog. Rotates proportionally to the pull, or spins while refreshing. */
+function Gear({
+  px,
+  x,
+  y,
+  color,
+  rotateDeg,
+  spin,
+  durationSec,
+  reverse,
+}: {
+  px: number;
+  x: number;
+  y: number;
+  color: string;
+  rotateDeg: number;
+  spin: boolean;
+  durationSec: number;
+  reverse: boolean;
+}) {
+  return (
+    <svg
+      width={px}
+      height={px}
+      viewBox="0 0 24 24"
+      style={{
+        position: "absolute",
+        left: x,
+        top: y,
+        fill: color,
+        transformOrigin: "center",
+        transform: spin ? undefined : `rotate(${rotateDeg}deg)`,
+        animation: spin
+          ? `${reverse ? "ptr-gear-rev" : "ptr-gear"} ${durationSec}s linear infinite`
+          : undefined,
+        transition: spin ? "none" : "transform 0.06s linear, fill 0.15s ease",
+      }}
+    >
+      <path d={GEAR_PATH} />
+    </svg>
+  );
+}
+
 /**
  * Returns the [data-ptr-content] element that should follow the finger.
  * This is the main page wrapper div in app/layout.tsx.
@@ -50,15 +97,29 @@ function getContentEl(): HTMLElement | null {
   return document.querySelector<HTMLElement>("[data-ptr-content]");
 }
 
+/** The sticky page header(s) — kept visually fixed while the content pulls. */
+function getHeaderEls(): HTMLElement[] {
+  if (typeof document === "undefined") return [];
+  return Array.from(document.querySelectorAll<HTMLElement>(".page-header-border"));
+}
+
 /**
- * Imperatively set / clear the content translateY.
+ * Imperatively set / clear the content translateY, and counter-translate the
+ * sticky header by the opposite amount so it stays fixed while the content
+ * below it pulls down (the indicator is revealed from under the header).
  * `animated` controls whether a CSS transition is applied (true = release/snap).
  */
 function setContentTranslate(px: number, animated: boolean): void {
   const el = getContentEl();
-  if (!el) return;
-  el.style.transition = animated ? SNAP_TRANSITION : "none";
-  el.style.transform = px === 0 ? "" : `translateY(${px}px)`;
+  if (el) {
+    el.style.transition = animated ? SNAP_TRANSITION : "none";
+    el.style.transform = px === 0 ? "" : `translateY(${px}px)`;
+  }
+  for (const h of getHeaderEls()) {
+    h.style.transition = animated ? SNAP_TRANSITION : "none";
+    // Cancel the content's downward shift so the header appears pinned.
+    h.style.transform = px === 0 ? "" : `translateY(${-px}px)`;
+  }
 }
 
 /**
@@ -246,45 +307,60 @@ export default function PullToRefresh() {
         display: "flex",
         justifyContent: "center",
         pointerEvents: "none",
-        zIndex: 1000,
+        // Behind the sticky header (z-index 20) so the indicator is revealed
+        // from *under* the fixed header as the content pulls down.
+        zIndex: 10,
         transform: `translateY(${(refreshing ? PULL_THRESHOLD_PX : offset) - PULL_MAX_PX}px)`,
         // Snap indicator back on release; no transition during live drag.
-        transition: offset === 0 && !refreshing ? "transform 0.28s cubic-bezier(0.25, 0.46, 0.45, 0.94)" : "none",
+        transition: offset === 0 && !refreshing ? SNAP_TRANSITION : "none",
         opacity: visible ? 1 : 0,
       }}
     >
       <div
         role="status"
         style={{
-          marginTop: "calc(env(safe-area-inset-top, 0px) + 12px)",
-          width: 32,
-          height: 32,
+          marginTop: "calc(env(safe-area-inset-top, 0px) + 14px)",
+          width: 46,
+          height: 46,
           borderRadius: "50%",
           background: "var(--paper)",
-          boxShadow: "0 1px 6px rgba(0,0,0,0.15)",
+          boxShadow: "0 2px 12px rgba(0,0,0,0.18)",
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
           // Scale the bubble in as the user pulls.
           transform: `scale(${spinnerScale})`,
-          transition: refreshing ? "none" : "transform 0.1s linear",
+          transition: refreshing ? "none" : "transform 0.12s ease-out",
         }}
       >
-        <span
-          style={{
-            display: "block",
-            width: 18,
-            height: 18,
-            borderRadius: "50%",
-            border: "2px solid var(--ink-mute)",
-            borderTopColor: ready || refreshing ? "var(--accent)" : "var(--ink-mute)",
-            // Spin while refreshing; otherwise rotate proportionally to the pull.
-            transform: refreshing ? undefined : `rotate(${progress * 270}deg)`,
-            animation: refreshing ? "ptr-spin 0.7s linear infinite" : undefined,
-          }}
-        />
+        {/* Two meshing gears — turn with the pull, spin (opposite ways) on refresh */}
+        <div style={{ position: "relative", width: 30, height: 28 }}>
+          <Gear
+            px={22}
+            x={0}
+            y={1}
+            color={ready || refreshing ? "var(--accent)" : "var(--ink-mute)"}
+            rotateDeg={progress * 200}
+            spin={refreshing}
+            durationSec={1.1}
+            reverse={false}
+          />
+          <Gear
+            px={15}
+            x={16}
+            y={12}
+            color="var(--ink-mute)"
+            rotateDeg={-progress * 330}
+            spin={refreshing}
+            durationSec={0.7}
+            reverse
+          />
+        </div>
       </div>
-      <style>{`@keyframes ptr-spin { to { transform: rotate(360deg); } }`}</style>
+      <style>{`
+        @keyframes ptr-gear { to { transform: rotate(360deg); } }
+        @keyframes ptr-gear-rev { to { transform: rotate(-360deg); } }
+      `}</style>
     </div>
   );
 }

--- a/components/pull-to-refresh.tsx
+++ b/components/pull-to-refresh.tsx
@@ -9,6 +9,15 @@
 // any waiting worker) before reloading, so a new build is actually fetched —
 // equivalent to Ctrl+Shift+R.
 //
+// Visual behaviour:
+//   • Content ([data-ptr-content]) translates down with the finger (1:1 up to
+//     the threshold, damped above) for an elastic/rubber-band feel.
+//   • The spinner grows and rotates with pull progress; it spins continuously
+//     once the threshold is passed and the refresh is running.
+//   • Release before threshold → eased snap-back, no reload.
+//   • Release past threshold → content settles to a small loading offset while
+//     the hard refresh runs.
+//
 // In a normal browser tab this renders null and attaches no listeners, so the
 // native gesture is left completely untouched.
 
@@ -20,12 +29,37 @@ import {
   decideRefresh,
   isStandalone,
   pullOffset,
+  contentOffset,
   PULL_THRESHOLD_PX,
   PULL_MAX_PX,
+  CONTENT_LOADING_PX,
 } from "@/lib/pwa/pull-to-refresh-logic";
 
 // Ignore horizontal-ish swipes so we don't hijack carousels / back gestures.
 const HORIZONTAL_TOLERANCE = 1.2;
+
+// CSS transition applied to content on release (snap-back or settle).
+const SNAP_TRANSITION = "transform 0.28s cubic-bezier(0.25, 0.46, 0.45, 0.94)";
+
+/**
+ * Returns the [data-ptr-content] element that should follow the finger.
+ * This is the main page wrapper div in app/layout.tsx.
+ */
+function getContentEl(): HTMLElement | null {
+  if (typeof document === "undefined") return null;
+  return document.querySelector<HTMLElement>("[data-ptr-content]");
+}
+
+/**
+ * Imperatively set / clear the content translateY.
+ * `animated` controls whether a CSS transition is applied (true = release/snap).
+ */
+function setContentTranslate(px: number, animated: boolean): void {
+  const el = getContentEl();
+  if (!el) return;
+  el.style.transition = animated ? SNAP_TRANSITION : "none";
+  el.style.transform = px === 0 ? "" : `translateY(${px}px)`;
+}
 
 /**
  * Ask the active Service Worker to update, activate any waiting worker, then
@@ -88,6 +122,13 @@ export default function PullToRefresh() {
     setEnabled(isStandalone());
   }, []);
 
+  // Cleanup: ensure content translate is cleared when component unmounts.
+  useEffect(() => {
+    return () => {
+      setContentTranslate(0, false);
+    };
+  }, []);
+
   useEffect(() => {
     if (!enabled) return;
 
@@ -114,16 +155,24 @@ export default function PullToRefresh() {
       const dx = e.touches[0].clientX - startX;
       // Only react to downward, mostly-vertical drags that begin at the top.
       if (dy <= 0 || Math.abs(dx) > Math.abs(dy) * HORIZONTAL_TOLERANCE) {
-        if (offsetRef.current !== 0) setOffset(0);
+        if (offsetRef.current !== 0) {
+          setOffset(0);
+          setContentTranslate(0, true);
+        }
         return;
       }
       if (!atTop()) {
         tracking = false;
         setOffset(0);
+        setContentTranslate(0, true);
         return;
       }
       triggered = true;
-      setOffset(pullOffset(dy));
+      const indicatorPx = pullOffset(dy);
+      const contentPx = contentOffset(dy);
+      setOffset(indicatorPx);
+      // Live drag: no transition — content follows finger in real time.
+      setContentTranslate(contentPx, false);
       // Prevent the browser/document from also scrolling/over-scrolling.
       if (e.cancelable) e.preventDefault();
     };
@@ -143,15 +192,24 @@ export default function PullToRefresh() {
       });
 
       if (decision.action === "blocked-offline") {
+        // Snap content back, then warn.
+        setContentTranslate(0, true);
         toast.error(t("pwa.refresh_blocked_offline"));
         return;
       }
-      if (decision.action === "refresh") {
-        setRefreshing(true);
-        refreshingRef.current = true;
-        toast.loading(t("pwa.refreshing"));
-        hardRefresh();
+
+      if (decision.action === "cancel") {
+        // Released before threshold — smooth snap-back to zero.
+        setContentTranslate(0, true);
+        return;
       }
+
+      // decision.action === "refresh": settle content to loading offset, then reload.
+      setContentTranslate(CONTENT_LOADING_PX, true);
+      setRefreshing(true);
+      refreshingRef.current = true;
+      toast.loading(t("pwa.refreshing"));
+      hardRefresh();
     };
 
     // passive:false on move so preventDefault works.
@@ -174,6 +232,9 @@ export default function PullToRefresh() {
   const visible = offset > 0 || refreshing;
   const ready = offset >= PULL_THRESHOLD_PX;
 
+  // Spinner grows from 0.4→1 as the user pulls, snapping to full size at threshold.
+  const spinnerScale = refreshing ? 1 : 0.4 + progress * 0.6;
+
   return (
     <div
       aria-hidden={!visible}
@@ -187,7 +248,8 @@ export default function PullToRefresh() {
         pointerEvents: "none",
         zIndex: 1000,
         transform: `translateY(${(refreshing ? PULL_THRESHOLD_PX : offset) - PULL_MAX_PX}px)`,
-        transition: offset === 0 && !refreshing ? "transform 0.2s ease" : "none",
+        // Snap indicator back on release; no transition during live drag.
+        transition: offset === 0 && !refreshing ? "transform 0.28s cubic-bezier(0.25, 0.46, 0.45, 0.94)" : "none",
         opacity: visible ? 1 : 0,
       }}
     >
@@ -203,6 +265,9 @@ export default function PullToRefresh() {
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
+          // Scale the bubble in as the user pulls.
+          transform: `scale(${spinnerScale})`,
+          transition: refreshing ? "none" : "transform 0.1s linear",
         }}
       >
         <span

--- a/lib/pwa/pull-to-refresh-logic.test.ts
+++ b/lib/pwa/pull-to-refresh-logic.test.ts
@@ -2,9 +2,12 @@ import { describe, it, expect } from "vitest";
 import {
   decideRefresh,
   pullOffset,
+  contentOffset,
   isStandalone,
   PULL_THRESHOLD_PX,
   PULL_MAX_PX,
+  CONTENT_MAX_PX,
+  CONTENT_RESISTANCE,
 } from "./pull-to-refresh-logic";
 
 describe("decideRefresh", () => {
@@ -79,6 +82,50 @@ describe("pullOffset", () => {
 
   it("never exceeds the max travel", () => {
     expect(pullOffset(10_000)).toBe(PULL_MAX_PX);
+  });
+});
+
+describe("contentOffset", () => {
+  it("returns 0 at pull 0", () => {
+    expect(contentOffset(0)).toBe(0);
+  });
+
+  it("returns 0 for negative pull", () => {
+    expect(contentOffset(-10)).toBe(0);
+  });
+
+  it("tracks 1:1 below the threshold (elastic feel, no resistance yet)", () => {
+    expect(contentOffset(1)).toBe(1);
+    expect(contentOffset(35)).toBe(35);
+    expect(contentOffset(PULL_THRESHOLD_PX)).toBe(PULL_THRESHOLD_PX);
+  });
+
+  it("is damped above the threshold (page feels heavy)", () => {
+    const overBy = 40;
+    const expected = PULL_THRESHOLD_PX + overBy * CONTENT_RESISTANCE;
+    expect(contentOffset(PULL_THRESHOLD_PX + overBy)).toBeCloseTo(expected);
+    // Must be less than raw drag distance.
+    expect(contentOffset(PULL_THRESHOLD_PX + overBy)).toBeLessThan(PULL_THRESHOLD_PX + overBy);
+    // Must be greater than threshold.
+    expect(contentOffset(PULL_THRESHOLD_PX + overBy)).toBeGreaterThan(PULL_THRESHOLD_PX);
+  });
+
+  it("is more damped than the indicator (CONTENT_RESISTANCE < PULL_RESISTANCE)", () => {
+    // Both applied to the same over-threshold amount.
+    const raw = PULL_THRESHOLD_PX + 50;
+    expect(contentOffset(raw)).toBeLessThan(pullOffset(raw));
+  });
+
+  it("never exceeds CONTENT_MAX_PX", () => {
+    expect(contentOffset(10_000)).toBe(CONTENT_MAX_PX);
+  });
+
+  it("is continuous at the threshold boundary (no jump)", () => {
+    const justBelow = contentOffset(PULL_THRESHOLD_PX - 0.001);
+    const atThreshold = contentOffset(PULL_THRESHOLD_PX);
+    const justAbove = contentOffset(PULL_THRESHOLD_PX + 0.001);
+    expect(atThreshold).toBeCloseTo(justBelow, 1);
+    expect(atThreshold).toBeCloseTo(justAbove, 1);
   });
 });
 

--- a/lib/pwa/pull-to-refresh-logic.ts
+++ b/lib/pwa/pull-to-refresh-logic.ts
@@ -7,6 +7,12 @@ export const PULL_THRESHOLD_PX = 70;
 export const PULL_RESISTANCE = 0.5;
 // Maximum visual travel of the indicator regardless of how far the user drags.
 export const PULL_MAX_PX = 120;
+// Resistance factor for content translation past the threshold (lighter than indicator).
+export const CONTENT_RESISTANCE = 0.3;
+// Maximum content translateY during the drag.
+export const CONTENT_MAX_PX = 90;
+// Content translateY held while the hard-refresh is running (spinner visible).
+export const CONTENT_LOADING_PX = 40;
 
 /**
  * Detects whether the app is running as an installed PWA (standalone display
@@ -33,6 +39,21 @@ export function pullOffset(rawDelta: number): number {
   if (rawDelta <= PULL_THRESHOLD_PX) return rawDelta;
   const extra = (rawDelta - PULL_THRESHOLD_PX) * PULL_RESISTANCE;
   return Math.min(PULL_THRESHOLD_PX + extra, PULL_MAX_PX);
+}
+
+/**
+ * Translates a raw vertical drag distance into the content wrapper's translateY
+ * offset, giving the elastic "the page follows your finger" feel.
+ *
+ * Curve: 1:1 up to the threshold (finger and content move in lock-step), then
+ * damped by CONTENT_RESISTANCE so the page feels increasingly heavy past the
+ * threshold, and clamped to CONTENT_MAX_PX.
+ */
+export function contentOffset(rawDelta: number): number {
+  if (rawDelta <= 0) return 0;
+  if (rawDelta <= PULL_THRESHOLD_PX) return rawDelta;
+  const extra = (rawDelta - PULL_THRESHOLD_PX) * CONTENT_RESISTANCE;
+  return Math.min(PULL_THRESHOLD_PX + extra, CONTENT_MAX_PX);
 }
 
 export interface RefreshDecisionInput {


### PR DESCRIPTION
Closes #332

Polishes the PWA pull-to-refresh to feel native:
- **Elastic content drag**: content follows the finger (1:1 ≤ 70px, damped → 90px cap) via `contentOffset`; eased snap-back on cancel, settle on refresh.
- **Header stays fixed**: the sticky title bar is counter-translated against the content pull, so the indicator is revealed from *under* a pinned header.
- **Gear-powered indicator**: two meshing cogs that rotate with pull progress (accent at threshold) and spin in opposite directions while refreshing.
- Strict no-op outside standalone; only engages at `scrollTop === 0`.

Drag math extracted + unit-tested (`lib/pwa/pull-to-refresh-logic.test.ts`, 21 tests). Lint clean, build ok. Visual feel validated manually in the installed/standalone PWA (can't be automated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)