### PR TITLE
fix(calendar): backfill reconciles existing events, not only missing (#347)

### DIFF
--- a/app/api/admin/calendar-backfill/route.test.ts
+++ b/app/api/admin/calendar-backfill/route.test.ts
@@ -28,8 +28,10 @@ vi.mock("@/lib/queries/settings", () => ({
 }));
 
 const mockSyncReservationCreate = vi.fn<(...a: unknown[]) => Promise<void>>();
+const mockSyncReservationUpdate = vi.fn<(...a: unknown[]) => Promise<void>>();
 vi.mock("@/lib/reservation-sync", () => ({
   syncReservationCreate: (...a: unknown[]) => mockSyncReservationCreate(...a),
+  syncReservationUpdate: (...a: unknown[]) => mockSyncReservationUpdate(...a),
 }));
 
 import { POST } from "./route";
@@ -59,6 +61,7 @@ beforeEach(() => {
   });
   mockPrepare.mockReturnValue({ all: vi.fn(() => []) });
   mockSyncReservationCreate.mockResolvedValue(undefined);
+  mockSyncReservationUpdate.mockResolvedValue(undefined);
 });
 
 describe("POST /api/admin/calendar-backfill", () => {
@@ -92,34 +95,62 @@ describe("POST /api/admin/calendar-backfill", () => {
     expect(body).toMatchObject({ ok: false, error: "no_token" });
   });
 
-  it("returns ok with synced=0 when no unsynced reservations", async () => {
+  it("returns ok with synced=0 when no upcoming reservations", async () => {
     const res = await POST(req());
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body).toEqual({ ok: true, synced: 0, failed: 0, total: 0 });
+    expect(body).toEqual({ ok: true, synced: 0, created: 0, updated: 0, failed: 0, total: 0 });
     expect(mockSyncReservationCreate).not.toHaveBeenCalled();
+    expect(mockSyncReservationUpdate).not.toHaveBeenCalled();
   });
 
-  it("syncs all unsynced upcoming reservations and reports count", async () => {
-    mockPrepare.mockReturnValue({ all: vi.fn(() => [{ id: 1 }, { id: 2 }, { id: 3 }]) });
+  it("creates events for unsynced upcoming reservations and reports count", async () => {
+    mockPrepare.mockReturnValue({
+      all: vi.fn(() => [
+        { id: 1, google_event_id: null },
+        { id: 2, google_event_id: null },
+        { id: 3, google_event_id: null },
+      ]),
+    });
     const res = await POST(req());
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body).toEqual({ ok: true, synced: 3, failed: 0, total: 3 });
+    expect(body).toEqual({ ok: true, synced: 3, created: 3, updated: 0, failed: 0, total: 3 });
     expect(mockSyncReservationCreate).toHaveBeenCalledTimes(3);
-    expect(mockSyncReservationCreate).toHaveBeenCalledWith(mockDb, 1);
-    expect(mockSyncReservationCreate).toHaveBeenCalledWith(mockDb, 2);
-    expect(mockSyncReservationCreate).toHaveBeenCalledWith(mockDb, 3);
+    expect(mockSyncReservationUpdate).not.toHaveBeenCalled();
   });
 
-  it("counts failed reservations when syncReservationCreate throws", async () => {
-    mockPrepare.mockReturnValue({ all: vi.fn(() => [{ id: 10 }, { id: 11 }]) });
-    mockSyncReservationCreate
-      .mockResolvedValueOnce(undefined)
-      .mockRejectedValueOnce(new Error("Google API error"));
+  it("re-pushes already-synced reservations via update (reconcile)", async () => {
+    mockPrepare.mockReturnValue({
+      all: vi.fn(() => [
+        { id: 1, google_event_id: null },
+        { id: 2, google_event_id: "evt-2" },
+        { id: 3, google_event_id: "evt-3" },
+      ]),
+    });
     const res = await POST(req());
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body).toEqual({ ok: true, synced: 1, failed: 1, total: 2 });
+    expect(body).toEqual({ ok: true, synced: 3, created: 1, updated: 2, failed: 0, total: 3 });
+    expect(mockSyncReservationCreate).toHaveBeenCalledTimes(1);
+    expect(mockSyncReservationCreate).toHaveBeenCalledWith(mockDb, 1);
+    expect(mockSyncReservationUpdate).toHaveBeenCalledTimes(2);
+    expect(mockSyncReservationUpdate).toHaveBeenCalledWith(mockDb, 2);
+    expect(mockSyncReservationUpdate).toHaveBeenCalledWith(mockDb, 3);
+  });
+
+  it("counts failed reservations when a sync call throws", async () => {
+    mockPrepare.mockReturnValue({
+      all: vi.fn(() => [
+        { id: 10, google_event_id: null },
+        { id: 11, google_event_id: "evt-11" },
+      ]),
+    });
+    mockSyncReservationCreate.mockResolvedValueOnce(undefined);
+    mockSyncReservationUpdate.mockRejectedValueOnce(new Error("Google API error"));
+    const res = await POST(req());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true, synced: 1, created: 1, updated: 0, failed: 1, total: 2 });
   });
 });

--- a/app/api/admin/calendar-backfill/route.ts
+++ b/app/api/admin/calendar-backfill/route.ts
@@ -3,7 +3,7 @@ import { getDb } from "@/lib/db";
 import { json, requireAdmin } from "@/lib/api";
 import { getSetting } from "@/lib/queries/settings";
 import { env } from "@/lib/env";
-import { syncReservationCreate } from "@/lib/reservation-sync";
+import { syncReservationCreate, syncReservationUpdate } from "@/lib/reservation-sync";
 
 export const POST = json(async (req) => {
   await requireAdmin(req);
@@ -20,25 +20,42 @@ export const POST = json(async (req) => {
 
   const today = new Date().toISOString().slice(0, 10);
 
-  // Upcoming reservations not yet synced
+  // Reconcile every upcoming non-rejected reservation: create a calendar event
+  // for ones not yet synced, and re-push the desired state for ones that already
+  // have an event (repaints title/color/attendees/status, e.g. the ✓+green
+  // confirmed marker, and repairs any drift). Updates are nonce-stamped, so the
+  // resulting webhook is skipped by the echo guard — no loop.
   const rows = db
     .prepare(
-      `SELECT id FROM reservations
-       WHERE end_date >= ? AND google_event_id IS NULL AND status != 'rejected'
+      `SELECT id, google_event_id FROM reservations
+       WHERE end_date >= ? AND status != 'rejected'
        ORDER BY start_date`
     )
-    .all(today) as { id: number }[];
+    .all(today) as { id: number; google_event_id: string | null }[];
 
-  let synced = 0;
+  let created = 0;
+  let updated = 0;
   let failed = 0;
   for (const row of rows) {
     try {
-      await syncReservationCreate(db, row.id);
-      synced++;
+      if (row.google_event_id) {
+        await syncReservationUpdate(db, row.id);
+        updated++;
+      } else {
+        await syncReservationCreate(db, row.id);
+        created++;
+      }
     } catch {
       failed++;
     }
   }
 
-  return NextResponse.json({ ok: true, synced, failed, total: rows.length });
+  return NextResponse.json({
+    ok: true,
+    synced: created + updated,
+    created,
+    updated,
+    failed,
+    total: rows.length,
+  });
 });


### PR DESCRIPTION
Closes #347. Follow-up to #344.

Backfill ("Sync upcoming reservations") only created events where `google_event_id IS NULL`, so already-synced reservations were skipped — after #344 it reported `0/0` and couldn't apply the ✓+green marker to existing confirmed events.

Now a full reconcile over all upcoming non-rejected reservations:
- unsynced → `syncReservationCreate`
- already synced → `syncReservationUpdate` (re-push title/color/attendees/status; nonce-stamped → webhook echo-skipped, no loop)

Response reports `{ created, updated, synced, failed, total }` (keeps `synced`/`total` for the UI).

Tests: create branch, update branch (reconcile), and failure counting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)