### PR TITLE
fix(cloak): correct admin-area access for cloaked sessions (#179)

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,7 +1,7 @@
 "use client";
-import { Suspense } from "react";
+import { Suspense, useEffect } from "react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { PageHeader, TITLE_BAR_HEIGHT } from "@/components/page-header";
 import { paper, fontMono } from "@/lib/paper-theme";
 import { useT } from "@/components/locale-provider";
@@ -81,9 +81,25 @@ function SubNav() {
   );
 }
 
+// The /admin area is for admins and car owners only. Bounce everyone else to the
+// dashboard — including an admin cloaked as a plain member, whose useMe reflects
+// the cloaked (non-admin, non-owner) identity (#179). Page-level data APIs already
+// enforce this server-side; this stops the shells/chrome from rendering at all.
+function AdminAccessGuard() {
+  const { data: me, isFetched } = useMe();
+  const router = useRouter();
+  useEffect(() => {
+    if (isFetched && me && !me.isAdmin && !me.isOwner) {
+      router.replace("/");
+    }
+  }, [isFetched, me, router]);
+  return null;
+}
+
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
   return (
     <div style={{ background: paper.paperDeep, minHeight: "100dvh", paddingBottom: 80 }}>
+      <AdminAccessGuard />
       <Suspense>
         <SubNav />
       </Suspense>

--- a/app/api/auth/cloak/route.test.ts
+++ b/app/api/auth/cloak/route.test.ts
@@ -23,6 +23,7 @@ const mockGetPersonById = vi.fn();
 vi.mock("@/lib/queries/people", () => ({
   getPersonById: (...args: unknown[]) => mockGetPersonById(...args),
   shortNameOf: (p: { first_name?: string }) => p.first_name ?? "Person",
+  isOwner: () => true,
 }));
 
 function makeReq(body: unknown) {
@@ -47,7 +48,7 @@ describe("POST /api/auth/cloak", () => {
     const res = await POST(makeReq({ personId: 5 }));
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true });
-    expect(mockSession.cloakedAs).toMatchObject({ personId: 5, shortName: "Alice" });
+    expect(mockSession.cloakedAs).toMatchObject({ personId: 5, shortName: "Alice", isOwner: true });
     expect(mockSession.save).toHaveBeenCalledOnce();
   });
 

--- a/app/api/auth/cloak/route.ts
+++ b/app/api/auth/cloak/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { getIronSession } from "iron-session";
 import { sessionOptions, type SessionData } from "@/lib/session";
 import { getDb } from "@/lib/db";
