### PR TITLE
feat(calendar): persistent 2-way sync log + admin viewer (#338)

### DIFF
--- a/app/admin/calendar-log/page.tsx
+++ b/app/admin/calendar-log/page.tsx
@@ -1,0 +1,167 @@
+"use client";
+import { useQuery } from "@tanstack/react-query";
+import { paper, fontMono, fontSerif } from "@/lib/paper-theme";
+import { Card } from "../_shared";
+
+interface SyncLogRow {
+  id: number;
+  created_at: string;
+  direction: string;
+  action: string;
+  reservation_id: number | null;
+  google_event_id: string | null;
+  ok: number;
+  detail: string | null;
+}
+
+const labelStyle: React.CSSProperties = {
+  fontFamily: fontMono,
+  fontSize: 9,
+  fontWeight: 700,
+  letterSpacing: 1,
+  textTransform: "uppercase",
+  color: paper.inkMute,
+};
+
+export default function CalendarLogPage() {
+  const { data, isLoading, refetch, isFetching } = useQuery<SyncLogRow[]>({
+    queryKey: ["admin", "calendar-log"],
+    queryFn: () => fetch("/api/admin/calendar-log").then((r) => r.json()),
+    refetchInterval: 15000,
+  });
+
+  return (
+    <div style={{ padding: "12px 0 40px" }}>
+      <Card>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "baseline",
+            justifyContent: "space-between",
+            marginBottom: 6,
+          }}
+        >
+          <div style={{ fontFamily: fontSerif, fontSize: 16, color: paper.ink }}>
+            Calendar sync log
+          </div>
+          <button
+            type="button"
+            onClick={() => refetch()}
+            disabled={isFetching}
+            style={{
+              fontFamily: fontMono,
+              fontSize: 9,
+              fontWeight: 700,
+              letterSpacing: 2,
+              textTransform: "uppercase",
+              background: "none",
+              color: isFetching ? paper.inkMute : paper.inkDim,
+              border: `1px solid ${paper.paperDark}`,
+              padding: "5px 10px",
+              cursor: isFetching ? "default" : "pointer",
+            }}
+          >
+            {isFetching ? "…" : "Refresh"}
+          </button>
+        </div>
+        <div
+          style={{
+            fontFamily: fontMono,
+            fontSize: 10,
+            color: paper.inkMute,
+            lineHeight: 1.5,
+            marginBottom: 12,
+          }}
+        >
+          Last 200 Google Calendar 2-way sync events (newest first, auto-refresh 15s). Times are
+          UTC. <strong>outbound</strong> = app → Google, <strong>inbound</strong> = Google → app.
+        </div>
+
+        {isLoading && <div style={labelStyle}>Loading…</div>}
+        {!isLoading && (!data || data.length === 0) && (
+          <div style={labelStyle}>No sync events logged yet.</div>
+        )}
+
+        {data && data.length > 0 && (
+          <div style={{ overflowX: "auto" }}>
+            <table
+              style={{
+                width: "100%",
+                borderCollapse: "collapse",
+                fontFamily: fontMono,
+                fontSize: 10,
+              }}
+            >
+              <thead>
+                <tr style={{ textAlign: "left", color: paper.inkMute }}>
+                  <th style={thStyle}>Time (UTC)</th>
+                  <th style={thStyle}>Dir</th>
+                  <th style={thStyle}>Action</th>
+                  <th style={thStyle}>Res</th>
+                  <th style={thStyle}>Event</th>
+                  <th style={thStyle}>Detail</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.map((row) => (
+                  <tr
+                    key={row.id}
+                    style={{ borderTop: `1px solid ${paper.paperDark}`, verticalAlign: "top" }}
+                  >
+                    <td style={{ ...tdStyle, whiteSpace: "nowrap", color: paper.inkDim }}>
+                      {row.created_at}
+                    </td>
+                    <td style={{ ...tdStyle, color: paper.inkMute }}>{row.direction}</td>
+                    <td
+                      style={{
+                        ...tdStyle,
+                        fontWeight: 700,
+                        color: row.ok ? paper.ink : paper.accent,
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {row.ok ? "" : "⚠ "}
+                      {row.action}
+                    </td>
+                    <td style={tdStyle}>{row.reservation_id ?? "—"}</td>
+                    <td style={{ ...tdStyle, color: paper.inkMute }}>
+                      {row.google_event_id ? "…" + row.google_event_id.slice(-6) : "—"}
+                    </td>
+                    <td style={{ ...tdStyle, color: paper.inkDim, wordBreak: "break-word" }}>
+                      {formatDetail(row.detail)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}
+
+const thStyle: React.CSSProperties = {
+  padding: "4px 8px 6px 0",
+  fontWeight: 700,
+  letterSpacing: 0.5,
+  textTransform: "uppercase",
+  fontSize: 9,
+};
+
+const tdStyle: React.CSSProperties = {
+  padding: "5px 8px 5px 0",
+};
+
+function formatDetail(detail: string | null): string {
+  if (!detail) return "";
+  try {
+    const obj = JSON.parse(detail) as Record<string, unknown>;
+    return Object.entries(obj)
+      .filter(([, v]) => v !== null && v !== undefined && v !== "")
+      .map(([k, v]) => `${k}=${typeof v === "object" ? JSON.stringify(v) : String(v)}`)
+      .join("  ");
+  } catch {
+    return detail;
+  }
+}

--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState, useEffect } from "react";
+import Link from "next/link";
 import { Eye, EyeOff } from "lucide-react";
 import { toast } from "sonner";
 import { paper, fontMono, fontSerif } from "@/lib/paper-theme";
@@ -425,6 +426,25 @@ export default function AdminSettingsPage() {
                   {backfillStatus.message}
                 </div>
               )}
+              <Link
+                href="/admin/calendar-log"
+                style={{
+                  display: "block",
+                  marginTop: 8,
+                  textAlign: "center",
+                  padding: "8px",
+                  fontFamily: fontMono,
+                  fontSize: 9,
+                  fontWeight: 700,
+                  letterSpacing: 2,
+                  textTransform: "uppercase",
+                  color: paper.inkDim,
+                  border: `1px solid ${paper.paperDark}`,
+                  textDecoration: "none",
+                }}
+              >
+                {t("settings.view_sync_log")}
+              </Link>
             </>
           )}
         </Card>

--- a/app/api/admin/calendar-log/route.ts
+++ b/app/api/admin/calendar-log/route.ts
@@ -1,0 +1,10 @@
+import { getDb } from "@/lib/db";
+import { json, requireAdmin } from "@/lib/api";
+import { getRecentSyncLog } from "@/lib/calendar-sync-log";
+
+// Read-only view of the calendar sync log (#338). Admin-only — the detail blobs
+// can contain owner email addresses and reservation context.
+export const GET = json(async (req) => {
+  await requireAdmin(req);
+  return getRecentSyncLog(getDb(), 200);
+});

--- a/app/api/calendar-webhook/route.ts
+++ b/app/api/calendar-webhook/route.ts
@@ -4,6 +4,7 @@ import { getDb } from "@/lib/db";
 import { getSetting } from "@/lib/queries/settings";
 import { getOAuthClient, listEventsDelta } from "@/lib/google-calendar";
 import { processCalendarDelta } from "@/lib/process-calendar-delta";
+import { logSync } from "@/lib/calendar-sync-log";
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   // Initial handshake from Google
@@ -23,6 +24,12 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   // Validate channel ID to reject spoofed webhook calls
   const incomingChannelId = req.headers.get("x-goog-channel-id");
   if (stateRow && incomingChannelId !== stateRow.channel_id) {
+    logSync(db, {
+      direction: "inbound",
+      action: "webhook",
+      ok: false,
+      detail: { reason: "channel_mismatch", incomingChannelId },
+    });
     return NextResponse.json({ ok: true });
   }
 
@@ -42,13 +49,31 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
         ({ items, nextSyncToken } = await listEventsDelta(client, calendarId));
       } catch (e2) {
         console.error("[calendar-webhook] full re-sync also failed", e2);
+        logSync(db, {
+          direction: "inbound",
+          action: "webhook",
+          ok: false,
+          detail: { reason: "resync_failed", message: e2 instanceof Error ? e2.message : String(e2) },
+        });
         return NextResponse.json({ ok: true });
       }
     } else {
       console.error("[calendar-webhook] listEventsDelta failed", e);
+      logSync(db, {
+        direction: "inbound",
+        action: "webhook",
+        ok: false,
+        detail: { reason: "delta_failed", code, message: e instanceof Error ? e.message : String(e) },
+      });
       return NextResponse.json({ ok: true });
     }
   }
