### PR TITLE
fix(calendar): visually mark confirmed events (✓ title + green) (#344)

### DIFF
--- a/lib/__tests__/google_calendar_build_event.test.ts
+++ b/lib/__tests__/google_calendar_build_event.test.ts
@@ -19,7 +19,13 @@ const base = {
   note: null,
 };
 
-type Body = { status: string; attendees: Array<{ email: string }>; end: { date: string } };
+type Body = {
+  status: string;
+  attendees: Array<{ email: string }>;
+  end: { date: string };
+  summary: string;
+  colorId?: string;
+};
 
 describe("buildEventBody attendee rule (#337)", () => {
   it("invites the owner as attendee while pending (tentative)", () => {
@@ -32,6 +38,18 @@ describe("buildEventBody attendee rule (#337)", () => {
     const body = buildEventBody({ ...base, status: "confirmed" }, "n1", "bob@example.com") as Body;
     expect(body.status).toBe("confirmed");
     expect(body.attendees).toEqual([]);
+  });
+
+  it("marks a confirmed event with a ✓ title prefix and green colorId (#344)", () => {
+    const body = buildEventBody({ ...base, status: "confirmed" }, "n1", "bob@example.com") as Body;
+    expect(body.summary).toBe("✓ [CA] Alice");
+    expect(body.colorId).toBe("10");
+  });
+
+  it("leaves a pending event's title and color at default (#344)", () => {
+    const body = buildEventBody({ ...base, status: "pending" }, "n1", "bob@example.com") as Body;
+    expect(body.summary).toBe("[CA] Alice");
+    expect(body.colorId).toBeUndefined();
   });
 
   it("marks a rejected reservation as a cancelled event (attendee moot)", () => {

--- a/lib/google-calendar.ts
+++ b/lib/google-calendar.ts
@@ -45,12 +45,18 @@ export function buildEventBody(r: ReservationShape, nonce: string, ownerEmail?: 
   // and stops showing "1 guest, awaiting reply" (#337). An empty array (not
   // undefined) is required for events.update to actually clear an attendee.
   const attendees = ownerEmail && calStatus !== "confirmed" ? [{ email: ownerEmail }] : [];
+  const confirmed = calStatus === "confirmed";
+  // Google has no checkmark UI for status=confirmed, so confirmed and tentative
+  // all-day events look identical. Add an explicit visual cue (#344): a ✓ title
+  // prefix and a green colorId (10 = Basil). Pending/rejected keep the default.
+  const baseSummary = r.car_short ? `[${r.car_short}] ${r.person_name ?? ""}` : "Reservering";
   return {
-    summary: r.car_short ? `[${r.car_short}] ${r.person_name ?? ""}` : "Reservering",
+    summary: confirmed ? `✓ ${baseSummary}` : baseSummary,
     description: r.note ?? undefined,
     start: { date: r.start_date },
     end: { date: addDays(r.end_date, 1) },
     status: calStatus,
+    colorId: confirmed ? "10" : undefined,
     attendees,
     extendedProperties: { private: { appWriteNonce: nonce } },
   };


### PR DESCRIPTION
Closes #344. Follow-up to #337.

Google Calendar has no checkmark UI for `status: confirmed`, so confirmed and tentative all-day events look identical. Add an explicit visual cue in `buildEventBody`:
- **Title:** `✓ ` prefix on confirmed events (`✓ [JF] Roeland De Meester`).
- **Color:** green `colorId: "10"` (Basil) when confirmed; default otherwise.

Pending/rejected unchanged. Idempotent — re-applied on every sync.

Tests: confirmed → ✓ title + colorId 10; pending → default title, no colorId.

🤖 Generated with [Claude Code](https://claude.com/claude-code)