### PR TITLE
fix(calendar): allow Google webhook through proxy auth (#339)

### DIFF
--- a/proxy.test.ts
+++ b/proxy.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/env", () => ({
+  env: {
+    SESSION_PASSWORD: "test-password-32-chars-minimum!!",
+    NODE_ENV: "test",
+    NEXT_PUBLIC_BASE_URL: "http://localhost:3000",
+  },
+}));
+
+// Default: unauthenticated session. Individual tests can override.
+const mockGetIronSession = vi.fn(async () => ({ authenticated: false }) as Record<string, unknown>);
+vi.mock("iron-session", () => ({
+  getIronSession: (...a: unknown[]) => mockGetIronSession(...(a as [])),
+}));
+
+import { NextRequest } from "next/server";
+import { proxy } from "./proxy";
+
+function reqFor(path: string) {
+  return new NextRequest(new URL(path, "http://localhost"));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetIronSession.mockResolvedValue({ authenticated: false });
+});
+
+describe("proxy auth gating", () => {
+  it("lets the Google calendar webhook through unauthenticated (public path)", async () => {
+    // Regression for #339: the webhook POST carries no session cookie. If proxy
+    // redirects it to /login, all inbound Google Calendar sync is dead.
+    const res = await proxy(reqFor("/api/calendar-webhook"));
+    expect(res.status).not.toBe(307);
+    expect(res.headers.get("location")).toBeNull();
+  });
+
+  it("redirects an unauthenticated protected route to /login", async () => {
+    const res = await proxy(reqFor("/api/reservations"));
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("/login");
+  });
+});

--- a/proxy.ts
+++ b/proxy.ts
@@ -14,6 +14,11 @@ const PUBLIC_PATHS = [
   "/api/invite",
   "/api/admin/calendar-renew",
   "/api/calendar-id",
+  // Google Calendar push notifications (events.watch webhook). The POST arrives
+  // with no session cookie, so it must bypass the auth redirect or inbound 2-way
+  // sync is dead (#339). The handler has its own auth: it validates the
+  // x-goog-channel-id header against the stored channel_id.
+  "/api/calendar-webhook",
   // Self-service password reset / magic-link sign-in (issue #267).
   "/forgot",
   "/reset",


### PR DESCRIPTION
Fixes #339.

## Problem
`proxy.ts` (Next 16 edge auth) `PUBLIC_PATHS` omitted `/api/calendar-webhook`. Google's push notification is an unauthenticated POST → proxy 307-redirected it to `/login` → the webhook handler never ran → **all inbound 2-way calendar sync was dead** (owner accept/decline/cancel/time edits in Google Calendar never reflected in the app).

Verified live on prod: `POST /api/calendar-webhook → HTTP/2 307, location: /login`.

## Fix
Add `/api/calendar-webhook` to `PUBLIC_PATHS`. The handler keeps its own auth — it validates `x-goog-channel-id` against the stored `channel_id` — so the path is safe to expose.

## Test
`proxy.test.ts` (new): asserts the webhook path passes through unauthenticated (not 307) while a protected route (`/api/reservations`) still redirects to `/login`.

Relates to #337 (confirmation sync) and #338 (sync logging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)