+
+  logSync(db, {
+    direction: "inbound",
+    action: "webhook",
+    detail: { itemCount: items.length, hadSyncToken: Boolean(stateRow?.sync_token) },
+  });
 
   await processCalendarDelta(db, client, calendarId, items);
 

--- a/lib/__tests__/calendar_sync_log.test.ts
+++ b/lib/__tests__/calendar_sync_log.test.ts
@@ -1,0 +1,67 @@
+// lib/__tests__/calendar_sync_log.test.ts
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../db/migrate";
+import { logSync, getRecentSyncLog, MAX_ROWS } from "../calendar-sync-log";
+
+function makeDb() {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  runMigrations(db);
+  return db;
+}
+
+describe("logSync / getRecentSyncLog", () => {
+  it("persists an entry and reads it back", () => {
+    const db = makeDb();
+    logSync(db, {
+      direction: "outbound",
+      action: "create",
+      reservationId: 7,
+      googleEventId: "evt-1",
+      detail: { start: "2026-06-01", nonce: "abc" },
+    });
+
+    const rows = getRecentSyncLog(db);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      direction: "outbound",
+      action: "create",
+      reservation_id: 7,
+      google_event_id: "evt-1",
+      ok: 1,
+    });
+    expect(JSON.parse(rows[0].detail!)).toEqual({ start: "2026-06-01", nonce: "abc" });
+  });
+
+  it("stores ok:false as 0", () => {
+    const db = makeDb();
+    logSync(db, { direction: "outbound", action: "error", ok: false, detail: { message: "boom" } });
+    expect(getRecentSyncLog(db)[0].ok).toBe(0);
+  });
+
+  it("returns rows newest-first and honours the limit", () => {
+    const db = makeDb();
+    for (let i = 0; i < 5; i++) {
+      logSync(db, { direction: "inbound", action: "rsvp", reservationId: i });
+    }
+    const rows = getRecentSyncLog(db, 2);
+    expect(rows).toHaveLength(2);
+    expect(rows[0].reservation_id).toBe(4);
+    expect(rows[1].reservation_id).toBe(3);
+  });
+
+  it("trims the table to MAX_ROWS (retention)", () => {
+    const db = makeDb();
+    for (let i = 0; i < MAX_ROWS + 5; i++) {
+      logSync(db, { direction: "inbound", action: "webhook" });
+    }
+    const count = db.prepare("SELECT COUNT(*) AS n FROM calendar_sync_log").get() as { n: number };
+    expect(count.n).toBe(MAX_ROWS);
+  });
+
+  it("never throws when the table is missing", () => {
+    const db = new Database(":memory:");
+    expect(() => logSync(db, { direction: "inbound", action: "webhook" })).not.toThrow();
+  });
+});

