### PR TITLE
feat(calendar): one-time toast nudging users to subscribe to the calendar (#264)

### DIFF
--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -15,6 +15,11 @@ import {
 } from "@/hooks/use-reservations";
 import { useCars } from "@/hooks/use-vehicles";
 import { apiFetch } from "@/lib/api/client";
+import {
+  CALENDAR_NUDGE_DURATION,
+  markCalendarNudgeSeen,
+  shouldShowCalendarNudge,
+} from "@/lib/calendar-nudge";
 import { useOnlineState } from "@/lib/offline/online-state";
 import { fontMono, fontSerif, paper } from "@/lib/paper-theme";
 import { canEdit } from "@/lib/permissions";
@@ -123,6 +128,27 @@ function CalendarContent() {
   const createR = useCreateReservation();
   const updateR = useUpdateReservation();
   const deleteR = useDeleteReservation();
+
+  // One-time nudge: prompt the user to subscribe to the CarSharing calendar.
+  // Fires on first /calendar visit; localStorage key cs.calendarNudgeSeen
+  // persists the dismissal.
+  useEffect(() => {
+    const calendarId = calendarMeta?.calendarId;
+    if (!calendarId) return;
+    if (!shouldShowCalendarNudge(localStorage)) return;
+
+    markCalendarNudgeSeen(localStorage);
+    const subscribeUrl = `https://calendar.google.com/calendar/r?cid=${encodeURIComponent(calendarId)}`;
+    toast(t("calendar.nudge_message"), {
+      duration: CALENDAR_NUDGE_DURATION,
+      action: {
+        label: t("calendar.nudge_action"),
+        onClick: () => {
+          window.open(subscribeUrl, "_blank", "noopener,noreferrer");
+        },
+      },
+    });
+  }, [calendarMeta, t]);
 
   const activeCars = cars.filter((c) => c.active);
 

--- a/lib/__tests__/calendar-nudge.test.ts
+++ b/lib/__tests__/calendar-nudge.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { markCalendarNudgeSeen, shouldShowCalendarNudge } from "../calendar-nudge";
+
+function makeStorage(initial: Record<string, string> = {}): Pick<Storage, "getItem" | "setItem"> {
+  const store = { ...initial };
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+  };
+}
+
+describe("shouldShowCalendarNudge", () => {
+  it("returns true when the flag is absent", () => {
+    const storage = makeStorage();
+    expect(shouldShowCalendarNudge(storage)).toBe(true);
+  });
+
+  it("returns false when the flag is set to '1'", () => {
+    const storage = makeStorage({ "cs.calendarNudgeSeen": "1" });
+    expect(shouldShowCalendarNudge(storage)).toBe(false);
+  });
+
+  it("returns false when the flag is set to any truthy string", () => {
+    const storage = makeStorage({ "cs.calendarNudgeSeen": "true" });
+    expect(shouldShowCalendarNudge(storage)).toBe(false);
+  });
+});
+
+describe("markCalendarNudgeSeen", () => {
+  it("sets the flag so subsequent shouldShowCalendarNudge returns false", () => {
+    const storage = makeStorage();
+    expect(shouldShowCalendarNudge(storage)).toBe(true);
+    markCalendarNudgeSeen(storage);
+    expect(shouldShowCalendarNudge(storage)).toBe(false);
+  });
+
+  it("writes '1' to the correct localStorage key", () => {
+    const written: Record<string, string> = {};
+    const storage: Pick<Storage, "getItem" | "setItem"> = {
+      getItem: () => null,
+      setItem: (key, value) => {
+        written[key] = value;
+      },
+    };
+    markCalendarNudgeSeen(storage);
+    expect(written["cs.calendarNudgeSeen"]).toBe("1");
+  });
+});

--- a/lib/calendar-nudge.ts
+++ b/lib/calendar-nudge.ts
@@ -1,0 +1,35 @@
+/**
+ * Calendar nudge — one-time toast prompting users to subscribe to the
+ * CarSharing Google Calendar.
+ *
+ * Defaults:
+ *   - localStorage key: "cs.calendarNudgeSeen"
+ *   - Toast duration:   8 000 ms (longer than the sonner default of 4 000 ms,
+ *                       giving users time to read + click the action button)
+ *   - Action destination: the Google Calendar subscribe URL built from the
+ *     calendarId returned by /api/calendar-id
+ *     (https://calendar.google.com/calendar/r?cid=<calendarId>).
+ *     If no calendarId is configured the nudge is skipped entirely.
+ */
+
+export const CALENDAR_NUDGE_KEY = "cs.calendarNudgeSeen";
+export const CALENDAR_NUDGE_DURATION = 8_000;
+
+/**
+ * Pure predicate — returns true when the nudge has not been seen yet.
+ * Accepts a storage stub so it can be tested without a real browser.
+ */
+export function shouldShowCalendarNudge(
+  storage: Pick<Storage, "getItem">
+): boolean {
+  return storage.getItem(CALENDAR_NUDGE_KEY) === null;
+}
+
+/**
+ * Marks the nudge as seen so it will not be shown again.
+ */
+export function markCalendarNudgeSeen(
+  storage: Pick<Storage, "getItem" | "setItem">
+): void {
+  storage.setItem(CALENDAR_NUDGE_KEY, "1");
+}

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -285,6 +285,8 @@ export const en: Messages = {
   "calendar.all_filter": "All",
   "calendar.mine_filter": "Mine",
   "calendar.subscribe": "Add to calendar app",
+  "calendar.nudge_message": "Add the CarSharing calendar to your own calendar app to stay up to date.",
+  "calendar.nudge_action": "Add calendar",
   "calendar.prev_weeks": "Previous weeks",
   "calendar.next_weeks": "Next weeks",
   "location.use_gps": "Use current location",

--- a/lib/i18n/messages/nl.ts
+++ b/lib/i18n/messages/nl.ts
@@ -284,6 +284,8 @@ export const nl = {
   "calendar.all_filter": "Alles",
   "calendar.mine_filter": "Mijn",
   "calendar.subscribe": "Voeg toe aan kalender-app",
+  "calendar.nudge_message": "Voeg de Autodelen-kalender toe aan je eigen kalender-app om altijd op de hoogte te blijven.",
+  "calendar.nudge_action": "Kalender toevoegen",
   "calendar.prev_weeks": "Vorige weken",
   "calendar.next_weeks": "Volgende weken",
   "location.use_gps": "Huidige locatie gebruiken",


### PR DESCRIPTION
Closes #264.

On a user's first visit to `/calendar`, show a one-time toast nudging them to subscribe to the CarSharing calendar (action → Google subscribe URL). Persisted via `localStorage` so it shows once; skipped entirely when no calendar is configured.

- `lib/calendar-nudge.ts` — pure `shouldShowCalendarNudge(storage)` / `markCalendarNudgeSeen(storage)` (key `cs.calendarNudgeSeen`).
- `app/calendar/page.tsx` — effect fires once after `calendarMeta` loads; only when a `calendarId` exists.
- i18n `calendar.nudge_message` / `calendar.nudge_action` (en + nl).
- Unit-tested; verified on a prod build (full e2e 71/71, unit 876, lint 0, typecheck clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)