### PR TITLE
fix(auth): log revoked sessions out client-side (#284)

### DIFF
--- a/app/api/me/route.test.ts
+++ b/app/api/me/route.test.ts
@@ -143,6 +143,9 @@ describe("GET /api/me", () => {
     const body = await res.json();
     expect(body).toBeNull();
     expect(mockSession.destroy).toHaveBeenCalledOnce();
+    // The destroyed cookie must actually be persisted to the response, or the
+    // client keeps a "valid" cookie and the Edge proxy never logs it out (#284).
+    expect(mockSession.save).toHaveBeenCalledOnce();
   });
 
   it("returns identity when epoch matches", async () => {

--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -62,8 +62,12 @@ export async function GET(req: Request) {
   // cookie's epoch is stale, destroy it and report as logged out.
   if (session.epoch !== undefined && session.personId !== undefined) {
     if (getSessionEpoch(getDb(), session.personId) !== session.epoch) {
+      // Persist the destroy to the bound response (`out`) — returning a fresh
+      // NextResponse would drop the cleared-cookie header, leaving the client a
+      // "valid" cookie that the Edge proxy keeps treating as authenticated (#284).
       session.destroy();
-      return withCsrfCookie(req, NextResponse.json(null));
+      await session.save();
+      return withCsrfCookie(req, out);
     }
   }
 

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,8 +1,9 @@
 "use client";
-import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
+import { QueryClient, QueryClientProvider, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Toaster } from "sonner";
 import { toast } from "sonner";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
+import { usePathname, useRouter } from "next/navigation";
 import { OnlineStateProvider, useOnlineState } from "@/lib/offline/online-state";
 import { useBootPrewarm } from "@/lib/offline/prewarm";
 import { useSyncEngine } from "@/lib/offline/sync-engine";
@@ -10,6 +11,61 @@ import { useT } from "@/components/locale-provider";
 import { ThemeProvider, useTheme } from "@/lib/theme-context";
 import { useMe } from "@/hooks/use-me";
 import PullToRefresh from "@/components/pull-to-refresh";
+
+// Guest pages where an unauthenticated (null) session is expected; never bounce
+// away from these. Mirrors the GUEST/PUBLIC page prefixes in proxy.ts.
+const PUBLIC_PAGE_PREFIXES = ["/login", "/forgot", "/reset", "/invite"];
+function isPublicPage(pathname: string): boolean {
+  return PUBLIC_PAGE_PREFIXES.some((p) => pathname === p || pathname.startsWith(p + "/"));
+}
+
+/**
+ * App-wide reaction to server-side session revocation (issue #284).
+ *
+ * The Edge proxy gates page navigation on cookie fields only and can't see the
+ * DB session epoch, so a revoked-but-undestroyed cookie still loads pages. The
+ * API layer 403s ("Session revoked") and /api/me resolves to null. This guard
+ * turns either signal into a real logout: clear caches and redirect to /login.
+ */
+function SessionGuard() {
+  const { data: me, isFetched } = useMe();
+  const pathname = usePathname();
+  const router = useRouter();
+  const qc = useQueryClient();
+
+  const logout = useCallback(() => {
+    // Destroy the still-present cookie first. The Edge proxy gates on cookie
+    // fields only, so a revoked-but-undestroyed cookie still reads as
+    // "authenticated" and would bounce /login straight back to / — leaving the
+    // user stuck. /api/auth/logout clears the cookie (no CSRF required); only
+    // then does the redirect to /login stick.
+    void fetch("/api/auth/logout", { method: "POST" }).finally(() => {
+      qc.clear();
+      router.replace("/login");
+    });
+  }, [qc, router]);
+
+  // A revoked/expired session surfaces as a null /api/me (on load, navigation,
+  // mount, or window-focus refetch). Bounce to /login unless already on a guest
+  // page.
+  useEffect(() => {
+    if (isFetched && me === null && !isPublicPage(pathname)) {
+      logout();
+    }
+  }, [isFetched, me, pathname, logout]);
+
+  // An API 403 "Session revoked" mid-session (e.g. an admin revoke while the tab
+  // is open) logs out immediately, before /api/me is refetched.
+  useEffect(() => {
+    const handler = () => {
+      if (!isPublicPage(window.location.pathname)) logout();
+    };
+    window.addEventListener("session-revoked", handler);
+    return () => window.removeEventListener("session-revoked", handler);
+  }, [logout]);
+
+  return null;
+}
 
 function BootPrewarm() {
   // useMe is the auth signal. Read it here so prewarm gates on auth.
@@ -60,6 +116,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
       <OnlineStateProvider>
         <ThemeProvider>
           <BootPrewarm />
+          <SessionGuard />
           <ThemeSync />
           <ConflictListener />
           {/* No-op in a normal browser tab; active only when installed as a PWA. */}

--- a/e2e/session-revocation.spec.ts
+++ b/e2e/session-revocation.spec.ts
@@ -108,3 +108,56 @@ test.describe("Session revocation", () => {
     await ctx.dispose();
   });
 });
+
+/**
+ * Client-side guard for server-side revocation (issue #284).
+ *
+ * The data layer revokes correctly (a stale-epoch cookie 403s on every API
+ * call), but the SPA must also *react*: a revoked-but-undestroyed cookie still
+ * passes the Edge proxy's cookie-only auth gate, so page navigation succeeds and
+ * the user keeps seeing app shells instead of being bounced to /login.
+ *
+ * Repro: device A is a real browser session; device B (same user) triggers
+ * "log out everywhere", bumping the shared session epoch — which revokes A's
+ * still-present cookie without destroying it. A fresh navigation in A must end
+ * up on /login.
+ */
+test.describe("Session revocation — client guard (#284)", () => {
+  test("a browser whose cookie was revoked elsewhere is bounced to /login", async ({
+    browser,
+    playwright,
+  }) => {
+    // Device A — a real browser tab, logged in as the dedicated revoke user.
+    const ctxA = await browser.newContext({ baseURL });
+    const pageA = await ctxA.newPage();
+    const loginA = await pageA.request.post("/api/auth/login", {
+      data: { username: EMAIL, password: PASSWORD },
+    });
+    test.skip(!loginA.ok(), "Test account not available — needs seeded demo data");
+
+    await pageA.goto("/trips");
+    await pageA.waitForLoadState("networkidle");
+    // Sanity: device A is authenticated (not already sitting on /login).
+    expect(new URL(pageA.url()).pathname).not.toBe("/login");
+
+    // Device B — a second session for the same user that triggers "log out
+    // everywhere". This bumps the user's session epoch, revoking device A's
+    // still-present cookie while only destroying device B's own cookie.
+    const ctxB = await playwright.request.newContext({ baseURL });
+    await ctxB.post("/api/auth/login", { data: { username: EMAIL, password: PASSWORD } });
+    await ctxB.get("/api/me"); // primes csrf-token
+    const csrf = (await ctxB.storageState()).cookies.find((c) => c.name === "csrf-token")?.value;
+    const revokeStatus = await ctxB
+      .post("/api/auth/logout-all", { headers: csrf ? { "x-csrf-token": csrf } : {} })
+      .then((r) => r.status());
+    expect(revokeStatus).toBe(200);
+    await ctxB.dispose();
+
+    // Device A's cookie is now revoked-but-present. The SPA must bounce it to
+    // /login on the next navigation (today it stays on /trips — the bug).
+    await pageA.goto("/trips");
+    await pageA.waitForURL(/\/login/, { timeout: 15_000 });
+
+    await ctxA.close();
+  });
+});

--- a/hooks/use-me.ts
+++ b/hooks/use-me.ts
@@ -20,6 +20,11 @@ export function useMe() {
         if (err instanceof ApiError) return null;
         throw err;
       }),
-    staleTime: 5 * 60 * 1000,
+    // Short stale window + refetch on mount/focus so a server-side session
+    // revocation (#284) is noticed promptly — on the next navigation or when the
+    // user returns to the tab — and the SessionGuard can act on the null result.
+    staleTime: 30 * 1000,
+    refetchOnMount: true,
+    refetchOnWindowFocus: true,
   });
 }

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -43,6 +43,12 @@ export async function apiFetch<T>(path: string, options?: RequestInit): Promise<
 
   if (!res.ok) {
     const body = await res.json().catch(() => ({ error: res.statusText }));
+    // A revoked session (epoch bump from an admin revoke, deactivation, or
+    // "log out everywhere") 403s every API call. Broadcast it so the app-wide
+    // SessionGuard can bounce the user to /login immediately, mid-session.
+    if (res.status === 403 && body?.error === "Session revoked" && typeof window !== "undefined") {
+      window.dispatchEvent(new Event("session-revoked"));
+    }
     throw new ApiError(res.status, body.error ?? "Request failed");
   }
 


