### PR TITLE
chore(ci): bump GitHub Actions off deprecated Node 20 runner (#356)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
   quality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/checkout@v6.0.3
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,13 +20,13 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v6.0.3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -39,7 +39,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/demeesterroel/carsharing
           tags: |
@@ -50,7 +50,7 @@ jobs:
             type=raw,value=${{ inputs.version }},enable=${{ github.event_name == 'workflow_dispatch' && inputs.version != '' }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true


### PR DESCRIPTION
Closes #356.

GitHub forces the Node 24 actions runtime on **2026-06-16** (Node 20 removed 2026-09-16). Bumps the flagged actions to latest majors.

| Workflow | Action | From → To |
|---|---|---|
| ci.yml | actions/checkout | v4.2.2 → v6.0.3 |
| ci.yml | actions/setup-node | v4.4.0 → v6.4.0 |
| docker.yml | actions/checkout | v4.2.2 → v6.0.3 |
| docker.yml | docker/setup-buildx-action | v3 → v4 |
| docker.yml | docker/login-action | v3 → v4 |
| docker.yml | docker/metadata-action | v5 → v6 |
| docker.yml | docker/build-push-action | v5 → v7 |

**release-please-action stays at v4** — it wasn't in the deprecation warning, and v4→v5 is a major bump that risks the release pipeline; handle separately if needed.

## Validation
- This PR's `quality` run exercises the new **checkout v6 + setup-node v6**.
- Merging to main triggers `docker.yml` (push to main isn't a `chore(main): release` commit, so the build runs) → exercises the new **docker actions** end-to-end (build + push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)