### PR TITLE
fix(calendar): converge confirm in both sync directions, uninvite owner (#337)

### DIFF
--- a/lib/__tests__/google_calendar_build_event.test.ts
+++ b/lib/__tests__/google_calendar_build_event.test.ts
@@ -1,0 +1,53 @@
+// lib/__tests__/google_calendar_build_event.test.ts
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@/lib/env", () => ({
+  env: {
+    GOOGLE_CLIENT_ID: "test-client-id",
+    GOOGLE_CLIENT_SECRET: "test-client-secret",
+    NODE_ENV: "test",
+  },
+}));
+
+import { buildEventBody } from "@/lib/google-calendar";
+
+const base = {
+  start_date: "2026-06-01",
+  end_date: "2026-06-03",
+  car_short: "CA",
+  person_name: "Alice",
+  note: null,
+};
+
+type Body = { status: string; attendees: Array<{ email: string }>; end: { date: string } };
+
+describe("buildEventBody attendee rule (#337)", () => {
+  it("invites the owner as attendee while pending (tentative)", () => {
+    const body = buildEventBody({ ...base, status: "pending" }, "n1", "bob@example.com") as Body;
+    expect(body.status).toBe("tentative");
+    expect(body.attendees).toEqual([{ email: "bob@example.com" }]);
+  });
+
+  it("drops the owner attendee once confirmed", () => {
+    const body = buildEventBody({ ...base, status: "confirmed" }, "n1", "bob@example.com") as Body;
+    expect(body.status).toBe("confirmed");
+    expect(body.attendees).toEqual([]);
+  });
+
+  it("marks a rejected reservation as a cancelled event (attendee moot)", () => {
+    // Only the confirmed transition uninvites the owner; a rejected reservation
+    // becomes a cancelled event, which leaves everyone's calendar regardless.
+    const body = buildEventBody({ ...base, status: "rejected" }, "n1", "bob@example.com") as Body;
+    expect(body.status).toBe("cancelled");
+  });
+
+  it("has no attendees when there is no owner email", () => {
+    const body = buildEventBody({ ...base, status: "pending" }, "n1") as Body;
+    expect(body.attendees).toEqual([]);
+  });
+
+  it("sets an exclusive end date (end_date + 1 day)", () => {
+    const body = buildEventBody({ ...base, status: "pending" }, "n1") as Body;
+    expect(body.end.date).toBe("2026-06-04");
+  });
+});

--- a/lib/__tests__/process_calendar_delta.test.ts
+++ b/lib/__tests__/process_calendar_delta.test.ts
@@ -157,6 +157,72 @@ describe("processCalendarDelta", () => {
     expect(row.status).toBe("rejected");
   });
 