### PR DESCRIPTION
Closes #284.

Server-side revocation (epoch bump from admin revoke / deactivation / "log out everywhere") was enforced at the API layer but the SPA never reacted: the Edge proxy gates page navigation on cookie fields only (no DB access), so a revoked-but-undestroyed cookie kept loading app shells while every API call 403'd. The user was effectively stuck "logged in" with empty data.

## Changes
- **`SessionGuard`** (`app/providers.tsx`): when `/api/me` resolves to `null` on a protected route, or any API returns `403 "Session revoked"`, it POSTs `/api/auth/logout` to destroy the still-present cookie (otherwise the proxy bounces `/login` back to `/`), clears the query cache, and redirects to `/login`.
- **`apiFetch`** (`lib/api/client.ts`): dispatches a `session-revoked` window event on a `403 "Session revoked"` so revocation mid-session is caught immediately.
- **`useMe`** (`hooks/use-me.ts`): `staleTime` 30s + refetch on mount/focus, so revocation is noticed promptly on navigation or tab focus.
- **`/api/me`** (`app/api/me/route.ts`): the revoked-epoch branch now `await session.save()` and returns the bound response, so the destroyed cookie is actually cleared (it previously returned a fresh response and dropped the cleared-cookie header). Defense-in-depth so the proxy also stops treating the session as authenticated.

## Tests
- New e2e repro (`session-revocation.spec.ts`): device A (browser) is revoked by device B's logout-all → A's next navigation lands on `/login`. Reproduced against the prod build before fixing.
- Unit: `/api/me` epoch branch now asserts the cookie is persisted.
- Verified manually on a prod build.

## Verification
- e2e **69/69** (prod build) · unit **871** · lint 0 errors · typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)