--- a/lib/__tests__/db.test.ts
+++ b/lib/__tests__/db.test.ts
@@ -3,7 +3,7 @@ import Database from "better-sqlite3";
 import { runMigrations } from "../db/migrate";
 
 describe("runMigrations", () => {
-  it("creates all 13 tables", () => {
+  it("creates all 14 tables", () => {
     const db = new Database(":memory:");
     runMigrations(db);
     const tables = db
@@ -14,6 +14,7 @@ describe("runMigrations", () => {
       .map((r: any) => r.name);
     expect(tables).toEqual([
       "_migrations",
+      "calendar_sync_log",
       "calendar_sync_state",
       "car_price_history",
       "cars",

--- a/lib/__tests__/migration_forward.test.ts
+++ b/lib/__tests__/migration_forward.test.ts
@@ -42,6 +42,7 @@ const ALL_MIGRATIONS = [
   "0021_people_session_epoch.sql",
   "0022_invite_tokens_purpose.sql",
   "0023_expenses_receipt.sql",
+  "0024_calendar_sync_log.sql",
 ];
 
 const LATER_MIGRATIONS = ALL_MIGRATIONS.slice(10); // 0011–0022
@@ -194,12 +195,12 @@ describe("forward migration — 0001–0010 → 0011–0022", () => {
     // (b) owner_person_id added to cars (migration 0012)
     expect(carCols.map((c) => c.name)).toContain("owner_person_id");
 
-    // (c) _migrations log lists all 22 migrations
+    // (c) _migrations log lists all migrations
     const applied = db
       .prepare("SELECT filename FROM _migrations ORDER BY filename")
       .pluck()
       .all() as string[];
-    expect(applied).toHaveLength(23);
+    expect(applied).toHaveLength(24);
     for (const f of ALL_MIGRATIONS) {
       expect(applied).toContain(f);
     }
@@ -210,6 +211,6 @@ describe("forward migration — 0001–0010 → 0011–0022", () => {
       .prepare("SELECT filename FROM _migrations ORDER BY filename")
       .pluck()
       .all() as string[];
-    expect(appliedAfter).toHaveLength(23);
+    expect(appliedAfter).toHaveLength(24);
   });
 });

--- a/lib/calendar-sync-log.ts
+++ b/lib/calendar-sync-log.ts
@@ -1,0 +1,76 @@
+// lib/calendar-sync-log.ts
+// Persistent, queryable log of Google Calendar 2-way sync events (#338).
+// Writing must never throw into the sync path — all failures are swallowed.
+import type Database from "better-sqlite3";
+
+export type SyncDirection = "outbound" | "inbound";
+
+export interface SyncLogEntry {
+  direction: SyncDirection;
+  /** create | update | delete | rsvp | time-overwrite | echo-skip | webhook | error */
+  action: string;
+  reservationId?: number | null;
+  googleEventId?: string | null;
+  /** false marks a failure; defaults to true. */
+  ok?: boolean;
+  /** Arbitrary context, JSON-serialized (dates, status, nonce, etag, error message). */
+  detail?: unknown;
+}
+
+export interface SyncLogRow {
+  id: number;
+  created_at: string;
+  direction: string;
+  action: string;
+  reservation_id: number | null;
+  google_event_id: string | null;
+  ok: number;
+  detail: string | null;
+}
+
+// Keep the table bounded — calendars can be chatty. Roughly a few weeks of
+// activity for a small fleet; oldest rows are trimmed on each insert.
+export const MAX_ROWS = 2000;
+
+export function logSync(db: Database.Database, entry: SyncLogEntry): void {
+  try {
+    db.prepare(
+      `INSERT INTO calendar_sync_log (direction, action, reservation_id, google_event_id, ok, detail)
+       VALUES (?, ?, ?, ?, ?, ?)`
+    ).run(
+      entry.direction,
+      entry.action,
+      entry.reservationId ?? null,
+      entry.googleEventId ?? null,
+      entry.ok === false ? 0 : 1,
+      entry.detail === undefined ? null : safeStringify(entry.detail)
+    );
+    // Retention: drop everything older than the most recent MAX_ROWS rows.
+    db.prepare(
+      `DELETE FROM calendar_sync_log
+       WHERE id <= (SELECT MAX(id) FROM calendar_sync_log) - ?`
+    ).run(MAX_ROWS);
+  } catch (e) {
+    // Logging is best-effort — never break the sync it is observing.
+    console.error("[calendar-sync-log] insert failed", e);
+  }
+}
+
+export function getRecentSyncLog(db: Database.Database, limit = 200): SyncLogRow[] {
+  return db
+    .prepare(
+      `SELECT id, created_at, direction, action, reservation_id, google_event_id, ok, detail
+       FROM calendar_sync_log
+       ORDER BY id DESC
+       LIMIT ?`
+    )
+    .all(limit) as SyncLogRow[];
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -584,6 +584,7 @@ export const en: Messages = {
     "✗ Read-only access — the app cannot create events. Change the sharing permission to 'Make changes to events'.",
   "settings.test_fail": "✗ Unexpected error: {error}",
   "settings.backfill": "Sync upcoming reservations",
+  "settings.view_sync_log": "View sync log",
 
   // Admin members
   "admin.members_title": "Members",

--- a/lib/i18n/messages/nl.ts
+++ b/lib/i18n/messages/nl.ts
@@ -583,6 +583,7 @@ export const nl = {
     "✗ Alleen leesrechten — de app kan geen afspraken aanmaken. Wijzig de deling naar 'Wijzigingen aanbrengen in evenementen'.",
   "settings.test_fail": "✗ Onverwachte fout: {error}",
   "settings.backfill": "Toekomstige reserveringen synchroniseren",
+  "settings.view_sync_log": "Synclog bekijken",
 
   // Admin members
   "admin.members_title": "Leden",

--- a/lib/process-calendar-delta.ts
+++ b/lib/process-calendar-delta.ts
@@ -3,6 +3,7 @@ import type Database from "better-sqlite3";
 import type { OAuth2Client } from "google-auth-library";
 import { addDays, updateEvent } from "@/lib/google-calendar";
 import type { CalendarEvent } from "@/lib/google-calendar";
+import { logSync } from "@/lib/calendar-sync-log";
 
 interface ReservationRowForDelta {
   id: number;
@@ -48,13 +49,30 @@ export async function processCalendarDelta(
     // Etag is the primary guard. Nonce is a fallback for the rare case where Google
     // returns a delta without an etag — using nonce as primary would suppress external
     // RSVP changes because Google preserves extendedProperties through user edits.
-    if (event.etag != null && event.etag === row.last_synced_etag) continue;
+    if (event.etag != null && event.etag === row.last_synced_etag) {
+      logSync(db, {
+        direction: "inbound",
+        action: "echo-skip",
+        reservationId: row.id,
+        googleEventId: event.id,
+        detail: { reason: "etag", etag: event.etag },
+      });
+      continue;
+    }
     if (
       event.etag == null &&
       event.extendedProperties?.private?.appWriteNonce != null &&
       event.extendedProperties.private.appWriteNonce === row.last_app_write_nonce
-    )
+    ) {
+      logSync(db, {
+        direction: "inbound",
+        action: "echo-skip",
+        reservationId: row.id,
+        googleEventId: event.id,
+        detail: { reason: "nonce" },
+      });
       continue;
+    }
 
     // Time-edit guard — app is authoritative for event times
     // Skip time check for cancelled events (start/end may be absent)
@@ -83,8 +101,29 @@ export async function processCalendarDelta(
         db.prepare(
           "UPDATE reservations SET last_synced_etag=?, last_app_write_nonce=? WHERE id=?"
         ).run(etag, nonce, row.id);
+        logSync(db, {
+          direction: "outbound",
+          action: "time-overwrite",
+          reservationId: row.id,
+          googleEventId: event.id,
+          detail: {
+            eventStart: event.start?.date,
+            eventEnd: event.end?.date,
+            rowStart: row.start_date,
+            rowEnd: expectedEnd,
+            nonce,
+          },
+        });
       } catch (e) {
         console.error("[calendar-delta] overwrite time edit failed", e);
+        logSync(db, {
+          direction: "outbound",
+          action: "time-overwrite",
+          reservationId: row.id,
+          googleEventId: event.id,
+          ok: false,
+          detail: { message: e instanceof Error ? e.message : String(e) },
+        });
       }
       continue;
     }
@@ -109,6 +148,18 @@ export async function processCalendarDelta(
       db.prepare(
         "UPDATE reservations SET status=COALESCE(?, status), last_known_response_status=?, last_synced_etag=? WHERE id=?"
       ).run(newStatus, newResponseStatus, event.etag ?? null, row.id);
+      logSync(db, {
+        direction: "inbound",
+        action: "rsvp",
+        reservationId: row.id,
+        googleEventId: event.id,
+        detail: {
+          from: row.last_known_response_status,
+          to: newResponseStatus,
+          newStatus,
+          eventStatus: event.status,
+        },
+      });
     }
   }
 }

--- a/lib/reservation-sync.ts
+++ b/lib/reservation-sync.ts
@@ -2,6 +2,11 @@
 import type Database from "better-sqlite3";
 import { getSetting } from "@/lib/queries/settings";
 import * as cal from "@/lib/google-calendar";
+import { logSync } from "@/lib/calendar-sync-log";
+
+function errMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
 
 interface ReservationRow {
   id: number;
@@ -57,8 +62,22 @@ export async function syncReservationCreate(db: Database.Database, id: number): 
     db.prepare(
       "UPDATE reservations SET google_event_id=?, last_synced_etag=?, last_app_write_nonce=? WHERE id=?"
     ).run(eventId, etag, nonce, id);
+    logSync(db, {
+      direction: "outbound",
+      action: "create",
+      reservationId: id,
+      googleEventId: eventId,
+      detail: { start: r.start_date, end: r.end_date, status: r.status, ownerEmail: r.owner_email, nonce },
+    });
   } catch (e) {
     console.error("[calendar-sync] createEvent failed", e);
+    logSync(db, {
+      direction: "outbound",
+      action: "create",
+      reservationId: id,
+      ok: false,
+      detail: { message: errMessage(e) },
+    });
   }
 }
 
@@ -82,8 +101,23 @@ export async function syncReservationUpdate(db: Database.Database, id: number): 
       nonce,
       id
     );
+    logSync(db, {
+      direction: "outbound",
+      action: "update",
+      reservationId: id,
+      googleEventId: r.google_event_id,
+      detail: { start: r.start_date, end: r.end_date, status: r.status, nonce },
+    });
   } catch (e) {
     console.error("[calendar-sync] updateEvent failed", e);
+    logSync(db, {
+      direction: "outbound",
+      action: "update",
+      reservationId: id,
+      googleEventId: r.google_event_id,
+      ok: false,
+      detail: { message: errMessage(e) },
+    });
   }
 }
 
@@ -97,7 +131,21 @@ export async function syncReservationDelete(db: Database.Database, id: number): 
     db.prepare(
       "UPDATE reservations SET google_event_id=NULL, last_synced_etag=NULL, last_app_write_nonce=NULL, last_known_response_status=NULL WHERE id=?"
     ).run(id);
+    logSync(db, {
+      direction: "outbound",
+      action: "delete",
+      reservationId: id,
+      googleEventId: r.google_event_id,
+    });
   } catch (e) {
     console.error("[calendar-sync] deleteEvent failed", e);
+    logSync(db, {
+      direction: "outbound",
+      action: "delete",
+      reservationId: id,
+      googleEventId: r.google_event_id,
+      ok: false,
+      detail: { message: errMessage(e) },
+    });
   }
 }

--- a/migrations/0024_calendar_sync_log.sql
+++ b/migrations/0024_calendar_sync_log.sql
@@ -1,0 +1,16 @@
+-- Persistent log of Google Calendar 2-way sync events (#338).
+-- Lives in the DB (on the mounted volume) so it survives container redeploys,
+-- unlike the previous console.error-only logging. Bounded by a retention trim
+-- in lib/calendar-sync-log.ts.
+CREATE TABLE IF NOT EXISTS calendar_sync_log (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  direction       TEXT NOT NULL,           -- 'outbound' (app -> GCal) | 'inbound' (GCal -> app)
+  action          TEXT NOT NULL,           -- create|update|delete|rsvp|time-overwrite|echo-skip|webhook|error
+  reservation_id  INTEGER,
+  google_event_id TEXT,
+  ok              INTEGER NOT NULL DEFAULT 1,
+  detail          TEXT                      -- JSON blob with context (dates, status, nonce, etag, error message)
+);
+
+CREATE INDEX IF NOT EXISTS idx_calendar_sync_log_id_desc ON calendar_sync_log(id DESC);


### PR DESCRIPTION
Closes #338.

## Why
Calendar 2-way sync was only observable via `console.error` (failures only), and those logs are wiped on every container redeploy. Debugging prod sync issues (e.g. #337) was effectively impossible.

## What
- **`calendar_sync_log` table** (migration `0024`) — lives in the DB on the mounted volume, so it survives redeploys. Bounded to the most recent `MAX_ROWS` (2000) via a retention trim on each insert.
- **`lib/calendar-sync-log.ts`** — `logSync()` (best-effort; swallows its own errors so it never breaks the sync it observes) + `getRecentSyncLog()`.
- **Instrumentation:**
  - outbound: `create` / `update` / `delete` (success + error) in `reservation-sync.ts`
  - inbound: `echo-skip` (etag/nonce), `time-overwrite`, `rsvp` in `process-calendar-delta.ts`
  - webhook: receipt (item count), `delta_failed` / `resync_failed` / `channel_mismatch` in the route
- **Admin viewer** — `/admin/calendar-log` (auto-refresh 15s, newest first) + `/api/admin/calendar-log` (admin-only — detail blobs can contain owner emails). Linked from admin → settings.

## Tests
- `lib/__tests__/calendar_sync_log.test.ts` — persistence, `ok:false`, ordering/limit, retention trim, never-throws.
- Updated `db.test.ts` (14 tables) and `migration_forward.test.ts` (24 migrations).
- Full suite green (840 passing).

Relates to #337 (confirmation sync) and #339 (webhook unblock, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)