### PR TITLE
feat(admin): Copy invite link copies a full welcome message (#368)

### DIFF
--- a/app/admin/members/__tests__/invite-message.test.ts
+++ b/app/admin/members/__tests__/invite-message.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { buildInviteMessage } from "../invite-message";
+
+// Stub t function: returns the key with placeholders substituted.
+// To make var values visible in output, we append them as "key[var=value]".
+function stubT(key: string, vars?: Record<string, string | number>): string {
+  let result = key;
+  if (vars) {
+    for (const [k, v] of Object.entries(vars)) {
+      result += `[${k}=${v}]`;
+    }
+  }
+  return result;
+}
+
+describe("buildInviteMessage", () => {
+  it("includes the username when provided", () => {
+    const msg = buildInviteMessage("alice", "https://example.com/invite/abc123", stubT);
+    expect(msg).toContain("alice");
+    expect(msg).toContain("https://example.com/invite/abc123");
+  });
+
+  it("includes the URL", () => {
+    const msg = buildInviteMessage("bob", "https://example.com/invite/xyz", stubT);
+    expect(msg).toContain("https://example.com/invite/xyz");
+  });
+
+  it("omits the username line when username is null", () => {
+    const msg = buildInviteMessage(null, "https://example.com/invite/token", stubT);
+    expect(msg).not.toContain("admin.invite_msg_username");
+    expect(msg).toContain("https://example.com/invite/token");
+  });
+
+  it("omits the username line when username is an empty string", () => {
+    const msg = buildInviteMessage("", "https://example.com/invite/token2", stubT);
+    expect(msg).not.toContain("admin.invite_msg_username");
+    expect(msg).toContain("https://example.com/invite/token2");
+  });
+
+  it("contains the intro and cta lines from t()", () => {
+    const msg = buildInviteMessage("carol", "https://example.com/invite/qqq", stubT);
+    expect(msg).toContain("admin.invite_msg_intro");
+    expect(msg).toContain("admin.invite_msg_cta");
+  });
+
+  it("the username line contains the username substituted in", () => {
+    const msg = buildInviteMessage("owner_a", "https://example.com/invite/qqq", stubT);
+    // stubT replaces {username} with the value, so the line should contain the username
+    expect(msg).toContain("owner_a");
+  });
+});

--- a/app/admin/members/invite-message.ts
+++ b/app/admin/members/invite-message.ts
@@ -1,0 +1,27 @@
+import type { MessageKey } from "@/lib/i18n/messages/nl";
+
+type TFn = (key: MessageKey, params?: Record<string, string | number>) => string;
+
+/**
+ * Builds a ready-to-send invite message for copy-to-clipboard.
+ * Mirrors the wording of the emailed invite (see app/api/people/[id]/invite/route.ts).
+ *
+ * @param username - The member's username; if null/empty, the username line is omitted.
+ * @param url      - The invite URL.
+ * @param t        - Localisation function (useT hook value or static t).
+ */
+export function buildInviteMessage(
+  username: string | null,
+  url: string,
+  t: TFn,
+): string {
+  const lines: string[] = [t("admin.invite_msg_intro"), ""];
+
+  if (username) {
+    lines.push(t("admin.invite_msg_username", { username }), "");
+  }
+
+  lines.push(t("admin.invite_msg_cta"), url);
+
+  return lines.join("\n");
+}

--- a/app/admin/members/page.tsx
+++ b/app/admin/members/page.tsx
@@ -15,6 +15,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { usePeople } from "../_shared";
+import { buildInviteMessage } from "./invite-message";
 import { MemberForm } from "./member-form";
 
 // ── Person Row (accordion) ────────────────────────────────────
@@ -110,7 +111,7 @@ function PersonRow({
         setInviteBanner(t("admin.invite_sent"));
       } else {
         const { url } = await res.json();
-        await navigator.clipboard.writeText(url);
+        await navigator.clipboard.writeText(buildInviteMessage(person.username, url, t));
         setInviteBanner(t("admin.invite_copied"));
       }
       setTimeout(() => setInviteBanner(null), 3000);

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -601,6 +601,10 @@ export const en: Messages = {
   "admin.invite_sent": "Invite sent!",
   "admin.invite_needs_username":
     "Set a username first — the invite lets the member set a password, not a username.",
+  "admin.invite_msg_intro": "Hi! You've been added to CarSharing.",
+  "admin.invite_msg_username": "Your username: {username}",
+  "admin.invite_msg_cta":
+    "Open this link to set your password and sign in (valid for 7 days):",
   "admin.username_label": "Username",
   "admin.is_admin_label": "Admin",
   "admin.no_username": "No login yet",

--- a/lib/i18n/messages/nl.ts
+++ b/lib/i18n/messages/nl.ts
@@ -600,6 +600,10 @@ export const nl = {
   "admin.invite_sent": "Uitnodiging verstuurd!",
   "admin.invite_needs_username":
     "Stel eerst een gebruikersnaam in — via de uitnodiging stelt het lid een wachtwoord in, geen gebruikersnaam.",
+  "admin.invite_msg_intro": "Hallo! Je bent toegevoegd aan Autodelen.",
+  "admin.invite_msg_username": "Jouw gebruikersnaam: {username}",
+  "admin.invite_msg_cta":
+    "Open deze link om je wachtwoord in te stellen en in te loggen (geldig voor 7 dagen):",
   "admin.username_label": "Gebruikersnaam",
   "admin.is_admin_label": "Admin",
   "admin.no_username": "Nog geen login",


### PR DESCRIPTION
Closes #368.

The "Copy invite link" action on `/admin/members` now copies a ready-to-send welcome message (greeting + username + 7-day instruction + invite link), localized (nl/en), instead of the bare URL — paste straight into WhatsApp/SMS.

- `app/admin/members/invite-message.ts` — pure `buildInviteMessage(username, url, t)`; omits the username line when absent. Mirrors the emailed-invite wording.
- i18n keys `admin.invite_msg_intro/_username/_cta` (en + nl).
- Unit-tested; verified on a prod build (full e2e 71/71, unit 877, lint 0, typecheck clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)