### PR TITLE
test(e2e): make the suite deterministic (fixes #360)

### DIFF
--- a/e2e/a11y-audit.spec.ts
+++ b/e2e/a11y-audit.spec.ts
@@ -22,18 +22,33 @@ type AxeViolation = {
 };
 
 async function runAxe(page: Page): Promise<AxeViolation[]> {
-  await page.addScriptTag({ path: AXE_PATH });
-  await page.waitForFunction(() => typeof (window as any).axe !== "undefined");
-  return page.evaluate(async () => {
-    const results = await (window as any).axe.run();
-    return results.violations.map((v: any) => ({
-      id: v.id,
-      impact: v.impact,
-      description: v.description,
-      nodes: v.nodes.length,
-      selector: v.nodes[0]?.target?.join(" ") ?? "",
-    }));
-  });
+  // A late client-side navigation (hydration/redirect) can destroy the page's
+  // execution context just as axe is injected ("Execution context was destroyed,
+  // most likely because of a navigation"). Re-settle and retry once.
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      await page.addScriptTag({ path: AXE_PATH });
+      await page.waitForFunction(() => typeof (window as any).axe !== "undefined");
+      return await page.evaluate(async () => {
+        const results = await (window as any).axe.run();
+        return results.violations.map((v: any) => ({
+          id: v.id,
+          impact: v.impact,
+          description: v.description,
+          nodes: v.nodes.length,
+          selector: v.nodes[0]?.target?.join(" ") ?? "",
+        }));
+      });
+    } catch (e) {
+      if (attempt === 0 && /Execution context was destroyed/.test(String(e))) {
+        await page.waitForLoadState("networkidle");
+        continue;
+      }
+      throw e;
+    }
+  }
+  // Unreachable — the loop either returns or throws.
+  return [];
 }
 
 async function loginAs(

--- a/e2e/auth-recovery.spec.ts
+++ b/e2e/auth-recovery.spec.ts
@@ -14,14 +14,15 @@ const PASSWORD = process.env.TEST_PASSWORD ?? "alice";
  */
 
 test.describe("Account recovery", () => {
-  test("login page links to the forgot-password page", async ({ page }) => {
+  test("login page offers inline password recovery (mail enabled)", async ({ page }) => {
     await page.goto("/login");
-    const link = page.getByRole("link", { name: /forgot|vergeten/i });
-    await expect(link).toBeVisible();
-    await link.click();
-    await page.waitForURL(/\/forgot/);
-    // The email field is focused and present.
-    await expect(page.locator("#forgot-email")).toBeVisible();
+    // With a mail transport configured (the e2e default sets MAIL_WEBHOOK_URL),
+    // the login page shows an inline "forgot password" toggle *button* — not a
+    // link to /forgot. Clicking it reveals the reset-email field in place.
+    const resetToggle = page.getByRole("button", { name: /forgot|vergeten/i });
+    await expect(resetToggle).toBeVisible();
+    await resetToggle.click();
+    await expect(page.locator("#login-reset-email")).toBeVisible();
   });
 
   test("submitting the forgot form shows a neutral confirmation", async ({ page }) => {

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -16,6 +16,15 @@ import path from "path";
 import fs from "fs";
 
 export default async function globalSetup(): Promise<void> {
+  // Skip when reusing an already-seeded server (e.g. running specs one file at a
+  // time against a persistent prod server to exercise a randomized file order).
+  // Wiping data/e2e.db here would pull the rug out from under that server's open
+  // (cached) SQLite connection.
+  if (process.env.E2E_REUSE_DB === "1") {
+    console.log("[e2e globalSetup] E2E_REUSE_DB=1 — skipping reseed.");
+    return;
+  }
+
   const root = path.resolve(__dirname, "..");
   const e2eDb = path.join(root, "data", "e2e.db");
 

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -44,16 +44,19 @@ export async function loginAndGetSession(
   }
 
   const meRes = await request.get("/api/me");
-  const meBody = await meRes.json() as { personId?: number | null };
-  const cookies = await meRes.headersArray();
-  for (const h of cookies) {
-    if (h.name.toLowerCase() === "set-cookie") {
-      const m = h.value.match(/csrf-token=([^;]+)/);
-      if (m) return { csrf: decodeURIComponent(m[1]), personId: meBody.personId ?? null };
-    }
-  }
+  const meBody = (await meRes.json()) as { personId?: number | null };
 
-  throw new Error("csrf-token cookie not found after login + /api/me");
+  // Read the csrf-token from the context cookie jar, not the /api/me Set-Cookie
+  // header. /api/me only emits that header when the cookie is absent (#333 — it
+  // must not rotate the token mid-session), so a context that already has one
+  // (e.g. a second login as a different user within the same test) would
+  // otherwise spuriously fail with "csrf-token cookie not found".
+  const { cookies } = await request.storageState();
+  const csrf = cookies.find((c) => c.name === "csrf-token")?.value;
+  if (!csrf) {
+    throw new Error("csrf-token cookie not found after login + /api/me");
+  }
+  return { csrf, personId: meBody.personId ?? null };
 }
 
 /**

--- a/e2e/vehicles.spec.ts
+++ b/e2e/vehicles.spec.ts
@@ -13,24 +13,32 @@ import { loginAndGetSession, loginAndGetCsrf, makeApi, scrollToLoadAll } from ".
  * Uses unique "short" code (E2ET) to avoid collisions with demo data.
  */
 
-const CAR_SHORT = "E2ET";
-const CAR_NAME = "E2E-Test-Vehicle";
-const CAR_NAME_UPDATED = "E2E-Test-Vehicle-Updated";
 const PRICE_PER_KM = 0.25;
 
 test.describe("vehicles CRUD", () => {
   let csrf: string;
   let api: ReturnType<typeof makeApi>;
   let carId: number;
+  // Unique per test so a failed cleanup never collides on the UNIQUE cars.short
+  // constraint (short is capped at 10 chars). A car with reservations/trips also
+  // can't be hard-deleted, so unique values keep the tests independent regardless.
+  let carShort: string;
+  let carName: string;
+  let carNameUpdated: string;
 
   test.beforeEach(async ({ request }) => {
     const session = await loginAndGetSession(request, "admin", "admin");
     csrf = session.csrf;
     api = makeApi(request, csrf);
 
+    const suffix = `${Date.now() % 100000}`;
+    carShort = `E2E${suffix}`; // ≤ 8 chars, within the 10-char limit
+    carName = `E2E-Test-Vehicle-${suffix}`;
+    carNameUpdated = `${carName}-Updated`;
+
     const res = await api.post<{ id: number }>("/api/vehicles", {
-      short: CAR_SHORT,
-      name: CAR_NAME,
+      short: carShort,
+      name: carName,
       price_per_km: PRICE_PER_KM,
     });
     carId = res.id;
@@ -56,14 +64,14 @@ test.describe("vehicles CRUD", () => {
     await page.waitForLoadState("networkidle");
     await scrollToLoadAll(page);
 
-    await expect(page.locator(`text=${CAR_NAME}`).first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator(`text=${carName}`).first()).toBeVisible({ timeout: 10_000 });
   });
 
   test("vehicle name updates via PUT and change appears in list", async ({ page }) => {
     // Update via API
     await api.put<{ ok: boolean }>(`/api/vehicles/${carId}`, {
-      short: CAR_SHORT,
-      name: CAR_NAME_UPDATED,
+      short: carShort,
+      name: carNameUpdated,
       price_per_km: PRICE_PER_KM,
     });
 
@@ -75,8 +83,8 @@ test.describe("vehicles CRUD", () => {
     await page.waitForLoadState("networkidle");
     await scrollToLoadAll(page);
 
-    await expect(page.locator(`text=${CAR_NAME_UPDATED}`).first()).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByText(CAR_NAME, { exact: true })).toHaveCount(0);
+    await expect(page.locator(`text=${carNameUpdated}`).first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText(carName, { exact: true })).toHaveCount(0);
   });
 
   test("vehicle disappears from list after deletion", async ({ page }) => {
@@ -88,13 +96,13 @@ test.describe("vehicles CRUD", () => {
     await page.waitForLoadState("networkidle");
     await scrollToLoadAll(page);
 
-    await expect(page.locator(`text=${CAR_NAME}`).first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator(`text=${carName}`).first()).toBeVisible({ timeout: 10_000 });
 
     await api.delete(`/api/vehicles/${carId}`);
     carId = 0;
 
     await page.reload();
     await page.waitForLoadState("networkidle");
-    await expect(page.getByText(CAR_NAME, { exact: true })).toHaveCount(0);
+    await expect(page.getByText(carName, { exact: true })).toHaveCount(0);
   });
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -33,10 +33,16 @@ export default defineConfig({
   webServer: process.env.TEST_BASE_URL
     ? undefined
     : {
-        command: "npm run dev",
+        // Run e2e against a PRODUCTION build, not `next dev`. The dev server
+        // compiles routes on demand, and the first browser request to an
+        // uncompiled route can stall — which produced flaky `csrf-token cookie
+        // not found` and `toBeVisible` timeouts (issue #360). A prebuilt server
+        // has no on-demand compilation, so these disappear.
+        command: "npm run build && npm run start",
         url: "http://localhost:3000",
         reuseExistingServer: !process.env.CI,
-        timeout: 60_000,
+        // Building can take a couple of minutes on a cold cache.
+        timeout: 240_000,
         // Pin the env the suite depends on so it doesn't rely on a local
         // .env.local. Kept identical across the e2e branches so the file never
         // conflicts on merge:


### PR DESCRIPTION
Closes #360.

Pre-existing e2e failures were environmental/flaky, not regressions. This makes the suite deterministic — full suite now **68/68**, and green in two different randomized file orders (headed + headless).

## Changes
- **Run against a production build** (`npm run build && next start`) instead of `next dev`. Removes Next's on-demand route compilation, which stalled the first browser request to an uncompiled route (flaky csrf/timeout — fuel/trips).
- **csrf helper reads the cookie jar** (`request.storageState()`) instead of the `/api/me` Set-Cookie header. `/api/me` only sets that cookie when absent (#333), so a second login in one context threw "csrf-token cookie not found" — which also made `afterEach` cleanups silently skip, leaving rows that collided later (vehicles `UNIQUE cars.short`, duplicate expense).
- **auth-recovery** asserts the mail-enabled inline reset *button* (e2e runs with mail on) instead of a `/forgot` link.
- **vehicles** use a unique short/name per test (belt-and-suspenders on `cars.short`).
- **a11y runAxe** retries once when a late client navigation destroys the execution context mid-injection.
- **globalSetup** skips the e2e.db wipe when `E2E_REUSE_DB=1`, enabling file-by-file runs in randomized order against one persistent server (Playwright has no native shuffle).

## Verification
- e2e 68/68 against prod build; 68/68 in two randomized file orders (headed + headless).
- unit 871 · lint 0 errors · typecheck clean.

## Note
- `clock-timepicker` (added by #363) wasn't in local node_modules; `npm install` resolves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)