+  it("pushes a confirmed event and uninvites the owner when the owner accepts (#337)", async () => {
+    const db = makeDb();
+    seedWithEvent(db);
+    const events: CalendarEvent[] = [
+      {
+        id: "evt-123",
+        etag: '"different-etag"',
+        start: { date: "2026-06-01" },
+        end: { date: "2026-06-04" },
+        attendees: [{ email: "bob@example.com", responseStatus: "accepted" }],
+        extendedProperties: { private: { appWriteNonce: "other-nonce" } },
+      },
+    ];
+    await processCalendarDelta(db, fakeClient, calendarId, events);
+
+    // Pushed an outbound confirm: updateEvent(client, calId, eventId, reservation, nonce, ownerEmail)
+    expect(calMock.updateEvent).toHaveBeenCalledOnce();
+    const args = (calMock.updateEvent as unknown as { mock: { calls: unknown[][] } }).mock.calls[0];
+    expect(args[2]).toBe("evt-123");
+    expect((args[3] as { status: string }).status).toBe("confirmed");
+    expect(args[5]).toBe("bob@example.com");
+
+    const row = db
+      .prepare(
+        "SELECT status, last_known_response_status, last_synced_etag, last_app_write_nonce FROM reservations WHERE google_event_id = 'evt-123'"
+      )
+      .get() as {
+      status: string;
+      last_known_response_status: string;
+      last_synced_etag: string;
+      last_app_write_nonce: string;
+    };
+    expect(row.status).toBe("confirmed");
+    expect(row.last_known_response_status).toBe("accepted");
+    // etag/nonce come from our own push, so the resulting webhook is echo-skipped.
+    expect(row.last_synced_etag).toBe('"new-etag"');
+    expect(row.last_app_write_nonce).toBeTruthy();
+    expect(row.last_app_write_nonce).not.toBe("nonce-abc");
+  });
+
+  it("does not churn an already-confirmed reservation once the owner is uninvited (#337)", async () => {
+    const db = makeDb();
+    // Confirmed + owner already removed as attendee; last known RSVP was accepted.
+    seedWithEvent(db, { status: "confirmed", last_known_response_status: "accepted" });
+    const events: CalendarEvent[] = [
+      {
+        id: "evt-123",
+        etag: '"different-etag"',
+        start: { date: "2026-06-01" },
+        end: { date: "2026-06-04" },
+        attendees: [], // owner no longer an attendee -> would read as needsAction
+        extendedProperties: { private: { appWriteNonce: "other-nonce" } },
+      },
+    ];
+    await processCalendarDelta(db, fakeClient, calendarId, events);
+
+    expect(calMock.updateEvent).not.toHaveBeenCalled();
+    const row = db
+      .prepare(
+        "SELECT status, last_known_response_status FROM reservations WHERE google_event_id = 'evt-123'"
+      )
+      .get() as { status: string; last_known_response_status: string };
+    expect(row.status).toBe("confirmed");
+    expect(row.last_known_response_status).toBe("accepted");
+  });
+
   it("treats cancelled event (owner deleted invite) as declined", async () => {
     const db = makeDb();
     seedWithEvent(db);

--- a/lib/google-calendar.ts
+++ b/lib/google-calendar.ts
@@ -36,16 +36,22 @@ interface ReservationShape {
   person_name?: string | null;
 }
 
-function buildEventBody(r: ReservationShape, nonce: string, ownerEmail?: string): object {
+export function buildEventBody(r: ReservationShape, nonce: string, ownerEmail?: string): object {
   const calStatus =
     r.status === "confirmed" ? "confirmed" : r.status === "rejected" ? "cancelled" : "tentative";
+  // While a reservation is pending, the owner is invited as an attendee so they
+  // can accept/decline from their own calendar. Once confirmed, the decision is
+  // made — drop the owner attendee so the event leaves their personal calendar
+  // and stops showing "1 guest, awaiting reply" (#337). An empty array (not
+  // undefined) is required for events.update to actually clear an attendee.
+  const attendees = ownerEmail && calStatus !== "confirmed" ? [{ email: ownerEmail }] : [];
   return {
     summary: r.car_short ? `[${r.car_short}] ${r.person_name ?? ""}` : "Reservering",
     description: r.note ?? undefined,
     start: { date: r.start_date },
     end: { date: addDays(r.end_date, 1) },
     status: calStatus,
-    attendees: ownerEmail ? [{ email: ownerEmail }] : undefined,
+    attendees,
     extendedProperties: { private: { appWriteNonce: nonce } },
   };
 }

--- a/lib/process-calendar-delta.ts
+++ b/lib/process-calendar-delta.ts
@@ -140,26 +140,88 @@ export async function processCalendarDelta(
       newResponseStatus = attendee?.responseStatus ?? "needsAction";
     }
 
-    if (newResponseStatus !== row.last_known_response_status) {
-      let newStatus: string | null = null;
-      if (newResponseStatus === "accepted") newStatus = "confirmed";
-      else if (newResponseStatus === "declined") newStatus = "rejected";
+    // After an in-app or GCal confirm we remove the owner attendee (below /
+    // buildEventBody), so later deltas legitimately report needsAction. Don't let
+    // that churn or revert an already-confirmed reservation.
+    if (newResponseStatus === "needsAction" && row.status === "confirmed") continue;
 
-      db.prepare(
-        "UPDATE reservations SET status=COALESCE(?, status), last_known_response_status=?, last_synced_etag=? WHERE id=?"
-      ).run(newStatus, newResponseStatus, event.etag ?? null, row.id);
-      logSync(db, {
-        direction: "inbound",
-        action: "rsvp",
-        reservationId: row.id,
-        googleEventId: event.id,
-        detail: {
-          from: row.last_known_response_status,
-          to: newResponseStatus,
-          newStatus,
-          eventStatus: event.status,
-        },
-      });
+    if (newResponseStatus !== row.last_known_response_status) {
+      if (newResponseStatus === "accepted") {
+        // Owner accepted the invite in Google Calendar. Converge to the same
+        // end-state as an in-app confirm: mark the event confirmed AND remove the
+        // owner attendee (buildEventBody drops it when status=confirmed). This is
+        // an app write — it stamps a fresh nonce/etag, so the webhook it triggers
+        // is skipped by the echo guard above. No loop. (#337)
+        const nonce = crypto.randomUUID();
+        let newEtag: string | null = event.etag ?? null;
+        try {
+          const res = await updateEvent(
+            client,
+            calendarId,
+            event.id,
+            {
+              start_date: row.start_date,
+              end_date: row.end_date,
+              note: row.note,
+              status: "confirmed",
+              car_short: row.car_short,
+              person_name: row.person_name,
+            },
+            nonce,
+            row.owner_email ?? undefined
+          );
+          newEtag = res.etag;
+          logSync(db, {
+            direction: "outbound",
+            action: "confirm",
+            reservationId: row.id,
+            googleEventId: event.id,
+            detail: { nonce, uninvited: row.owner_email ?? null },
+          });
+        } catch (e) {
+          console.error("[calendar-delta] confirm push failed", e);
+          logSync(db, {
+            direction: "outbound",
+            action: "confirm",
+            reservationId: row.id,
+            googleEventId: event.id,
+            ok: false,
+            detail: { message: e instanceof Error ? e.message : String(e) },
+          });
+        }
+        db.prepare(
+          "UPDATE reservations SET status='confirmed', last_known_response_status='accepted', last_synced_etag=?, last_app_write_nonce=? WHERE id=?"
+        ).run(newEtag, nonce, row.id);
+        logSync(db, {
+          direction: "inbound",
+          action: "rsvp",
+          reservationId: row.id,
+          googleEventId: event.id,
+          detail: {
+            from: row.last_known_response_status,
+            to: "accepted",
+            newStatus: "confirmed",
+            eventStatus: event.status,
+          },
+        });
+      } else {
+        const newStatus: string | null = newResponseStatus === "declined" ? "rejected" : null;
+        db.prepare(
+          "UPDATE reservations SET status=COALESCE(?, status), last_known_response_status=?, last_synced_etag=? WHERE id=?"
+        ).run(newStatus, newResponseStatus, event.etag ?? null, row.id);
+        logSync(db, {
+          direction: "inbound",
+          action: "rsvp",
+          reservationId: row.id,
+          googleEventId: event.id,
+          detail: {
+            from: row.last_known_response_status,
+            to: newResponseStatus,
+            newStatus,
+            eventStatus: event.status,
+          },
+        });
+      }
     }
   }
 }


### PR DESCRIPTION
Closes #337.

## Problem
Two halves of the same bug:
1. **In-app confirm → GCal:** confirming a reservation in the app couldn't clear Google Calendar's "1 guest, awaiting reply". The organizer/service-account **cannot set an attendee's `responseStatus`** via the API — only the attendee can RSVP.
2. **GCal accept → app:** when the owner accepted the invite in Google Calendar, the reservation flipped to `confirmed` in-app, but the calendar event itself was never marked confirmed.

## Fix — one converged end-state
Whichever way it's confirmed, the calendar lands the same: **event confirmed + owner removed as attendee** (so it also leaves the owner's personal calendar, and the "awaiting reply" disappears).

- **`buildEventBody`**: drop the owner attendee when `status=confirmed` (empty array, required for `events.update` to actually clear an attendee). The in-app confirm path (`status route → syncReservationUpdate → updateEvent`) now uninvites automatically — no separate code path needed.
- **`process-calendar-delta`**: when the owner accepts in GCal, push a confirmed-event update (uninvite) **in addition** to flipping the DB to `confirmed`. The push stamps a fresh nonce/etag → the webhook it triggers is **echo-skipped** → no loop. Plus a guard: `needsAction` on an already-confirmed reservation is a no-op (prevents churn once the owner is uninvited).

## Loop safety
```
owner accepts in GCal → webhook → delta (not echo)
  → push confirmed + uninvite  [stamps nonce N / etag E]
    → webhook for our own write → delta sees etag E == last_synced_etag → echo-skip → stop
```

## Tests
- `google_calendar_build_event.test.ts` (new): attendee rule — pending invites owner, confirmed drops them.
- `process_calendar_delta.test.ts`: confirm-push + uninvite on accept; no-churn guard.
- Full suite green (849).

Depends on #339 (webhook unblock) and #338 (sync log) — both merged. Best verified on prod with the sync log open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)