-import { getPersonById, shortNameOf } from "@/lib/queries/people";
+import { getPersonById, shortNameOf, isOwner } from "@/lib/queries/people";
 
 export async function POST(req: Request) {
   const res = NextResponse.json({ ok: true });
@@ -33,6 +33,7 @@ export async function POST(req: Request) {
     personId: person.id,
     shortName: shortNameOf(person),
     isAdmin: person.is_admin === 1,
+    isOwner: isOwner(getDb(), person.id),
   };
   await session.save();
   return res;

--- a/e2e/cloak-owner-access.spec.ts
+++ b/e2e/cloak-owner-access.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from "@playwright/test";
+import { loginAndGetSession, makeApi } from "./helpers";
+
+const baseURL = process.env.TEST_BASE_URL ?? "http://localhost:3000";
+
+/**
+ * #179 — an admin cloaked as a car owner must keep the owner's access, including
+ * the owner vehicles page (/admin/vehicles, which is part of OWNER_PAGES).
+ *
+ * Repro: log in as admin, cloak as the seeded non-admin car owner ("owner"),
+ * then open /admin/vehicles. The Edge proxy currently blocks /admin/vehicles for
+ * any cloaked non-admin and bounces to /admin — even though the cloaked person
+ * is an owner who should see it.
+ */
+test.describe("cloak owner access (#179)", () => {
+  test("admin cloaked as a car owner can open the owner vehicles page", async ({ browser }) => {
+    const ctx = await browser.newContext({ baseURL });
+    const page = await ctx.newPage();
+
+    // Authenticate the browser context as admin and grab a csrf token.
+    const session = await loginAndGetSession(page.request, "admin", "admin");
+    const api = makeApi(page.request, session.csrf);
+
+    // The seeded "owner" account is a non-admin car owner — the exact case in #179.
+    const people = await api.get<Array<{ id: number; username: string | null; is_admin: number }>>(
+      "/api/people"
+    );
+    const owner = people.find((p) => p.username === "owner");
+    test.skip(!owner, "Seed has no 'owner' account — needs demo seed data");
+    expect(owner!.is_admin).toBe(0);
+
+    // Cloak as that owner (admin-only; makeApi attaches the csrf header).
+    await api.post("/api/auth/cloak", { personId: owner!.id });
+
+    // The owner vehicles page must be reachable while cloaked.
+    await page.goto("/admin/vehicles");
+    await page.waitForLoadState("networkidle");
+
+    // EXPECTED: still on /admin/vehicles. BUG today: the proxy bounces to /admin.
+    expect(new URL(page.url()).pathname).toBe("/admin/vehicles");
+
+    await ctx.close();
+  });
+});

--- a/e2e/cloak-owner-access.spec.ts
+++ b/e2e/cloak-owner-access.spec.ts
@@ -41,4 +41,30 @@ test.describe("cloak owner access (#179)", () => {
 
     await ctx.close();
   });
+
+  test("admin cloaked as a non-owner member is kept out of the owner/admin area", async ({
+    browser,
+  }) => {
+    const ctx = await browser.newContext({ baseURL });
+    const page = await ctx.newPage();
+
+    const session = await loginAndGetSession(page.request, "admin", "admin");
+    const api = makeApi(page.request, session.csrf);
+
+    // Pick a non-admin member who owns no car — they have no admin area at all.
+    const people = await api.get<Array<{ id: number; is_admin: number }>>("/api/people");
+    const cars = await api.get<Array<{ owner_person_id: number }>>("/api/vehicles");
+    const ownerIds = new Set(cars.map((c) => c.owner_person_id));
+    const member = people.find((p) => p.is_admin === 0 && !ownerIds.has(p.id));
+    test.skip(!member, "Seed has no non-admin non-owner member");
+
+    await api.post("/api/auth/cloak", { personId: member!.id });
+
+    // Owner/admin pages must be off-limits to a cloaked plain member — including
+    // /admin/settlement, which today renders its chrome instead of bouncing.
+    await page.goto("/admin/settlement");
+    await page.waitForURL((u) => new URL(u).pathname === "/", { timeout: 15_000 });
+
+    await ctx.close();
+  });
 });

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -18,6 +18,9 @@ export interface SessionData {
     personId: number;
     shortName: string;
     isAdmin: boolean;
+    /** Whether the impersonated person owns a car — gates owner-only pages
+     *  (e.g. /admin/vehicles) at the Edge proxy, which has no DB access. */
+    isOwner: boolean;
   };
 }
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -79,10 +79,14 @@ export async function proxy(req: NextRequest) {
   }
 
   // While cloaking as a non-admin, block admin-only pages (redirect to dashboard).
-
+  // /admin/vehicles is an OWNER page, so it stays open to a cloaked car owner —
+  // matching the access the impersonated person has when logged in directly (#179).
   if (session.cloakedAs && !session.cloakedAs.isAdmin) {
-    const adminOnlyPaths = ["/admin/vehicles", "/admin/members", "/admin/payout"];
-    if (adminOnlyPaths.some((p) => pathname === p || pathname.startsWith(p + "/"))) {
+    const blockedPaths = ["/admin/members", "/admin/payout"];
+    if (!session.cloakedAs.isOwner) {
+      blockedPaths.push("/admin/vehicles");
+    }
+    if (blockedPaths.some((p) => pathname === p || pathname.startsWith(p + "/"))) {
       return NextResponse.redirect(new URL("/admin", req.url));
     }
   }


### PR DESCRIPTION
Closes #179.

An admin cloaked as a car owner was wrongly bounced from the owner vehicles page (`/admin/vehicles`); separately, a cloaked plain member (or any non-admin/non-owner via direct URL) could land on `/admin` pages — most visibly `/admin/settlement`, which rendered its chrome instead of redirecting (data APIs already 403 non-owners, so no data leak — but the page shouldn't open).

## Changes
- **`cloakedAs.isOwner`** (`lib/session.ts`, `app/api/auth/cloak/route.ts`): the impersonated person's ownership is computed at cloak time (Node has DB) and carried in the session, so the Edge proxy can reason about it.
- **`proxy.ts`**: a cloaked owner keeps `/admin/vehicles` (an OWNER page); `/admin/members` and `/admin/payout` stay blocked.
- **`AdminAccessGuard`** (`app/admin/layout.tsx`): if `useMe` resolves to a non-admin **and** non-owner identity, redirect to `/`. Guards every `/admin/*` page uniformly and is cloak-aware (useMe reflects the cloaked identity).

## Tests (prod build)
- e2e: cloaked **owner** → `/admin/vehicles` accessible.
- e2e: cloaked **non-owner** → bounced from `/admin/settlement` to `/`.
- cloak unit test asserts `cloakedAs.isOwner` flows through.
- Full e2e **71/71** · unit **871** · lint 0 errors · typecheck clean. Verified manually on a prod build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)