### PR TITLE
fix(reservations): editing re-opens for approval; clear stale GCal RSVP (#2)

### DIFF
--- a/app/calendar/reservation-form.tsx
+++ b/app/calendar/reservation-form.tsx
@@ -91,6 +91,12 @@ export function ReservationForm({ defaultValues, onSubmit, onCancel, readOnly = 
   const isAdmin = me?.isAdmin ?? false;
   const today = new Date().toISOString().slice(0, 10);
 
+  // Editing a decided reservation re-opens it for approval (→ pending): the
+  // calendar event reverts to tentative and the owner is re-invited. Warn so the
+  // revert isn't a surprise. (#2)
+  const reopensForApproval =
+    Boolean(defaultValues?.id) && (defaultValues?.status ?? "pending") !== "pending";
+
   const { register, handleSubmit, control, setValue, getValues } = useForm<
     FormInput,
     unknown,
@@ -325,6 +331,23 @@ export function ReservationForm({ defaultValues, onSubmit, onCancel, readOnly = 
             }}
           >
             🔒 {t("form.read_only_hint")}
+          </div>
+        )}
+        {!readOnly && reopensForApproval && (
+          <div
+            style={{
+              padding: "8px 14px",
+              fontFamily: fontMono,
+              fontSize: 9,
+              fontWeight: 700,
+              letterSpacing: 1,
+              color: paper.amber,
+              borderBottom: mono
+                ? `1px solid ${paper.paperDark}`
+                : `1.5px dashed ${paper.paperDark}`,
+            }}
+          >
+            ⚠ {t("form.edit_reopens_hint")}
           </div>
         )}
 

--- a/lib/__tests__/queries_reservations.test.ts
+++ b/lib/__tests__/queries_reservations.test.ts
@@ -198,6 +198,38 @@ describe("updateReservation", () => {
     expect(res?.note).toBe("Updated note");
   });
 
+  it("resets a confirmed reservation to pending when edited without a status (#2)", () => {
+    // The reservation edit form submits car/date/driver/note but no status, so
+    // editing any reservation re-opens it for approval: a confirmed booking
+    // reverts to pending (→ event becomes tentative + owner re-invited).
+    const db = makeDb();
+    seed(db);
+    const id = insertReservation(db, {
+      person_id: 1,
+      car_id: 1,
+      start_date: "2026-06-01",
+      end_date: "2026-06-03",
+      status: "confirmed",
+    });
+    // Simulate a prior GCal accept that confirmed it.
+    db.prepare("UPDATE reservations SET last_known_response_status='accepted' WHERE id=?").run(id);
+    expect(getReservationById(db, id)?.status).toBe("confirmed");
+
+    updateReservation(db, id, {
+      person_id: 1,
+      car_id: 1,
+      start_date: "2026-06-05",
+      end_date: "2026-06-07",
+      // no status field — mirrors the edit form payload
+    });
+    const after = db
+      .prepare("SELECT status, last_known_response_status FROM reservations WHERE id=?")
+      .get(id) as { status: string; last_known_response_status: string | null };
+    expect(after.status).toBe("pending");
+    // Stale RSVP cleared so a re-accept in GCal is detected again.
+    expect(after.last_known_response_status).toBeNull();
+  });
+
   it("with expectedUpdatedAt: succeeds when timestamp matches", () => {
     const db = makeDb();
     seed(db);

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -129,6 +129,7 @@ export const en: Messages = {
   "form.driver_locked_hint": "Your name — only admins can log on behalf of others",
   "form.read_only": "Read-only",
   "form.read_only_hint": "Read-only — you cannot edit this",
+  "form.edit_reopens_hint": "Editing re-opens this for approval — it goes back to pending and the owner is re-invited.",
   "form.pick_dates_first": "Pick a period first",
   "form.fill_required": "Fill in required fields",
   "field.car": "car",

--- a/lib/i18n/messages/nl.ts
+++ b/lib/i18n/messages/nl.ts
@@ -128,6 +128,7 @@ export const nl = {
   "form.driver_locked_hint": "Jouw naam — enkel admins kunnen voor anderen loggen",
   "form.read_only": "Alleen-lezen",
   "form.read_only_hint": "Alleen-lezen — je kan dit niet bewerken",
+  "form.edit_reopens_hint": "Bewerken heropent de aanvraag — ze gaat terug naar 'in afwachting' en de eigenaar wordt opnieuw uitgenodigd.",
   "form.pick_dates_first": "Kies eerst een periode",
   "form.fill_required": "Vul verplichte velden in",
   "field.car": "wagen",

--- a/lib/queries/reservations.ts
+++ b/lib/queries/reservations.ts
@@ -77,17 +77,18 @@ export function updateReservation(
       throw new ConflictError("Reservation was modified after this offline edit");
     }
   }
+  const status = input.status ?? "pending";
   db.prepare(
     "UPDATE reservations SET person_id=?,car_id=?,start_date=?,end_date=?,status=?,note=? WHERE id=?"
-  ).run(
-    input.person_id,
-    input.car_id,
-    input.start_date,
-    input.end_date,
-    input.status ?? "pending",
-    input.note ?? null,
-    id
-  );
+  ).run(input.person_id, input.car_id, input.start_date, input.end_date, status, input.note ?? null, id);
+
+  // Editing re-opens a reservation for approval (status → pending). Clear any
+  // stale Google Calendar RSVP so a fresh owner accept/decline on the re-issued
+  // invite is detected again (otherwise "accepted" would still equal the last
+  // known value and the re-accept would be ignored). (#2)
+  if (status === "pending") {
+    db.prepare("UPDATE reservations SET last_known_response_status=NULL WHERE id=?").run(id);
+  }
 }
 
 export function updateReservationStatus(db: Database.Database, id: number, status: string): void {


### PR DESCRIPTION
Implements calendar-matrix **#2** with the simple "edit → pending" model (instead of a field-level edit ACL — that's deferred, see #353).

## Behavior
Editing any reservation re-opens it for approval: the edit form submits no status, so `updateReservation` resets status to **pending**. A confirmed booking that's edited → pending → the calendar event reverts to **tentative** and the owner is **re-invited** (`syncReservationUpdate` already runs in the PUT route). To change a confirmed booking you just edit it (or delete + recreate).

## Fix (the real change)
When an edit reverts a reservation to pending, **clear `last_known_response_status`**. Without this, a booking confirmed via a Google Calendar *accept* kept `last_known='accepted'`; after revert-to-pending, the owner re-accepting the re-issued invite produced `accepted == accepted` → no delta change → it silently stayed pending. Clearing it makes the GCal re-accept path work again.

## UX
Warning banner on the edit form for a non-pending reservation: *"Editing re-opens this for approval — back to pending, owner re-invited."*

## Tests
- `updateReservation`: confirmed + edited (no status) → pending **and** `last_known_response_status` cleared.
- Full suite green (853).

## Note
The richer per-field edit ACL (lock car/date/driver after confirm, note-only edits, etc.) is intentionally **deferred** — tracked in #353.

🤖 Generated with [Claude Code](https://claude.com/claude-code)