### PR TITLE
fix(calendar): converge reject to GCal + poll reservations for webhook changes (#350)

### DIFF
--- a/app/admin/_shared.tsx
+++ b/app/admin/_shared.tsx
@@ -132,6 +132,11 @@ export function useReservations() {
       if (!res.ok) throw new Error("Failed");
       return res.json();
     },
+    // Reservation status can change from outside the app (Google Calendar
+    // accept/decline/cancel → webhook → DB) with no server→client push. Poll so
+    // those changes surface in an open session (inbox, calendar). Background
+    // polling stays off while the tab is hidden. (#350)
+    refetchInterval: 30000,
   });
 }
 

--- a/lib/__tests__/process_calendar_delta.test.ts
+++ b/lib/__tests__/process_calendar_delta.test.ts
@@ -137,7 +137,7 @@ describe("processCalendarDelta", () => {
     expect(row.last_known_response_status).toBe("accepted");
   });
 
-  it("updates reservation to rejected when owner declines", async () => {
+  it("rejects and cancels the live event when owner declines (#350 converge)", async () => {
     const db = makeDb();
     seedWithEvent(db);
     const events: CalendarEvent[] = [
@@ -151,10 +151,26 @@ describe("processCalendarDelta", () => {
       },
     ];
     await processCalendarDelta(db, fakeClient, calendarId, events);
+
+    // Converge: event still live → push a cancel so it doesn't linger as a ghost.
+    expect(calMock.updateEvent).toHaveBeenCalledOnce();
+    const args = (calMock.updateEvent as unknown as { mock: { calls: unknown[][] } }).mock.calls[0];
+    expect((args[3] as { status: string }).status).toBe("rejected"); // -> cancelled event
     const row = db
-      .prepare("SELECT status FROM reservations WHERE google_event_id = 'evt-123'")
-      .get() as { status: string };
+      .prepare(
+        "SELECT status, last_known_response_status, last_synced_etag, last_app_write_nonce FROM reservations WHERE google_event_id = 'evt-123'"
+      )
+      .get() as {
+      status: string;
+      last_known_response_status: string;
+      last_synced_etag: string;
+      last_app_write_nonce: string;
+    };
     expect(row.status).toBe("rejected");
+    expect(row.last_known_response_status).toBe("declined");
+    // nonce/etag from our own cancel push → resulting webhook is echo-skipped
+    expect(row.last_synced_etag).toBe('"new-etag"');
+    expect(row.last_app_write_nonce).not.toBe("nonce-abc");
   });
 
   it("pushes a confirmed event and uninvites the owner when the owner accepts (#337)", async () => {
@@ -223,7 +239,7 @@ describe("processCalendarDelta", () => {
     expect(row.last_known_response_status).toBe("accepted");
   });
 
-  it("treats cancelled event (owner deleted invite) as declined", async () => {
+  it("treats an already-cancelled event as declined without re-pushing (#350)", async () => {
     const db = makeDb();
     seedWithEvent(db);
     const events: CalendarEvent[] = [
@@ -237,6 +253,8 @@ describe("processCalendarDelta", () => {
       },
     ];
     await processCalendarDelta(db, fakeClient, calendarId, events);
+    // Event already gone (owner deleted the shared event, #8) → nothing to push.
+    expect(calMock.updateEvent).not.toHaveBeenCalled();
     const row = db
       .prepare("SELECT status FROM reservations WHERE google_event_id = 'evt-123'")
       .get() as { status: string };

--- a/lib/process-calendar-delta.ts
+++ b/lib/process-calendar-delta.ts
@@ -204,11 +204,71 @@ export async function processCalendarDelta(
             eventStatus: event.status,
           },
         });
-      } else {
-        const newStatus: string | null = newResponseStatus === "declined" ? "rejected" : null;
+      } else if (newResponseStatus === "declined") {
+        // Owner declined the invite, or removed it from their own calendar. Flip to
+        // rejected AND converge the calendar: if the shared event is still live,
+        // cancel it so it doesn't linger as a ghost (#350 / #7 / #8bis). If the
+        // event is already cancelled (owner deleted the shared event, #8), there is
+        // nothing to push. The push is nonce-stamped → echo-skipped, no loop.
+        const nonce = crypto.randomUUID();
+        let newEtag: string | null = event.etag ?? null;
+        if (event.status !== "cancelled") {
+          try {
+            const res = await updateEvent(
+              client,
+              calendarId,
+              event.id,
+              {
+                start_date: row.start_date,
+                end_date: row.end_date,
+                note: row.note,
+                status: "rejected",
+                car_short: row.car_short,
+                person_name: row.person_name,
+              },
+              nonce,
+              row.owner_email ?? undefined
+            );
+            newEtag = res.etag;
+            logSync(db, {
+              direction: "outbound",
+              action: "cancel",
+              reservationId: row.id,
+              googleEventId: event.id,
+              detail: { nonce, reason: "declined" },
+            });
+          } catch (e) {
+            console.error("[calendar-delta] cancel push failed", e);
+            logSync(db, {
+              direction: "outbound",
+              action: "cancel",
+              reservationId: row.id,
+              googleEventId: event.id,
+              ok: false,
+              detail: { message: e instanceof Error ? e.message : String(e) },
+            });
+          }
+        }
         db.prepare(
-          "UPDATE reservations SET status=COALESCE(?, status), last_known_response_status=?, last_synced_etag=? WHERE id=?"
-        ).run(newStatus, newResponseStatus, event.etag ?? null, row.id);
+          "UPDATE reservations SET status='rejected', last_known_response_status='declined', last_synced_etag=?, last_app_write_nonce=? WHERE id=?"
+        ).run(newEtag, nonce, row.id);
+        logSync(db, {
+          direction: "inbound",
+          action: "rsvp",
+          reservationId: row.id,
+          googleEventId: event.id,
+          detail: {
+            from: row.last_known_response_status,
+            to: "declined",
+            newStatus: "rejected",
+            eventStatus: event.status,
+          },
+        });
+      } else {
+        // Other transitions (e.g. needsAction) — record the RSVP, leave status.
+        db.prepare(
+          "UPDATE reservations SET last_known_response_status=?, last_synced_etag=? WHERE id=?"
+        ).run(newResponseStatus, event.etag ?? null, row.id);
         logSync(db, {
           direction: "inbound",
           action: "rsvp",
@@ -217,7 +277,7 @@ export async function processCalendarDelta(
           detail: {
             from: row.last_known_response_status,
             to: newResponseStatus,
-            newStatus,
+            newStatus: null,
             eventStatus: event.status,
           },
         });


### PR DESCRIPTION
Closes #350. Follow-up from live-testing the cancel/delete matrix.

## B — Reject converges to the calendar (no ghost events)
When a GCal action flips a reservation to `rejected` via the **declined** path (owner declines, or deletes the invite from their own calendar — #7 / #8bis), `process-calendar-delta` now pushes `status=cancelled` to the shared event **if it's still live**, so it doesn't linger. If the event is already `cancelled` (owner deleted the shared event, #8), it skips the push. Nonce-stamped → echo-skipped (no loop). Mirrors accept→confirm (#337); symmetric with app-reject (#4).

## A — Live-refresh on webhook-driven changes
Google accept/decline/cancel updates the DB via webhook with no server→client push, so an open session kept showing stale cards. Added `refetchInterval: 30s` to the reservations query (background polling off when tab hidden; `refetchOnWindowFocus` already default-on) so those changes surface in the inbox/calendar.

## Tests
- declined + live event → cancel pushed + rejected (converge)
- already-cancelled event → rejected, **no** push
- full suite green (852)

🤖 Generated with [Claude Code](https://claude.com/claude-code)