### PR TITLE
feat(notifications): in-app notifications with two-block prefs (#358)

### DIFF
--- a/app/admin/members/page.tsx
+++ b/app/admin/members/page.tsx
@@ -685,6 +685,9 @@ export default function AdminLedenPage() {
                 email: null,
                 theme_preference: "mono",
                 updated_at: "",
+                notify_new_reservations: "off",
+                notify_reservation_updates: "off",
+                notify_new_trips: "off",
               },
               {
                 onSuccess: () => {

--- a/app/admin/members/page.tsx
+++ b/app/admin/members/page.tsx
@@ -686,8 +686,10 @@ export default function AdminLedenPage() {
                 theme_preference: "mono",
                 updated_at: "",
                 notify_new_reservations: "off",
-                notify_reservation_updates: "off",
+                notify_reservation_updates: "mine",
                 notify_new_trips: "off",
+                notify_my_car_reservations: "off",
+                notify_my_car_trips: "off",
               },
               {
                 onSuccess: () => {

--- a/app/api/notifications/read/route.test.ts
+++ b/app/api/notifications/read/route.test.ts
@@ -1,0 +1,85 @@
+// app/api/notifications/read/route.test.ts
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/env", () => ({
+  env: { SESSION_PASSWORD: "test-password-32-chars-minimum!!", NODE_ENV: "test" },
+}));
+
+const mockSession = {
+  authenticated: true,
+  personId: 1,
+  isAdmin: false,
+  save: vi.fn(),
+};
+vi.mock("iron-session", () => ({ getIronSession: vi.fn(async () => mockSession) }));
+
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+vi.mock("@/lib/queries/people", () => ({ isActivePerson: vi.fn(() => true) }));
+
+const mockMarkRead = vi.fn();
+vi.mock("@/lib/queries/notifications", () => ({
+  markRead: (...a: unknown[]) => mockMarkRead(...a),
+}));
+
+import { POST } from "./route";
+
+const CSRF = "test-csrf-token";
+const ctx = { params: Promise.resolve({}) };
+
+let ipCounter = 0;
+function postReq(body: unknown, withCsrf = true) {
+  return new Request("http://localhost/api/notifications/read", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(withCsrf ? { Cookie: `csrf-token=${CSRF}`, "x-csrf-token": CSRF } : {}),
+      "x-forwarded-for": `203.0.113.${++ipCounter}`,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSession.authenticated = true;
+  mockSession.personId = 1;
+  mockSession.isAdmin = false;
+});
+
+describe("POST /api/notifications/read", () => {
+  it("marks all notifications read when no ids provided", async () => {
+    mockSession.personId = 3;
+    const res = await POST(postReq({}), ctx);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(mockMarkRead).toHaveBeenCalledWith({}, 3, undefined);
+  });
+
+  it("marks specific notifications read and scopes to session person", async () => {
+    mockSession.personId = 4;
+    const res = await POST(postReq({ ids: [10, 11, 12] }), ctx);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(mockMarkRead).toHaveBeenCalledWith({}, 4, [10, 11, 12]);
+  });
+
+  it("returns 403 for an unauthenticated request", async () => {
+    mockSession.personId = undefined as unknown as number;
+    const res = await POST(postReq({}), ctx);
+    expect(res.status).toBe(403);
+    expect(mockMarkRead).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when CSRF token is missing", async () => {
+    const res = await POST(postReq({}, false), ctx);
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ error: "invalid_csrf" });
+    expect(mockMarkRead).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for an invalid body (ids contains non-integer)", async () => {
+    const res = await POST(postReq({ ids: ["not-a-number"] }), ctx);
+    expect(res.status).toBe(400);
+    expect(mockMarkRead).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/notifications/read/route.ts
+++ b/app/api/notifications/read/route.ts
@@ -1,0 +1,16 @@
+import { json, requireSession } from "@/lib/api";
+import { getDb } from "@/lib/db";
+import { markRead } from "@/lib/queries/notifications";
+import { z } from "zod";
+
+const readSchema = z.object({
+  ids: z.array(z.number().int().positive()).optional(),
+});
+
+export const POST = json(async (req) => {
+  const session = await requireSession(req);
+  const raw = await req.json();
+  const { ids } = readSchema.parse(raw);
+  markRead(getDb(), session.personId!, ids);
+  return { ok: true };
+});

--- a/app/api/notifications/route.test.ts
+++ b/app/api/notifications/route.test.ts
@@ -1,0 +1,55 @@
+// app/api/notifications/route.test.ts
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/env", () => ({
+  env: { SESSION_PASSWORD: "test-password-32-chars-minimum!!", NODE_ENV: "test" },
+}));
+
+const mockSession = {
+  authenticated: true,
+  personId: 1,
+  isAdmin: false,
+  save: vi.fn(),
+};
+vi.mock("iron-session", () => ({ getIronSession: vi.fn(async () => mockSession) }));
+
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+vi.mock("@/lib/queries/people", () => ({ isActivePerson: vi.fn(() => true) }));
+
+const mockListNotifications = vi.fn((..._a: unknown[]) => [{ id: 1 }, { id: 2 }]);
+vi.mock("@/lib/queries/notifications", () => ({
+  listNotifications: (...a: unknown[]) => mockListNotifications(...a),
+}));
+
+import { GET } from "./route";
+
+const ctx = { params: Promise.resolve({}) };
+
+function getReq() {
+  return new Request("http://localhost/api/notifications");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSession.authenticated = true;
+  mockSession.personId = 1;
+  mockSession.isAdmin = false;
+  mockListNotifications.mockReturnValue([{ id: 1 }, { id: 2 }]);
+});
+
+describe("GET /api/notifications", () => {
+  it("returns the notifications list scoped to the session person", async () => {
+    mockSession.personId = 5;
+    const res = await GET(getReq(), ctx);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(mockListNotifications).toHaveBeenCalledWith({}, 5);
+  });
+
+  it("returns 403 for an unauthenticated request (no personId)", async () => {
+    mockSession.personId = undefined as unknown as number;
+    const res = await GET(getReq(), ctx);
+    expect(res.status).toBe(403);
+    expect(mockListNotifications).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,0 +1,8 @@
+import { json, requireSession } from "@/lib/api";
+import { getDb } from "@/lib/db";
+import { listNotifications } from "@/lib/queries/notifications";
+
+export const GET = json(async (req) => {
+  const session = await requireSession(req);
+  return listNotifications(getDb(), session.personId!);
+});

--- a/app/api/notifications/unread-count/route.test.ts
+++ b/app/api/notifications/unread-count/route.test.ts
@@ -1,0 +1,56 @@
+// app/api/notifications/unread-count/route.test.ts
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/env", () => ({
+  env: { SESSION_PASSWORD: "test-password-32-chars-minimum!!", NODE_ENV: "test" },
+}));
+
+const mockSession = {
+  authenticated: true,
+  personId: 1,
+  isAdmin: false,
+  save: vi.fn(),
+};
+vi.mock("iron-session", () => ({ getIronSession: vi.fn(async () => mockSession) }));
+
+vi.mock("@/lib/db", () => ({ getDb: vi.fn(() => ({})) }));
+vi.mock("@/lib/queries/people", () => ({ isActivePerson: vi.fn(() => true) }));
+
+const mockUnreadCount = vi.fn((..._a: unknown[]) => 3);
+vi.mock("@/lib/queries/notifications", () => ({
+  unreadCount: (...a: unknown[]) => mockUnreadCount(...a),
+}));
+
+import { GET } from "./route";
+
+const ctx = { params: Promise.resolve({}) };
+
+function getReq() {
+  return new Request("http://localhost/api/notifications/unread-count");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSession.authenticated = true;
+  mockSession.personId = 1;
+  mockSession.isAdmin = false;
+  mockUnreadCount.mockReturnValue(3);
+});
+
+describe("GET /api/notifications/unread-count", () => {
+  it("returns the unread count scoped to the session person", async () => {
+    mockSession.personId = 7;
+    mockUnreadCount.mockReturnValue(5);
+    const res = await GET(getReq(), ctx);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ count: 5 });
+    expect(mockUnreadCount).toHaveBeenCalledWith({}, 7);
+  });
+
+  it("returns 403 for an unauthenticated request (no personId)", async () => {
+    mockSession.personId = undefined as unknown as number;
+    const res = await GET(getReq(), ctx);
+    expect(res.status).toBe(403);
+    expect(mockUnreadCount).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/notifications/unread-count/route.ts
+++ b/app/api/notifications/unread-count/route.ts
@@ -1,0 +1,8 @@
+import { json, requireSession } from "@/lib/api";
+import { getDb } from "@/lib/db";
+import { unreadCount } from "@/lib/queries/notifications";
+
+export const GET = json(async (req) => {
+  const session = await requireSession(req);
+  return { count: unreadCount(getDb(), session.personId!) };
+});

--- a/app/api/people/[id]/profile/route.test.ts
+++ b/app/api/people/[id]/profile/route.test.ts
@@ -41,6 +41,9 @@ const existingPerson = {
   discount: 0,
   discount_long: 0,
   updated_at: "",
+  notify_new_reservations: "off" as const,
+  notify_reservation_updates: "off" as const,
+  notify_new_trips: "off" as const,
 };
 
 function makeCtx(id: string) {
@@ -130,5 +133,56 @@ describe("PATCH /api/people/[id]/profile", () => {
     expect(res.status).toBe(200);
     const [, , data] = mockUpdatePerson.mock.calls[0];
     expect(data.theme_preference).toBe("paper");
+  });
+
+  it("persists notify_new_reservations update", async () => {
+    const res = await PATCH(
+      makeReq({ ...validBody, notify_new_reservations: "all" }),
+      makeCtx("1")
+    );
+    expect(res.status).toBe(200);
+    const [, , data] = mockUpdatePerson.mock.calls[0];
+    expect(data.notify_new_reservations).toBe("all");
+  });
+
+  it("persists notify_reservation_updates update", async () => {
+    const res = await PATCH(
+      makeReq({ ...validBody, notify_reservation_updates: "own" }),
+      makeCtx("1")
+    );
+    expect(res.status).toBe(200);
+    const [, , data] = mockUpdatePerson.mock.calls[0];
+    expect(data.notify_reservation_updates).toBe("own");
+  });
+
+  it("persists notify_new_trips update", async () => {
+    const res = await PATCH(makeReq({ ...validBody, notify_new_trips: "off" }), makeCtx("1"));
+    expect(res.status).toBe(200);
+    const [, , data] = mockUpdatePerson.mock.calls[0];
+    expect(data.notify_new_trips).toBe("off");
+  });
+
+  it("rejects invalid notify_new_reservations value", async () => {
+    const res = await PATCH(
+      makeReq({ ...validBody, notify_new_reservations: "invalid" }),
+      makeCtx("1")
+    );
+    expect(res.status).toBe(400);
+    expect(mockUpdatePerson).not.toHaveBeenCalled();
+  });
+
+  it("falls back to existing notify prefs when not provided", async () => {
+    mockGetPersonById.mockReturnValue({
+      ...existingPerson,
+      notify_new_reservations: "all",
+      notify_reservation_updates: "own",
+      notify_new_trips: "all",
+    });
+    const res = await PATCH(makeReq(validBody), makeCtx("1"));
+    expect(res.status).toBe(200);
+    const [, , data] = mockUpdatePerson.mock.calls[0];
+    expect(data.notify_new_reservations).toBe("all");
+    expect(data.notify_reservation_updates).toBe("own");
+    expect(data.notify_new_trips).toBe("all");
   });
 });

--- a/app/api/people/[id]/profile/route.test.ts
+++ b/app/api/people/[id]/profile/route.test.ts
@@ -42,8 +42,10 @@ const existingPerson = {
   discount_long: 0,
   updated_at: "",
   notify_new_reservations: "off" as const,
-  notify_reservation_updates: "off" as const,
+  notify_reservation_updates: "mine" as const,
   notify_new_trips: "off" as const,
+  notify_my_car_reservations: "off" as const,
+  notify_my_car_trips: "off" as const,
 };
 
 function makeCtx(id: string) {
@@ -147,12 +149,22 @@ describe("PATCH /api/people/[id]/profile", () => {
 
   it("persists notify_reservation_updates update", async () => {
     const res = await PATCH(
-      makeReq({ ...validBody, notify_reservation_updates: "own" }),
+      makeReq({ ...validBody, notify_reservation_updates: "all" }),
       makeCtx("1")
     );
     expect(res.status).toBe(200);
     const [, , data] = mockUpdatePerson.mock.calls[0];
-    expect(data.notify_reservation_updates).toBe("own");
+    expect(data.notify_reservation_updates).toBe("all");
+  });
+
+  it("persists notify_reservation_updates set to 'off'", async () => {
+    const res = await PATCH(
+      makeReq({ ...validBody, notify_reservation_updates: "off" }),
+      makeCtx("1")
+    );
+    expect(res.status).toBe(200);
+    const [, , data] = mockUpdatePerson.mock.calls[0];
+    expect(data.notify_reservation_updates).toBe("off");
   });
 
   it("persists notify_new_trips update", async () => {
@@ -160,6 +172,21 @@ describe("PATCH /api/people/[id]/profile", () => {
     expect(res.status).toBe(200);
     const [, , data] = mockUpdatePerson.mock.calls[0];
     expect(data.notify_new_trips).toBe("off");
+  });
+
+  it("persists owner notify toggles", async () => {
+    const res = await PATCH(
+      makeReq({
+        ...validBody,
+        notify_my_car_reservations: "on",
+        notify_my_car_trips: "on",
+      }),
+      makeCtx("1")
+    );
+    expect(res.status).toBe(200);
+    const [, , data] = mockUpdatePerson.mock.calls[0];
+    expect(data.notify_my_car_reservations).toBe("on");
+    expect(data.notify_my_car_trips).toBe("on");
   });
 
   it("rejects invalid notify_new_reservations value", async () => {
@@ -175,14 +202,14 @@ describe("PATCH /api/people/[id]/profile", () => {
     mockGetPersonById.mockReturnValue({
       ...existingPerson,
       notify_new_reservations: "all",
-      notify_reservation_updates: "own",
+      notify_reservation_updates: "all",
       notify_new_trips: "all",
     });
     const res = await PATCH(makeReq(validBody), makeCtx("1"));
     expect(res.status).toBe(200);
     const [, , data] = mockUpdatePerson.mock.calls[0];
     expect(data.notify_new_reservations).toBe("all");
-    expect(data.notify_reservation_updates).toBe("own");
+    expect(data.notify_reservation_updates).toBe("all");
     expect(data.notify_new_trips).toBe("all");
   });
 });

--- a/app/api/people/[id]/profile/route.ts
+++ b/app/api/people/[id]/profile/route.ts
@@ -6,8 +6,6 @@ import { getIronSession } from "iron-session";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
-const notifyPref = z.enum(["off", "all", "own"]).optional();
-
 const profileSchema = z.object({
   first_name: z.string().min(1),
   last_name: z.string().default(""),
@@ -19,9 +17,13 @@ const profileSchema = z.object({
     .optional()
     .transform((v) => v ?? null),
   theme_preference: z.enum(["paper", "mono"]).optional(),
-  notify_new_reservations: notifyPref,
-  notify_reservation_updates: notifyPref,
-  notify_new_trips: notifyPref,
+  // Driver/member prefs
+  notify_new_reservations: z.enum(["off", "all"]).optional(),
+  notify_reservation_updates: z.enum(["off", "all", "mine"]).optional(),
+  notify_new_trips: z.enum(["off", "all"]).optional(),
+  // Owner prefs (events on cars I own)
+  notify_my_car_reservations: z.enum(["off", "on"]).optional(),
+  notify_my_car_trips: z.enum(["off", "on"]).optional(),
 });
 
 export const PATCH = json(async (req, ctx) => {
@@ -44,6 +46,9 @@ export const PATCH = json(async (req, ctx) => {
     notify_reservation_updates:
       data.notify_reservation_updates ?? existing.notify_reservation_updates,
     notify_new_trips: data.notify_new_trips ?? existing.notify_new_trips,
+    notify_my_car_reservations:
+      data.notify_my_car_reservations ?? existing.notify_my_car_reservations,
+    notify_my_car_trips: data.notify_my_car_trips ?? existing.notify_my_car_trips,
   });
   return { ok: true };
 });

--- a/app/api/people/[id]/profile/route.ts
+++ b/app/api/people/[id]/profile/route.ts
@@ -6,6 +6,8 @@ import { getIronSession } from "iron-session";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
+const notifyPref = z.enum(["off", "all", "own"]).optional();
+
 const profileSchema = z.object({
   first_name: z.string().min(1),
   last_name: z.string().default(""),
@@ -17,6 +19,9 @@ const profileSchema = z.object({
     .optional()
     .transform((v) => v ?? null),
   theme_preference: z.enum(["paper", "mono"]).optional(),
+  notify_new_reservations: notifyPref,
+  notify_reservation_updates: notifyPref,
+  notify_new_trips: notifyPref,
 });
 
 export const PATCH = json(async (req, ctx) => {
@@ -35,6 +40,10 @@ export const PATCH = json(async (req, ctx) => {
     bank_account: data.bank_account,
     email: data.email ?? null,
     theme_preference: data.theme_preference ?? existing.theme_preference,
+    notify_new_reservations: data.notify_new_reservations ?? existing.notify_new_reservations,
+    notify_reservation_updates:
+      data.notify_reservation_updates ?? existing.notify_reservation_updates,
+    notify_new_trips: data.notify_new_trips ?? existing.notify_new_trips,
   });
   return { ok: true };
 });

--- a/app/api/reservations/[id]/route.ts
+++ b/app/api/reservations/[id]/route.ts
@@ -76,6 +76,12 @@ export const DELETE = json(async (req, ctx) => {
       end: existing.end_date,
       status: t("notif.status_deleted"),
     }),
+    alwaysNotifyMessage: t("notif.reservation_update_self", {
+      car: existing.car_short ?? String(existing.car_id),
+      start: existing.start_date,
+      end: existing.end_date,
+      status: t("notif.status_deleted"),
+    }),
   }).catch(() => {});
   notifyAdminOfChange({
     db,

--- a/app/api/reservations/[id]/route.ts
+++ b/app/api/reservations/[id]/route.ts
@@ -69,6 +69,7 @@ export const DELETE = json(async (req, ctx) => {
     entityId: id,
     carId: existing.car_id,
     actorPersonId: session.personId!,
+    alwaysNotifyPersonId: existing.person_id,
     message: t("notif.reservation_update", {
       car: existing.car_short ?? String(existing.car_id),
       start: existing.start_date,

--- a/app/api/reservations/[id]/route.ts
+++ b/app/api/reservations/[id]/route.ts
@@ -1,6 +1,8 @@
 import { json, notFound, readBody, readId, requireCanEdit, requireSession } from "@/lib/api";
 import { getDb } from "@/lib/db";
+import { t } from "@/lib/i18n";
 import { notifyAdminOfChange } from "@/lib/notify-admin";
+import { notifyUsersOfEvent } from "@/lib/notify-users";
 import {
   ConflictError,
   deleteReservation,
@@ -60,6 +62,20 @@ export const DELETE = json(async (req, ctx) => {
   const session = await requireCanEdit(req, existing, db);
   await syncReservationDelete(db, id).catch(() => {});
   deleteReservation(db, id);
+  notifyUsersOfEvent({
+    db,
+    trigger: "reservation_update",
+    entityType: "reservation",
+    entityId: id,
+    carId: existing.car_id,
+    actorPersonId: session.personId!,
+    message: t("notif.reservation_update", {
+      car: existing.car_short ?? String(existing.car_id),
+      start: existing.start_date,
+      end: existing.end_date,
+      status: t("notif.status_deleted"),
+    }),
+  }).catch(() => {});
   notifyAdminOfChange({
     db,
     actor: session,

--- a/app/api/reservations/[id]/status/route.ts
+++ b/app/api/reservations/[id]/status/route.ts
@@ -30,6 +30,7 @@ export const PATCH = json(async (req, ctx) => {
     entityId: id,
     carId: reservation.car_id,
     actorPersonId: session.personId!,
+    alwaysNotifyPersonId: reservation.person_id,
     message: t("notif.reservation_update", {
       car: reservation.car_short ?? String(reservation.car_id),
       start: reservation.start_date,

--- a/app/api/reservations/[id]/status/route.ts
+++ b/app/api/reservations/[id]/status/route.ts
@@ -1,5 +1,7 @@
 import { json, notFound, readBody, readId, requireAdminOrCarOwner } from "@/lib/api";
 import { getDb } from "@/lib/db";
+import { t } from "@/lib/i18n";
+import { notifyUsersOfEvent } from "@/lib/notify-users";
 import { getReservationById, updateReservationStatus } from "@/lib/queries/reservations";
 import { syncReservationUpdate } from "@/lib/reservation-sync";
 import { reservationStatusSchema } from "@/lib/schemas/reservation";
@@ -11,9 +13,21 @@ export const PATCH = json(async (req, ctx) => {
   if (!reservation) notFound();
   // Confirming/rejecting a reservation is the car owner's (or an admin's)
   // decision — not something every authenticated member may do.
-  await requireAdminOrCarOwner(req, reservation.car_id, db);
+  const session = await requireAdminOrCarOwner(req, reservation.car_id, db);
   const body = await readBody(req, reservationStatusSchema);
   updateReservationStatus(db, id, body.status);
   syncReservationUpdate(db, id).catch(() => {});
+  notifyUsersOfEvent({
+    db,
+    trigger: "reservation_update",
+    entityType: "reservation",
+    entityId: id,
+    carId: reservation.car_id,
+    actorPersonId: session.personId!,
+    message: t("notif.reservation_update", {
+      car: reservation.car_short ?? String(reservation.car_id),
+      date: reservation.start_date,
+    }),
+  }).catch(() => {});
   return { ok: true };
 });

--- a/app/api/reservations/[id]/status/route.ts
+++ b/app/api/reservations/[id]/status/route.ts
@@ -17,6 +17,12 @@ export const PATCH = json(async (req, ctx) => {
   const body = await readBody(req, reservationStatusSchema);
   updateReservationStatus(db, id, body.status);
   syncReservationUpdate(db, id).catch(() => {});
+  const statusWordKey =
+    body.status === "confirmed"
+      ? "notif.status_confirmed"
+      : body.status === "rejected"
+        ? "notif.status_rejected"
+        : "notif.status_pending";
   notifyUsersOfEvent({
     db,
     trigger: "reservation_update",
@@ -26,7 +32,9 @@ export const PATCH = json(async (req, ctx) => {
     actorPersonId: session.personId!,
     message: t("notif.reservation_update", {
       car: reservation.car_short ?? String(reservation.car_id),
-      date: reservation.start_date,
+      start: reservation.start_date,
+      end: reservation.end_date,
+      status: t(statusWordKey),
     }),
   }).catch(() => {});
   return { ok: true };

--- a/app/api/reservations/[id]/status/route.ts
+++ b/app/api/reservations/[id]/status/route.ts
@@ -37,6 +37,12 @@ export const PATCH = json(async (req, ctx) => {
       end: reservation.end_date,
       status: t(statusWordKey),
     }),
+    alwaysNotifyMessage: t("notif.reservation_update_self", {
+      car: reservation.car_short ?? String(reservation.car_id),
+      start: reservation.start_date,
+      end: reservation.end_date,
+      status: t(statusWordKey),
+    }),
   }).catch(() => {});
   return { ok: true };
 });

--- a/app/api/reservations/route.test.ts
+++ b/app/api/reservations/route.test.ts
@@ -29,6 +29,11 @@ vi.mock("@/lib/reservation-sync", () => ({
   syncReservationCreate: vi.fn(() => Promise.resolve()),
 }));
 
+const mockNotifyUsersOfEvent = vi.fn(() => Promise.resolve());
+vi.mock("@/lib/notify-users", () => ({
+  notifyUsersOfEvent: (...a: unknown[]) => mockNotifyUsersOfEvent(...a),
+}));
+
 import { GET, POST } from "./route";
 
 const CSRF = "test-csrf-token";
@@ -120,5 +125,30 @@ describe("POST /api/reservations", () => {
     expect(res.status).toBe(403);
     expect(await res.json()).toMatchObject({ error: "invalid_csrf" });
     expect(mockInsertReservation).not.toHaveBeenCalled();
+  });
+
+  it("fires notifyUsersOfEvent with trigger=new_reservation after a successful insert", async () => {
+    mockSession.personId = 1;
+    mockGetReservationById.mockReturnValue({
+      id: 7,
+      person_id: 2,
+      car_id: 3,
+      car_short: "JF",
+      start_date: "2025-06-01",
+    });
+    const res = await POST(postReq(validReservation), ctx);
+    expect(res.status).toBe(201);
+    // notifyUsersOfEvent is fire-and-forget; allow the microtask queue to flush
+    await Promise.resolve();
+    expect(mockNotifyUsersOfEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        trigger: "new_reservation",
+        entityType: "reservation",
+        entityId: 7,
+        carId: 3,
+        actorPersonId: 1,
+        message: expect.stringContaining("JF"),
+      })
+    );
   });
 });

--- a/app/api/reservations/route.ts
+++ b/app/api/reservations/route.ts
@@ -43,7 +43,8 @@ export const POST = json(async (req) => {
     actorPersonId: session.personId!,
     message: t("notif.new_reservation", {
       car: reservation?.car_short ?? String(body.car_id),
-      date: body.start_date,
+      start: body.start_date,
+      end: body.end_date,
     }),
   }).catch(() => {});
   return NextResponse.json(reservation, { status: 201 });

--- a/app/api/reservations/route.ts
+++ b/app/api/reservations/route.ts
@@ -1,6 +1,8 @@
 import { json, requireSession } from "@/lib/api";
 import { getDb } from "@/lib/db";
+import { t } from "@/lib/i18n";
 import { notifyAdminOfChange } from "@/lib/notify-admin";
+import { notifyUsersOfEvent } from "@/lib/notify-users";
 import { getReservationById, getReservations, insertReservation } from "@/lib/queries/reservations";
 import { syncReservationCreate } from "@/lib/reservation-sync";
 import { reservationSchema } from "@/lib/schemas/reservation";
@@ -31,6 +33,18 @@ export const POST = json(async (req) => {
       `To: ${body.end_date}${body.end_time ? ` ${body.end_time}` : ""}`,
       ...(body.note ? [`Note: ${body.note}`] : []),
     ].join("\n"),
+  }).catch(() => {});
+  notifyUsersOfEvent({
+    db,
+    trigger: "new_reservation",
+    entityType: "reservation",
+    entityId: id,
+    carId: body.car_id,
+    actorPersonId: session.personId!,
+    message: t("notif.new_reservation", {
+      car: reservation?.car_short ?? String(body.car_id),
+      date: body.start_date,
+    }),
   }).catch(() => {});
   return NextResponse.json(reservation, { status: 201 });
 });

--- a/app/api/trips/route.ts
+++ b/app/api/trips/route.ts
@@ -1,7 +1,9 @@
 import { json, requireSession } from "@/lib/api";
 import { listHandler } from "@/lib/api/crud-handler";
 import { getDb } from "@/lib/db";
+import { t } from "@/lib/i18n";
 import { notifyAdminOfChange } from "@/lib/notify-admin";
+import { notifyUsersOfEvent } from "@/lib/notify-users";
 import { getTripById, getTrips, insertTrip } from "@/lib/queries/trips";
 import { tripSchema } from "@/lib/schemas/trip";
 import { NextResponse } from "next/server";
@@ -31,5 +33,17 @@ export const POST = json(async (req: Request) => {
       ].join("\n"),
     }).catch(() => {});
   }
+  notifyUsersOfEvent({
+    db,
+    trigger: "new_trip",
+    entityType: "trip",
+    entityId: id,
+    carId: data.car_id,
+    actorPersonId: session.personId!,
+    message: t("notif.new_trip", {
+      car: trip?.car_short ?? String(data.car_id),
+      date: trip?.date ?? data.date,
+    }),
+  }).catch(() => {});
   return NextResponse.json(trip, { status: 201 });
 });

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -158,11 +158,16 @@ function CalendarContent() {
 
   const actionParam = searchParams.get("action");
   const editIdParam = searchParams.get("edit");
+  // ?reservation=<id> deep-link from notification bell
+  const reservationParam = searchParams.get("reservation");
+  // Resolve notification deep-link: treat ?reservation=<id> the same as ?edit=<id>
+  const resolvedEditId = editIdParam ?? reservationParam;
 
-  const sheet: "add" | "edit" | null = actionParam === "add" ? "add" : editIdParam ? "edit" : null;
+  const sheet: "add" | "edit" | null =
+    actionParam === "add" ? "add" : resolvedEditId ? "edit" : null;
   const editing =
-    !isLoading && editIdParam
-      ? (reservations.find((r) => r.id === Number(editIdParam)) ?? null)
+    !isLoading && resolvedEditId
+      ? (reservations.find((r) => r.id === Number(resolvedEditId)) ?? null)
       : null;
 
   const editingReadOnly =
@@ -180,7 +185,7 @@ function CalendarContent() {
   const [sheetClosed, setSheetClosed] = useState(false);
   useEffect(() => {
     setSheetClosed(false);
-  }, [editIdParam, actionParam]);
+  }, [editIdParam, actionParam, reservationParam]);
 
   // Refetch reservations whenever the new-reservation sheet opens online —
   // the conflict warning needs to see the freshest server state.

--- a/app/notifications/page.tsx
+++ b/app/notifications/page.tsx
@@ -7,7 +7,6 @@ import { fontMono, fontSerif, paper } from "@/lib/paper-theme";
 import type { Notification } from "@/types";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
-import { useEffect } from "react";
 
 function relativeTime(isoString: string): string {
   const diffMs = Date.now() - new Date(isoString).getTime();
@@ -29,22 +28,6 @@ export default function NotificationsPage() {
     queryKey: ["notifications"],
     queryFn: () => apiFetch("/api/notifications"),
   });
-
-  // Mark all read on mount
-  useEffect(() => {
-    apiFetch("/api/notifications/read", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({}),
-    })
-      .then(() => {
-        void queryClient.invalidateQueries({ queryKey: ["notifications", "unread"] });
-        void queryClient.invalidateQueries({ queryKey: ["notifications"] });
-      })
-      .catch(() => {
-        // non-critical — ignore
-      });
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   async function handleMarkAllRead() {
     try {

--- a/app/notifications/page.tsx
+++ b/app/notifications/page.tsx
@@ -56,20 +56,22 @@ export default function NotificationsPage() {
               onClick={handleMarkAllRead}
               disabled={unreadCount === 0}
               style={{
-                padding: "4px 8px",
+                padding: "4px 2px",
                 fontFamily: fontMono,
-                fontSize: 9,
-                letterSpacing: 1,
-                fontWeight: 700,
+                fontSize: 10,
+                letterSpacing: 0.5,
+                fontWeight: 600,
                 textTransform: "uppercase",
                 background: "transparent",
-                border: `1.5px solid ${unreadCount > 0 ? paper.ink : paper.paperDark}`,
-                color: unreadCount > 0 ? paper.ink : paper.inkMute,
+                border: "none",
+                color: unreadCount > 0 ? paper.inkDim : paper.inkMute,
+                textDecoration: unreadCount > 0 ? "underline" : "none",
+                textUnderlineOffset: 2,
                 cursor: unreadCount > 0 ? "pointer" : "default",
-                opacity: unreadCount > 0 ? 1 : 0.55,
+                opacity: unreadCount > 0 ? 1 : 0.5,
               }}
             >
-              {unreadCount > 0 ? `${t("notif.mark_all_read")} (${unreadCount})` : t("notif.mark_all_read")}
+              {t("notif.mark_all_read")}
             </button>
           ) : undefined
         }

--- a/app/notifications/page.tsx
+++ b/app/notifications/page.tsx
@@ -1,0 +1,191 @@
+"use client";
+import { useT } from "@/components/locale-provider";
+import { PageHeader } from "@/components/page-header";
+import { apiFetch } from "@/lib/api/client";
+import { notificationHref } from "@/lib/notification-href";
+import { fontMono, fontSerif, paper } from "@/lib/paper-theme";
+import type { Notification } from "@/types";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import Link from "next/link";
+import { useEffect } from "react";
+
+function relativeTime(isoString: string): string {
+  const diffMs = Date.now() - new Date(isoString).getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  if (diffSec < 60) return `${diffSec}s`;
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h`;
+  const diffDays = Math.floor(diffHr / 24);
+  return `${diffDays}d`;
+}
+
+export default function NotificationsPage() {
+  const t = useT();
+  const queryClient = useQueryClient();
+
+  const { data: notifications = [], isLoading } = useQuery<Notification[]>({
+    queryKey: ["notifications"],
+    queryFn: () => apiFetch("/api/notifications"),
+  });
+
+  // Mark all read on mount
+  useEffect(() => {
+    apiFetch("/api/notifications/read", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    })
+      .then(() => {
+        void queryClient.invalidateQueries({ queryKey: ["notifications", "unread"] });
+        void queryClient.invalidateQueries({ queryKey: ["notifications"] });
+      })
+      .catch(() => {
+        // non-critical — ignore
+      });
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function handleMarkAllRead() {
+    try {
+      await apiFetch("/api/notifications/read", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      await queryClient.invalidateQueries({ queryKey: ["notifications", "unread"] });
+      await queryClient.invalidateQueries({ queryKey: ["notifications"] });
+    } catch {
+      // ignore
+    }
+  }
+
+  return (
+    <div style={{ background: paper.paperDeep, minHeight: "100dvh" }}>
+      <PageHeader
+        title={t("notif.page_title")}
+        right={
+          notifications.length > 0 ? (
+            <button
+              type="button"
+              onClick={handleMarkAllRead}
+              style={{
+                padding: "4px 8px",
+                fontFamily: fontMono,
+                fontSize: 9,
+                letterSpacing: 1,
+                fontWeight: 700,
+                textTransform: "uppercase",
+                background: "transparent",
+                border: `1.5px solid ${paper.paperDark}`,
+                color: paper.inkDim,
+                cursor: "pointer",
+              }}
+            >
+              {t("notif.mark_all_read")}
+            </button>
+          ) : undefined
+        }
+      />
+
+      {isLoading && (
+        <div
+          style={{
+            padding: "32px 20px",
+            fontFamily: fontMono,
+            fontSize: 11,
+            color: paper.inkDim,
+            letterSpacing: 1,
+          }}
+        >
+          {t("state.loading")}
+        </div>
+      )}
+
+      {!isLoading && notifications.length === 0 && (
+        <div
+          style={{
+            padding: "32px 20px",
+            textAlign: "center",
+            fontFamily: fontMono,
+            fontSize: 11,
+            color: paper.inkDim,
+            letterSpacing: 1,
+          }}
+        >
+          {t("notif.empty")}
+        </div>
+      )}
+
+      {!isLoading && notifications.length > 0 && (
+        <div style={{ padding: "12px 0" }}>
+          {notifications.map((n) => {
+            const href = notificationHref(n);
+            const isUnread = n.read_at === null;
+            const inner = (
+              <div
+                style={{
+                  padding: "10px 16px",
+                  borderBottom: `1px solid ${paper.paperDark}`,
+                  background: isUnread ? paper.paper : paper.paperDeep,
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "flex-start",
+                  gap: 12,
+                  opacity: isUnread ? 1 : 0.7,
+                }}
+              >
+                <div>
+                  {isUnread && (
+                    <span
+                      style={{
+                        display: "inline-block",
+                        width: 6,
+                        height: 6,
+                        borderRadius: "50%",
+                        background: paper.accent,
+                        marginRight: 6,
+                        verticalAlign: "middle",
+                        flexShrink: 0,
+                      }}
+                    />
+                  )}
+                  <span
+                    style={{
+                      fontFamily: fontSerif,
+                      fontSize: 13,
+                      color: paper.ink,
+                    }}
+                  >
+                    {n.message}
+                  </span>
+                </div>
+                <span
+                  style={{
+                    fontFamily: fontMono,
+                    fontSize: 9,
+                    color: paper.inkMute,
+                    letterSpacing: 1,
+                    flexShrink: 0,
+                    paddingTop: 2,
+                  }}
+                >
+                  {relativeTime(n.created_at)}
+                </span>
+              </div>
+            );
+
+            if (href) {
+              return (
+                <Link key={n.id} href={href} style={{ textDecoration: "none", display: "block" }}>
+                  {inner}
+                </Link>
+              );
+            }
+            return <div key={n.id}>{inner}</div>;
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/notifications/page.tsx
+++ b/app/notifications/page.tsx
@@ -31,6 +31,23 @@ export default function NotificationsPage() {
 
   const unreadCount = notifications.filter((n) => n.read_at === null).length;
 
+  // Mark a single notification read when the user opens it (fire-and-forget: the
+  // click navigates away, but the POST completes and the shared query cache —
+  // bell badge + the list on return — refreshes).
+  async function markOneRead(notificationId: number) {
+    try {
+      await apiFetch("/api/notifications/read", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ids: [notificationId] }),
+      });
+      await queryClient.invalidateQueries({ queryKey: ["notifications", "unread"] });
+      await queryClient.invalidateQueries({ queryKey: ["notifications"] });
+    } catch {
+      // ignore
+    }
+  }
+
   async function handleMarkAllRead() {
     try {
       await apiFetch("/api/notifications/read", {
@@ -166,7 +183,14 @@ export default function NotificationsPage() {
 
             if (href) {
               return (
-                <Link key={n.id} href={href} style={{ textDecoration: "none", display: "block" }}>
+                <Link
+                  key={n.id}
+                  href={href}
+                  onClick={() => {
+                    if (isUnread) void markOneRead(n.id);
+                  }}
+                  style={{ textDecoration: "none", display: "block" }}
+                >
                   {inner}
                 </Link>
               );

--- a/app/notifications/page.tsx
+++ b/app/notifications/page.tsx
@@ -29,6 +29,8 @@ export default function NotificationsPage() {
     queryFn: () => apiFetch("/api/notifications"),
   });
 
+  const unreadCount = notifications.filter((n) => n.read_at === null).length;
+
   async function handleMarkAllRead() {
     try {
       await apiFetch("/api/notifications/read", {
@@ -52,6 +54,7 @@ export default function NotificationsPage() {
             <button
               type="button"
               onClick={handleMarkAllRead}
+              disabled={unreadCount === 0}
               style={{
                 padding: "4px 8px",
                 fontFamily: fontMono,
@@ -60,12 +63,13 @@ export default function NotificationsPage() {
                 fontWeight: 700,
                 textTransform: "uppercase",
                 background: "transparent",
-                border: `1.5px solid ${paper.paperDark}`,
-                color: paper.inkDim,
-                cursor: "pointer",
+                border: `1.5px solid ${unreadCount > 0 ? paper.ink : paper.paperDark}`,
+                color: unreadCount > 0 ? paper.ink : paper.inkMute,
+                cursor: unreadCount > 0 ? "pointer" : "default",
+                opacity: unreadCount > 0 ? 1 : 0.55,
               }}
             >
-              {t("notif.mark_all_read")}
+              {unreadCount > 0 ? `${t("notif.mark_all_read")} (${unreadCount})` : t("notif.mark_all_read")}
             </button>
           ) : undefined
         }

--- a/app/trips/page.tsx
+++ b/app/trips/page.tsx
@@ -14,7 +14,7 @@ import { useCreateTrip, useDeleteTrip, useTrips, useUpdateTrip } from "@/hooks/u
 import { useCars } from "@/hooks/use-vehicles";
 import { fmtYearMonth, fontMono, paper } from "@/lib/paper-theme";
 import { canEdit } from "@/lib/permissions";
-import { Suspense } from "react";
+import { Suspense, useEffect } from "react";
 import { toast } from "sonner";
 import { TripForm } from "./trip-form";
 
@@ -30,8 +30,21 @@ function TripsContent() {
   const [mineParam, setMineParam] = useQueryParam("mine", "");
   const [carFilter, setCarFilter] = useQueryParam("car", "");
   const [yearFilter, setYearFilter] = useQueryParam("year", "");
+  const [tripParam] = useQueryParam("trip", "");
 
   const { adding, editingId, modalClosed, openAdd, openEdit, closeModal } = useEditModal();
+
+  // Deep-link from notification bell: ?trip=<id> opens the edit modal
+  useEffect(() => {
+    if (tripParam && !isLoading) {
+      const id = Number(tripParam);
+      if (id > 0) {
+        openEdit(id);
+      }
+    }
+    // Only run when tripParam changes or data loads — not on every openEdit re-render
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tripParam, isLoading]);
 
   const editing =
     !isLoading && editingId ? (trips.find((tr) => tr.id === editingId) ?? null) : null;

--- a/app/user/[id]/edit/page.tsx
+++ b/app/user/[id]/edit/page.tsx
@@ -235,28 +235,29 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
         >
           <div
             style={{
-              fontFamily: fontSerif,
-              fontSize: 14,
-              fontWeight: 700,
-              color: paper.ink,
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "baseline",
+              gap: 8,
               marginBottom: 16,
             }}
           >
-            {fullNameOf({ first_name: firstName, last_name: lastName, username: person.username })}
-          </div>
-
-          <div
-            aria-live="polite"
-            style={{
-              fontFamily: fontMono,
-              fontSize: 9,
-              letterSpacing: 1,
-              minHeight: 12,
-              marginBottom: 12,
-              color: saving ? paper.inkMute : paper.green,
-            }}
-          >
-            {saving ? t("action.saving") : saved ? t("action.saved") : ""}
+            <div style={{ fontFamily: fontSerif, fontSize: 14, fontWeight: 700, color: paper.ink }}>
+              {fullNameOf({ first_name: firstName, last_name: lastName, username: person.username })}
+            </div>
+            <div
+              aria-live="polite"
+              style={{
+                fontFamily: fontMono,
+                fontSize: 9,
+                letterSpacing: 1,
+                textTransform: "uppercase",
+                whiteSpace: "nowrap",
+                color: saving ? paper.inkMute : paper.green,
+              }}
+            >
+              {saving ? t("action.saving") : saved ? t("action.saved") : ""}
+            </div>
           </div>
 
           <form id="profile-form" onSubmit={handleSubmit}>

--- a/app/user/[id]/edit/page.tsx
+++ b/app/user/[id]/edit/page.tsx
@@ -28,7 +28,6 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
   const [saved, setSaved] = useState(false);
   const { theme: _theme, setTheme } = useTheme();
   const [themePreference, setThemePreference] = useState<Theme>("mono");
-  const [themeSaved, setThemeSaved] = useState(false);
   type NotifyPref = "off" | "all" | "own";
   const [notifyNewReservations, setNotifyNewReservations] = useState<NotifyPref>("off");
   const [notifyReservationUpdates, setNotifyReservationUpdates] = useState<NotifyPref>("off");
@@ -173,6 +172,8 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
         body: JSON.stringify({ ...patch, email: email || null }),
       });
       await queryClient.invalidateQueries({ queryKey: ["me"] });
+      setSaved(true);
+      setTimeout(() => setSaved(false), 1500);
     } catch {
       toast.error(t("toast.error"));
       // revert
@@ -198,7 +199,6 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
   async function handleThemeToggle(newTheme: Theme) {
     setThemePreference(newTheme);
     setTheme(newTheme);
-    setThemeSaved(false);
     try {
       await apiFetch(`/api/people/${id}/profile`, {
         method: "PATCH",
@@ -211,8 +211,8 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
           theme_preference: newTheme,
         }),
       });
-      setThemeSaved(true);
-      setTimeout(() => setThemeSaved(false), 1500);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 1500);
       await queryClient.invalidateQueries({ queryKey: ["me"] });
     } catch {
       toast.error(t("toast.error"));
@@ -490,19 +490,6 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
                 </button>
               ))}
             </div>
-            {themeSaved && (
-              <div
-                style={{
-                  fontFamily: fontMono,
-                  fontSize: 9,
-                  color: paper.green,
-                  marginTop: 6,
-                  letterSpacing: 1,
-                }}
-              >
-                {t("action.saved")}
-              </div>
-            )}
           </div>
 
           {/* Notification preferences */}

--- a/app/user/[id]/edit/page.tsx
+++ b/app/user/[id]/edit/page.tsx
@@ -29,6 +29,10 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
   const { theme: _theme, setTheme } = useTheme();
   const [themePreference, setThemePreference] = useState<Theme>("mono");
   const [themeSaved, setThemeSaved] = useState(false);
+  type NotifyPref = "off" | "all" | "own";
+  const [notifyNewReservations, setNotifyNewReservations] = useState<NotifyPref>("off");
+  const [notifyReservationUpdates, setNotifyReservationUpdates] = useState<NotifyPref>("off");
+  const [notifyNewTrips, setNotifyNewTrips] = useState<NotifyPref>("off");
 
   useEffect(() => {
     params.then(({ id: rawId }) => {
@@ -58,6 +62,9 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
   useEffect(() => {
     if (person) {
       setThemePreference((person.theme_preference as Theme) ?? "mono");
+      setNotifyNewReservations(person.notify_new_reservations ?? "off");
+      setNotifyReservationUpdates(person.notify_reservation_updates ?? "off");
+      setNotifyNewTrips(person.notify_new_trips ?? "off");
     }
   }, [person]);
 
@@ -103,6 +110,9 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
           last_name: lastName,
           bank_account: bankAccount,
           email: email || null,
+          notify_new_reservations: notifyNewReservations,
+          notify_reservation_updates: notifyReservationUpdates,
+          notify_new_trips: notifyNewTrips,
         }),
       });
       setSaved(true);
@@ -112,6 +122,40 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
       setError(err instanceof Error ? err.message : "Fout bij opslaan");
     } finally {
       setSaving(false);
+    }
+  }
+
+  async function handleNotifyChange(
+    field: "notify_new_reservations" | "notify_reservation_updates" | "notify_new_trips",
+    value: NotifyPref
+  ) {
+    const patch: Record<string, string> = {
+      first_name: firstName,
+      last_name: lastName,
+      bank_account: bankAccount,
+      email: email || "",
+      notify_new_reservations: notifyNewReservations,
+      notify_reservation_updates: notifyReservationUpdates,
+      notify_new_trips: notifyNewTrips,
+      [field]: value,
+    };
+    if (field === "notify_new_reservations") setNotifyNewReservations(value);
+    if (field === "notify_reservation_updates") setNotifyReservationUpdates(value);
+    if (field === "notify_new_trips") setNotifyNewTrips(value);
+    try {
+      await apiFetch(`/api/people/${id}/profile`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...patch, email: email || null }),
+      });
+      await queryClient.invalidateQueries({ queryKey: ["me"] });
+    } catch {
+      // revert
+      if (field === "notify_new_reservations")
+        setNotifyNewReservations(person!.notify_new_reservations ?? "off");
+      if (field === "notify_reservation_updates")
+        setNotifyReservationUpdates(person!.notify_reservation_updates ?? "off");
+      if (field === "notify_new_trips") setNotifyNewTrips(person!.notify_new_trips ?? "off");
     }
   }
 
@@ -445,6 +489,123 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
                 {t("action.saved")}
               </div>
             )}
+          </div>
+
+          {/* Notification preferences */}
+          <div style={{ marginTop: 20, paddingTop: 16, borderTop: `1px solid ${paper.paperDark}` }}>
+            <div
+              style={{
+                fontFamily: fontMono,
+                fontSize: 9,
+                color: paper.inkMute,
+                letterSpacing: 1,
+                marginBottom: 12,
+                textTransform: "uppercase",
+              }}
+            >
+              {t("notif.pref_section")}
+            </div>
+            {(
+              [
+                {
+                  field: "notify_new_reservations" as const,
+                  label: t("notif.pref_new_reservations"),
+                  value: notifyNewReservations,
+                },
+                {
+                  field: "notify_reservation_updates" as const,
+                  label: t("notif.pref_reservation_updates"),
+                  value: notifyReservationUpdates,
+                },
+                {
+                  field: "notify_new_trips" as const,
+                  label: t("notif.pref_new_trips"),
+                  value: notifyNewTrips,
+                },
+              ] as {
+                field:
+                  | "notify_new_reservations"
+                  | "notify_reservation_updates"
+                  | "notify_new_trips";
+                label: string;
+                value: NotifyPref;
+              }[]
+            ).map(({ field, label, value }) => {
+              const isOwner = me?.isOwner ?? false;
+              const enabled = value !== "off";
+              return (
+                <div
+                  key={field}
+                  style={{
+                    marginBottom: 12,
+                    padding: "8px 10px",
+                    background: paper.paperDark,
+                  }}
+                >
+                  <label
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 8,
+                      cursor: "pointer",
+                      fontFamily: fontMono,
+                      fontSize: 11,
+                      color: paper.ink,
+                    }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={enabled}
+                      onChange={(e) => {
+                        if (!e.target.checked) {
+                          handleNotifyChange(field, "off");
+                        } else {
+                          handleNotifyChange(field, isOwner ? "all" : "all");
+                        }
+                      }}
+                      style={{ accentColor: paper.ink }}
+                    />
+                    {label}
+                  </label>
+                  {enabled && isOwner && (
+                    <div
+                      style={{
+                        marginTop: 6,
+                        marginLeft: 20,
+                        display: "flex",
+                        gap: 16,
+                      }}
+                    >
+                      {(["all", "own"] as const).map((scope) => (
+                        <label
+                          key={scope}
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 4,
+                            fontFamily: fontMono,
+                            fontSize: 9,
+                            color: paper.inkMute,
+                            cursor: "pointer",
+                            letterSpacing: 0.5,
+                          }}
+                        >
+                          <input
+                            type="radio"
+                            name={`${field}-scope`}
+                            value={scope}
+                            checked={value === scope}
+                            onChange={() => handleNotifyChange(field, scope)}
+                            style={{ accentColor: paper.ink }}
+                          />
+                          {scope === "all" ? t("notif.pref_scope_all") : t("notif.pref_scope_own")}
+                        </label>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
           </div>
 
           {me?.personId === id && (

--- a/app/user/[id]/edit/page.tsx
+++ b/app/user/[id]/edit/page.tsx
@@ -97,8 +97,11 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
     bankAccount !== (person.bank_account ?? "") ||
     email !== (person.email ?? "");
 
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
+  // Auto-save the text fields: persist whenever a dirty field loses focus, the
+  // same immediate-save behaviour the theme and notification controls already
+  // use. No explicit Save button, no redirect.
+  async function saveProfile() {
+    if (saving) return;
     setSaving(true);
     setError(null);
     try {
@@ -115,14 +118,36 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
           notify_new_trips: notifyNewTrips,
         }),
       });
+      // Advance the local baseline so the form is no longer dirty (prevents the
+      // next blur from re-saving unchanged values).
+      setPerson((p) =>
+        p
+          ? {
+              ...p,
+              first_name: firstName,
+              last_name: lastName,
+              bank_account: bankAccount,
+              email: email || null,
+            }
+          : p
+      );
       setSaved(true);
+      setTimeout(() => setSaved(false), 1500);
       await queryClient.invalidateQueries({ queryKey: ["me"] });
-      setTimeout(() => router.push("/"), 800);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Fout bij opslaan");
     } finally {
       setSaving(false);
     }
+  }
+
+  function handleFieldBlur() {
+    if (dirty && !saving) void saveProfile();
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (dirty) await saveProfile();
   }
 
   async function handleNotifyChange(
@@ -220,6 +245,20 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
             {fullNameOf({ first_name: firstName, last_name: lastName, username: person.username })}
           </div>
 
+          <div
+            aria-live="polite"
+            style={{
+              fontFamily: fontMono,
+              fontSize: 9,
+              letterSpacing: 1,
+              minHeight: 12,
+              marginBottom: 12,
+              color: saving ? paper.inkMute : paper.green,
+            }}
+          >
+            {saving ? t("action.saving") : saved ? t("action.saved") : ""}
+          </div>
+
           <form id="profile-form" onSubmit={handleSubmit}>
             <div style={{ marginBottom: 12 }}>
               <label
@@ -275,6 +314,7 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
                   type="text"
                   value={firstName}
                   onChange={(e) => setFirstName(e.target.value)}
+                  onBlur={handleFieldBlur}
                   required
                   style={{
                     width: "100%",
@@ -308,6 +348,7 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
                   type="text"
                   value={lastName}
                   onChange={(e) => setLastName(e.target.value)}
+                  onBlur={handleFieldBlur}
                   style={{
                     width: "100%",
                     padding: "8px 10px",
@@ -342,6 +383,7 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
                 type="text"
                 value={bankAccount}
                 onChange={(e) => setBankAccount(e.target.value)}
+                onBlur={handleFieldBlur}
                 placeholder="BE00 0000 0000 0000"
                 style={{
                   width: "100%",
@@ -377,6 +419,7 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
+                onBlur={handleFieldBlur}
                 placeholder="naam@voorbeeld.be"
                 style={{
                   width: "100%",
@@ -587,29 +630,6 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
                 </div>
               );
             })}
-          </div>
-
-          <div style={{ marginTop: 20 }}>
-            <button
-              type="submit"
-              form="profile-form"
-              disabled={!dirty || saving}
-              style={{
-                width: "100%",
-                padding: "8px",
-                fontFamily: fontMono,
-                fontSize: 9,
-                fontWeight: 700,
-                letterSpacing: 2,
-                textTransform: "uppercase",
-                background: saved ? paper.green : dirty ? paper.ink : paper.paperDark,
-                color: dirty || saved ? paper.paper : paper.inkMute,
-                border: "none",
-                cursor: dirty && !saving ? "pointer" : "default",
-              }}
-            >
-              {saved ? t("action.saved") : saving ? t("action.saving") : t("action.save")}
-            </button>
           </div>
 
           {me?.personId === id && (

--- a/app/user/[id]/edit/page.tsx
+++ b/app/user/[id]/edit/page.tsx
@@ -28,10 +28,15 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
   const [saved, setSaved] = useState(false);
   const { theme: _theme, setTheme } = useTheme();
   const [themePreference, setThemePreference] = useState<Theme>("mono");
-  type NotifyPref = "off" | "all" | "own";
-  const [notifyNewReservations, setNotifyNewReservations] = useState<NotifyPref>("off");
-  const [notifyReservationUpdates, setNotifyReservationUpdates] = useState<NotifyPref>("off");
-  const [notifyNewTrips, setNotifyNewTrips] = useState<NotifyPref>("off");
+  // Driver/member prefs (all users)
+  const [notifyNewReservations, setNotifyNewReservations] = useState<"off" | "all">("off");
+  const [notifyReservationUpdates, setNotifyReservationUpdates] = useState<"off" | "all" | "mine">(
+    "mine"
+  );
+  const [notifyNewTrips, setNotifyNewTrips] = useState<"off" | "all">("off");
+  // Owner prefs (only people who own a car)
+  const [notifyMyCarReservations, setNotifyMyCarReservations] = useState<"off" | "on">("off");
+  const [notifyMyCarTrips, setNotifyMyCarTrips] = useState<"off" | "on">("off");
 
   useEffect(() => {
     params.then(({ id: rawId }) => {
@@ -61,9 +66,17 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
   useEffect(() => {
     if (person) {
       setThemePreference((person.theme_preference as Theme) ?? "mono");
-      setNotifyNewReservations(person.notify_new_reservations ?? "off");
-      setNotifyReservationUpdates(person.notify_reservation_updates ?? "off");
-      setNotifyNewTrips(person.notify_new_trips ?? "off");
+      setNotifyNewReservations(person.notify_new_reservations === "all" ? "all" : "off");
+      setNotifyReservationUpdates(
+        person.notify_reservation_updates === "all"
+          ? "all"
+          : person.notify_reservation_updates === "off"
+            ? "off"
+            : "mine"
+      );
+      setNotifyNewTrips(person.notify_new_trips === "all" ? "all" : "off");
+      setNotifyMyCarReservations(person.notify_my_car_reservations === "on" ? "on" : "off");
+      setNotifyMyCarTrips(person.notify_my_car_trips === "on" ? "on" : "off");
     }
   }, [person]);
 
@@ -114,6 +127,8 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
           notify_new_reservations: notifyNewReservations,
           notify_reservation_updates: notifyReservationUpdates,
           notify_new_trips: notifyNewTrips,
+          notify_my_car_reservations: notifyMyCarReservations,
+          notify_my_car_trips: notifyMyCarTrips,
         }),
       });
       // Advance the local baseline so the form is no longer dirty (prevents the
@@ -149,39 +164,51 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
   }
 
   async function handleNotifyChange(
-    field: "notify_new_reservations" | "notify_reservation_updates" | "notify_new_trips",
-    value: NotifyPref
+    field:
+      | "notify_new_reservations"
+      | "notify_reservation_updates"
+      | "notify_new_trips"
+      | "notify_my_car_reservations"
+      | "notify_my_car_trips",
+    value: string
   ) {
-    const patch: Record<string, string> = {
-      first_name: firstName,
-      last_name: lastName,
-      bank_account: bankAccount,
-      email: email || "",
+    const current = {
       notify_new_reservations: notifyNewReservations,
       notify_reservation_updates: notifyReservationUpdates,
       notify_new_trips: notifyNewTrips,
-      [field]: value,
+      notify_my_car_reservations: notifyMyCarReservations,
+      notify_my_car_trips: notifyMyCarTrips,
     };
-    if (field === "notify_new_reservations") setNotifyNewReservations(value);
-    if (field === "notify_reservation_updates") setNotifyReservationUpdates(value);
-    if (field === "notify_new_trips") setNotifyNewTrips(value);
+    const next = { ...current, [field]: value };
+    // Optimistic update — re-applies every value so the changed one wins.
+    setNotifyNewReservations(next.notify_new_reservations as "off" | "all");
+    setNotifyReservationUpdates(next.notify_reservation_updates as "off" | "all" | "mine");
+    setNotifyNewTrips(next.notify_new_trips as "off" | "all");
+    setNotifyMyCarReservations(next.notify_my_car_reservations as "off" | "on");
+    setNotifyMyCarTrips(next.notify_my_car_trips as "off" | "on");
     try {
       await apiFetch(`/api/people/${id}/profile`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...patch, email: email || null }),
+        body: JSON.stringify({
+          first_name: firstName,
+          last_name: lastName,
+          bank_account: bankAccount,
+          email: email || null,
+          ...next,
+        }),
       });
       await queryClient.invalidateQueries({ queryKey: ["me"] });
       setSaved(true);
       setTimeout(() => setSaved(false), 1500);
     } catch {
       toast.error(t("toast.error"));
-      // revert
-      if (field === "notify_new_reservations")
-        setNotifyNewReservations(person!.notify_new_reservations ?? "off");
-      if (field === "notify_reservation_updates")
-        setNotifyReservationUpdates(person!.notify_reservation_updates ?? "off");
-      if (field === "notify_new_trips") setNotifyNewTrips(person!.notify_new_trips ?? "off");
+      // Revert to the pre-change values.
+      setNotifyNewReservations(current.notify_new_reservations);
+      setNotifyReservationUpdates(current.notify_reservation_updates);
+      setNotifyNewTrips(current.notify_new_trips);
+      setNotifyMyCarReservations(current.notify_my_car_reservations);
+      setNotifyMyCarTrips(current.notify_my_car_trips);
     }
   }
 
@@ -221,6 +248,48 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
       setTheme(themePreference);
     }
   }
+
+  const notifySectionStyle: React.CSSProperties = {
+    fontFamily: fontMono,
+    fontSize: 9,
+    color: paper.inkMute,
+    letterSpacing: 1,
+    marginBottom: 12,
+    textTransform: "uppercase",
+  };
+  const notifyRowStyle: React.CSSProperties = {
+    marginBottom: 10,
+    padding: "8px 10px",
+    background: paper.paperDark,
+  };
+  const notifyCheckbox = (
+    key: string,
+    label: string,
+    checked: boolean,
+    onToggle: (checked: boolean) => void
+  ) => (
+    <div key={key} style={notifyRowStyle}>
+      <label
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          cursor: "pointer",
+          fontFamily: fontMono,
+          fontSize: 11,
+          color: paper.ink,
+        }}
+      >
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={(e) => onToggle(e.target.checked)}
+          style={{ accentColor: paper.ink }}
+        />
+        {label}
+      </label>
+    </div>
+  );
 
   return (
     <div style={{ background: paper.paperDeep, minHeight: "100dvh" }}>
@@ -492,122 +561,102 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
             </div>
           </div>
 
-          {/* Notification preferences */}
+          {/* Notification preferences — driver/member block (all users) */}
           <div style={{ marginTop: 20, paddingTop: 16, borderTop: `1px solid ${paper.paperDark}` }}>
-            <div
-              style={{
-                fontFamily: fontMono,
-                fontSize: 9,
-                color: paper.inkMute,
-                letterSpacing: 1,
-                marginBottom: 12,
-                textTransform: "uppercase",
-              }}
-            >
-              {t("notif.pref_section")}
-            </div>
-            {(
-              [
-                {
-                  field: "notify_new_reservations" as const,
-                  label: t("notif.pref_new_reservations"),
-                  value: notifyNewReservations,
-                },
-                {
-                  field: "notify_reservation_updates" as const,
-                  label: t("notif.pref_reservation_updates"),
-                  value: notifyReservationUpdates,
-                },
-                {
-                  field: "notify_new_trips" as const,
-                  label: t("notif.pref_new_trips"),
-                  value: notifyNewTrips,
-                },
-              ] as {
-                field:
-                  | "notify_new_reservations"
-                  | "notify_reservation_updates"
-                  | "notify_new_trips";
-                label: string;
-                value: NotifyPref;
-              }[]
-            ).map(({ field, label, value }) => {
-              const isOwner = me?.isOwner ?? false;
-              const enabled = value !== "off";
-              return (
-                <div
-                  key={field}
-                  style={{
-                    marginBottom: 12,
-                    padding: "8px 10px",
-                    background: paper.paperDark,
-                  }}
-                >
-                  <label
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: 8,
-                      cursor: "pointer",
-                      fontFamily: fontMono,
-                      fontSize: 11,
-                      color: paper.ink,
-                    }}
-                  >
-                    <input
-                      type="checkbox"
-                      checked={enabled}
-                      onChange={(e) => {
-                        if (!e.target.checked) {
-                          handleNotifyChange(field, "off");
-                        } else {
-                          handleNotifyChange(field, isOwner ? "all" : "all");
-                        }
-                      }}
-                      style={{ accentColor: paper.ink }}
-                    />
-                    {label}
-                  </label>
-                  {enabled && isOwner && (
-                    <div
+            <div style={notifySectionStyle}>{t("notif.pref_section")}</div>
+
+            {notifyCheckbox(
+              "new_reservations",
+              t("notif.pref_new_reservations"),
+              notifyNewReservations === "all",
+              (c) => handleNotifyChange("notify_new_reservations", c ? "all" : "off")
+            )}
+
+            {/* Reservation updates: unchecking turns off ALL update notifications
+                (not even your own outcome). Checked reveals the all/mine choice. */}
+            <div style={notifyRowStyle}>
+              <label
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  cursor: "pointer",
+                  fontFamily: fontMono,
+                  fontSize: 11,
+                  color: paper.ink,
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={notifyReservationUpdates !== "off"}
+                  onChange={(e) =>
+                    handleNotifyChange(
+                      "notify_reservation_updates",
+                      e.target.checked ? "mine" : "off"
+                    )
+                  }
+                  style={{ accentColor: paper.ink }}
+                />
+                {t("notif.pref_reservation_updates")}
+              </label>
+              {notifyReservationUpdates !== "off" && (
+                <div style={{ display: "flex", gap: 16, marginTop: 8, marginLeft: 24 }}>
+                  {(["all", "mine"] as const).map((scope) => (
+                    <label
+                      key={scope}
                       style={{
-                        marginTop: 6,
-                        marginLeft: 20,
                         display: "flex",
-                        gap: 16,
+                        alignItems: "center",
+                        gap: 4,
+                        fontFamily: fontMono,
+                        fontSize: 10,
+                        color: paper.ink,
+                        cursor: "pointer",
                       }}
                     >
-                      {(["all", "own"] as const).map((scope) => (
-                        <label
-                          key={scope}
-                          style={{
-                            display: "flex",
-                            alignItems: "center",
-                            gap: 4,
-                            fontFamily: fontMono,
-                            fontSize: 9,
-                            color: paper.inkMute,
-                            cursor: "pointer",
-                            letterSpacing: 0.5,
-                          }}
-                        >
-                          <input
-                            type="radio"
-                            name={`${field}-scope`}
-                            value={scope}
-                            checked={value === scope}
-                            onChange={() => handleNotifyChange(field, scope)}
-                            style={{ accentColor: paper.ink }}
-                          />
-                          {scope === "all" ? t("notif.pref_scope_all") : t("notif.pref_scope_own")}
-                        </label>
-                      ))}
-                    </div>
-                  )}
+                      <input
+                        type="radio"
+                        name="reservation-updates-scope"
+                        value={scope}
+                        checked={notifyReservationUpdates === scope}
+                        onChange={() => handleNotifyChange("notify_reservation_updates", scope)}
+                        style={{ accentColor: paper.ink }}
+                      />
+                      {scope === "all" ? t("notif.pref_updates_all") : t("notif.pref_updates_mine")}
+                    </label>
+                  ))}
                 </div>
-              );
-            })}
+              )}
+            </div>
+
+            {notifyCheckbox(
+              "new_trips",
+              t("notif.pref_new_trips"),
+              notifyNewTrips === "all",
+              (c) => handleNotifyChange("notify_new_trips", c ? "all" : "off")
+            )}
           </div>
+
+          {/* Owner block — only shown to people who own a car */}
+          {me?.isOwner && (
+            <div
+              style={{ marginTop: 20, paddingTop: 16, borderTop: `1px solid ${paper.paperDark}` }}
+            >
+              <div style={notifySectionStyle}>{t("notif.pref_section_owner")}</div>
+              {notifyCheckbox(
+                "my_car_reservations",
+                t("notif.pref_my_car_reservations"),
+                notifyMyCarReservations === "on",
+                (c) => handleNotifyChange("notify_my_car_reservations", c ? "on" : "off")
+              )}
+              {notifyCheckbox(
+                "my_car_trips",
+                t("notif.pref_my_car_trips"),
+                notifyMyCarTrips === "on",
+                (c) => handleNotifyChange("notify_my_car_trips", c ? "on" : "off")
+              )}
+            </div>
+          )}
 
           {me?.personId === id && (
             <div

--- a/app/user/[id]/edit/page.tsx
+++ b/app/user/[id]/edit/page.tsx
@@ -9,6 +9,7 @@ import { useTheme, type Theme } from "@/lib/theme-context";
 import type { Person } from "@/types";
 import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 import { useEffect, useState } from "react";
 
 export default function EditProfilePage({ params }: { params: Promise<{ id: string }> }) {
@@ -24,7 +25,6 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
   const [bankAccount, setBankAccount] = useState("");
   const [email, setEmail] = useState("");
   const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
   const { theme: _theme, setTheme } = useTheme();
   const [themePreference, setThemePreference] = useState<Theme>("mono");
@@ -103,7 +103,6 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
   async function saveProfile() {
     if (saving) return;
     setSaving(true);
-    setError(null);
     try {
       await apiFetch(`/api/people/${id}/profile`, {
         method: "PATCH",
@@ -135,7 +134,7 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
       setTimeout(() => setSaved(false), 1500);
       await queryClient.invalidateQueries({ queryKey: ["me"] });
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "Fout bij opslaan");
+      toast.error(err instanceof Error ? err.message : t("toast.error"));
     } finally {
       setSaving(false);
     }
@@ -175,6 +174,7 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
       });
       await queryClient.invalidateQueries({ queryKey: ["me"] });
     } catch {
+      toast.error(t("toast.error"));
       // revert
       if (field === "notify_new_reservations")
         setNotifyNewReservations(person!.notify_new_reservations ?? "off");
@@ -215,6 +215,7 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
       setTimeout(() => setThemeSaved(false), 1500);
       await queryClient.invalidateQueries({ queryKey: ["me"] });
     } catch {
+      toast.error(t("toast.error"));
       // revert local
       setThemePreference(themePreference);
       setTheme(themePreference);
@@ -449,18 +450,6 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
               </p>
             </div>
 
-            {error && (
-              <div
-                style={{
-                  fontFamily: fontMono,
-                  fontSize: 10,
-                  color: paper.accent,
-                  marginBottom: 10,
-                }}
-              >
-                {error}
-              </div>
-            )}
 
           </form>
 

--- a/app/user/[id]/edit/page.tsx
+++ b/app/user/[id]/edit/page.tsx
@@ -220,7 +220,7 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
             {fullNameOf({ first_name: firstName, last_name: lastName, username: person.username })}
           </div>
 
-          <form onSubmit={handleSubmit}>
+          <form id="profile-form" onSubmit={handleSubmit}>
             <div style={{ marginBottom: 12 }}>
               <label
                 htmlFor="edit-username"
@@ -418,25 +418,6 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
               </div>
             )}
 
-            <button
-              type="submit"
-              disabled={!dirty || saving}
-              style={{
-                width: "100%",
-                padding: "8px",
-                fontFamily: fontMono,
-                fontSize: 9,
-                fontWeight: 700,
-                letterSpacing: 2,
-                textTransform: "uppercase",
-                background: saved ? paper.green : dirty ? paper.ink : paper.paperDark,
-                color: dirty || saved ? paper.paper : paper.inkMute,
-                border: "none",
-                cursor: dirty && !saving ? "pointer" : "default",
-              }}
-            >
-              {saved ? t("action.saved") : saving ? t("action.saving") : t("action.save")}
-            </button>
           </form>
 
           <div style={{ marginTop: 20, paddingTop: 16, borderTop: `1px solid ${paper.paperDark}` }}>
@@ -606,6 +587,29 @@ export default function EditProfilePage({ params }: { params: Promise<{ id: stri
                 </div>
               );
             })}
+          </div>
+
+          <div style={{ marginTop: 20 }}>
+            <button
+              type="submit"
+              form="profile-form"
+              disabled={!dirty || saving}
+              style={{
+                width: "100%",
+                padding: "8px",
+                fontFamily: fontMono,
+                fontSize: 9,
+                fontWeight: 700,
+                letterSpacing: 2,
+                textTransform: "uppercase",
+                background: saved ? paper.green : dirty ? paper.ink : paper.paperDark,
+                color: dirty || saved ? paper.paper : paper.inkMute,
+                border: "none",
+                cursor: dirty && !saving ? "pointer" : "default",
+              }}
+            >
+              {saved ? t("action.saved") : saving ? t("action.saving") : t("action.save")}
+            </button>
           </div>
 
           {me?.personId === id && (

--- a/components/notification-bell.tsx
+++ b/components/notification-bell.tsx
@@ -1,0 +1,62 @@
+"use client";
+import { useT } from "@/components/locale-provider";
+import { apiFetch } from "@/lib/api/client";
+import { fontMono, paper } from "@/lib/paper-theme";
+import { useQuery } from "@tanstack/react-query";
+import { Bell } from "lucide-react";
+import Link from "next/link";
+
+export function NotificationBell() {
+  const t = useT();
+  const { data } = useQuery<{ count: number }>({
+    queryKey: ["notifications", "unread"],
+    queryFn: () => apiFetch("/api/notifications/unread-count"),
+    refetchInterval: 60_000,
+    refetchOnWindowFocus: true,
+  });
+
+  const count = data?.count ?? 0;
+
+  return (
+    <Link
+      href="/notifications"
+      title={count > 0 ? t("notif.unread_badge").replace("{count}", String(count)) : t("notif.page_title")}
+      aria-label={count > 0 ? t("notif.unread_badge").replace("{count}", String(count)) : t("notif.page_title")}
+      style={{
+        position: "relative",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: "4px 7px",
+        color: count > 0 ? paper.ink : paper.inkDim,
+        textDecoration: "none",
+      }}
+    >
+      <Bell size={15} strokeWidth={1.75} />
+      {count > 0 && (
+        <span
+          style={{
+            position: "absolute",
+            top: 0,
+            right: 0,
+            minWidth: 14,
+            height: 14,
+            borderRadius: "50%",
+            background: paper.accent,
+            color: "white",
+            fontFamily: fontMono,
+            fontSize: 8,
+            fontWeight: 700,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: "0 2px",
+            lineHeight: 1,
+          }}
+        >
+          {count > 99 ? "99+" : count}
+        </span>
+      )}
+    </Link>
+  );
+}

--- a/components/page-header.tsx
+++ b/components/page-header.tsx
@@ -6,6 +6,7 @@ import pkg from "@/package.json";
 import { Power } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { LangSwitcher } from "./lang-switcher";
+import { NotificationBell } from "./notification-bell";
 import { OfflineBadge } from "./offline-badge";
 
 const version = pkg.version;
@@ -83,6 +84,7 @@ export function PageHeader({ title, subtitle, right, titleSize = 26 }: Props) {
         >
           <OfflineBadge />
           {right}
+          <NotificationBell />
           <LangSwitcher />
           <button
             onClick={handleLogout}

--- a/e2e/notifications.spec.ts
+++ b/e2e/notifications.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect, request as playwrightRequest } from "@playwright/test";
+import { loginAndGetSession, makeApi, scrollToLoadAll } from "./helpers";
+
+const baseURL = process.env.TEST_BASE_URL ?? "http://localhost:3000";
+
+/**
+ * In-app notifications (#358).
+ *
+ * Alice opts in to "new reservations (all cars)". Bob (a different non-admin
+ * user) creates a reservation → Alice gets an in-app notification: unread count
+ * rises, the /notifications page lists it, clicking deep-links to the
+ * reservation on /calendar, and viewing the page clears the unread count.
+ */
+test.describe("in-app notifications (#358)", () => {
+  test("opted-in user is notified of another user's new reservation", async ({ page, request }) => {
+    // Alice opts in to all new reservations (via her own profile).
+    const alice = await loginAndGetSession(request, "alice", "alice");
+    test.skip(alice.personId == null, "needs seeded alice");
+    const aliceApi = makeApi(request, alice.csrf);
+    await aliceApi.patch(`/api/people/${alice.personId}/profile`, {
+      first_name: "Alice",
+      notify_new_reservations: "all",
+    });
+    // Clear any pre-existing unread for a deterministic count.
+    await aliceApi.post("/api/notifications/read", {});
+
+    // Bob (a different non-admin actor, own cookie jar) creates a reservation.
+    const bobCtx = await playwrightRequest.newContext({ baseURL });
+    const bob = await loginAndGetSession(bobCtx, "bob", "bob");
+    const bobApi = makeApi(bobCtx, bob.csrf);
+    const cars = await bobApi.get<Array<{ id: number }>>("/api/vehicles");
+    const day = futureDate(30);
+    const resv = await bobApi.post<{ id: number }>("/api/reservations", {
+      person_id: bob.personId,
+      car_id: cars[0].id,
+      start_date: day,
+      end_date: day,
+      note: "E2E-notif-resv",
+    });
+
+    // Alice now has exactly one unread notification for that reservation.
+    await expect
+      .poll(
+        async () =>
+          (await aliceApi.get<{ count: number }>("/api/notifications/unread-count")).count,
+        { timeout: 10_000 }
+      )
+      .toBe(1);
+    const list = await aliceApi.get<Array<{ entity_type: string; entity_id: number }>>(
+      "/api/notifications"
+    );
+    expect(list[0]).toMatchObject({ entity_type: "reservation", entity_id: resv.id });
+
+    // Browser: the notifications page lists it; clicking deep-links to /calendar.
+    await page.request.post("/api/auth/login", { data: { username: "alice", password: "alice" } });
+    // Warm the session (loads the app → /api/me sets the csrf-token cookie), the
+    // way a real user reaches /notifications from inside the app via the bell.
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await page.goto("/notifications");
+    await page.waitForLoadState("networkidle");
+    await scrollToLoadAll(page);
+    const row = page.getByRole("link").filter({ hasText: /reserv/i }).first();
+    await expect(row).toBeVisible({ timeout: 10_000 });
+
+    // Viewing /notifications marks everything read (assert before navigating away,
+    // so we don't race the mark-read-on-mount against the row click).
+    await expect
+      .poll(
+        async () =>
+          (await aliceApi.get<{ count: number }>("/api/notifications/unread-count")).count,
+        { timeout: 10_000 }
+      )
+      .toBe(0);
+
+    // Clicking the notification deep-links to the reservation on the calendar.
+    await row.click();
+    await page.waitForURL(new RegExp(`/calendar\\?reservation=${resv.id}`));
+
+    await bobCtx.dispose();
+  });
+});
+
+function futureDate(daysAhead: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + daysAhead);
+  return d.toISOString().slice(0, 10);
+}

--- a/e2e/notifications.spec.ts
+++ b/e2e/notifications.spec.ts
@@ -62,9 +62,13 @@ test.describe("in-app notifications (#358)", () => {
     await scrollToLoadAll(page);
     const row = page.getByRole("link").filter({ hasText: /reserv/i }).first();
     await expect(row).toBeVisible({ timeout: 10_000 });
+    // Still unread on view (no auto-mark) — the unread count holds.
+    expect(
+      (await aliceApi.get<{ count: number }>("/api/notifications/unread-count")).count
+    ).toBe(1);
 
-    // Viewing /notifications marks everything read (assert before navigating away,
-    // so we don't race the mark-read-on-mount against the row click).
+    // The "mark all read" button clears the unread count.
+    await page.getByRole("button", { name: "Alles gelezen" }).click();
     await expect
       .poll(
         async () =>
@@ -73,7 +77,7 @@ test.describe("in-app notifications (#358)", () => {
       )
       .toBe(0);
 
-    // Clicking the notification deep-links to the reservation on the calendar.
+    // Clicking the notification still deep-links to the reservation on the calendar.
     await row.click();
     await page.waitForURL(new RegExp(`/calendar\\?reservation=${resv.id}`));
 

--- a/e2e/notifications.spec.ts
+++ b/e2e/notifications.spec.ts
@@ -83,6 +83,60 @@ test.describe("in-app notifications (#358)", () => {
 
     await bobCtx.dispose();
   });
+
+  test("opening a notification marks just that one read", async ({ page, request }) => {
+    const alice = await loginAndGetSession(request, "alice", "alice");
+    test.skip(alice.personId == null, "needs seeded alice");
+    const aliceApi = makeApi(request, alice.csrf);
+    await aliceApi.patch(`/api/people/${alice.personId}/profile`, {
+      first_name: "Alice",
+      notify_new_reservations: "all",
+    });
+    await aliceApi.post("/api/notifications/read", {}); // baseline clear
+
+    const bobCtx = await playwrightRequest.newContext({ baseURL });
+    const bob = await loginAndGetSession(bobCtx, "bob", "bob");
+    const bobApi = makeApi(bobCtx, bob.csrf);
+    const cars = await bobApi.get<Array<{ id: number }>>("/api/vehicles");
+    const resv = await bobApi.post<{ id: number }>("/api/reservations", {
+      person_id: bob.personId,
+      car_id: cars[0].id,
+      start_date: futureDate(45),
+      end_date: futureDate(45),
+      note: "E2E-notif-click",
+    });
+
+    await expect
+      .poll(
+        async () =>
+          (await aliceApi.get<{ count: number }>("/api/notifications/unread-count")).count,
+        { timeout: 10_000 }
+      )
+      .toBe(1);
+
+    await page.request.post("/api/auth/login", { data: { username: "alice", password: "alice" } });
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await page.goto("/notifications");
+    await page.waitForLoadState("networkidle");
+    await scrollToLoadAll(page);
+
+    // Clicking the notification deep-links AND marks just that one read.
+    const row = page.getByRole("link").filter({ hasText: /reserv/i }).first();
+    await expect(row).toBeVisible({ timeout: 10_000 });
+    await row.click();
+    await page.waitForURL(new RegExp(`/calendar\\?reservation=${resv.id}`));
+
+    await expect
+      .poll(
+        async () =>
+          (await aliceApi.get<{ count: number }>("/api/notifications/unread-count")).count,
+        { timeout: 10_000 }
+      )
+      .toBe(0);
+
+    await bobCtx.dispose();
+  });
 });
 
 function futureDate(daysAhead: number): string {

--- a/lib/__tests__/db.test.ts
+++ b/lib/__tests__/db.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { runMigrations } from "../db/migrate";
 
 describe("runMigrations", () => {
-  it("creates all 14 tables", () => {
+  it("creates all 15 tables", () => {
     const db = new Database(":memory:");
     runMigrations(db);
     const tables = db
@@ -21,6 +21,7 @@ describe("runMigrations", () => {
       "expenses",
       "fuel_fillups",
       "invite_tokens",
+      "notifications",
       "payments",
       "people",
       "reservations",

--- a/lib/__tests__/migration_0004.test.ts
+++ b/lib/__tests__/migration_0004.test.ts
@@ -46,6 +46,7 @@ describe("migration 0004 — car owner era", () => {
       INSERT INTO _migrations (filename) VALUES ('0023_expenses_receipt.sql');
       INSERT INTO _migrations (filename) VALUES ('0024_calendar_sync_log.sql');
       INSERT INTO _migrations (filename) VALUES ('0025_reservation_times.sql');
+      INSERT INTO _migrations (filename) VALUES ('0026_notifications.sql');
     `);
     runMigrations(db2);
     const car = db2.prepare("SELECT owner_from FROM cars WHERE short = 'XX'").get() as {

--- a/lib/__tests__/migration_0004.test.ts
+++ b/lib/__tests__/migration_0004.test.ts
@@ -47,6 +47,7 @@ describe("migration 0004 — car owner era", () => {
       INSERT INTO _migrations (filename) VALUES ('0024_calendar_sync_log.sql');
       INSERT INTO _migrations (filename) VALUES ('0025_reservation_times.sql');
       INSERT INTO _migrations (filename) VALUES ('0026_notifications.sql');
+      INSERT INTO _migrations (filename) VALUES ('0027_owner_notify_prefs.sql');
     `);
     runMigrations(db2);
     const car = db2.prepare("SELECT owner_from FROM cars WHERE short = 'XX'").get() as {

--- a/lib/__tests__/migration_forward.test.ts
+++ b/lib/__tests__/migration_forward.test.ts
@@ -17,7 +17,7 @@ import Database from "better-sqlite3";
 import { describe, expect, it } from "vitest";
 import { runMigrations } from "../db/migrate";
 
-// All 22 migration filenames in order
+// All migration filenames in order
 const ALL_MIGRATIONS = [
   "0001_initial_schema.sql",
   "0002_data_corrections_trips.sql",
@@ -44,6 +44,7 @@ const ALL_MIGRATIONS = [
   "0023_expenses_receipt.sql",
   "0024_calendar_sync_log.sql",
   "0025_reservation_times.sql",
+  "0026_notifications.sql",
 ];
 
 const LATER_MIGRATIONS = ALL_MIGRATIONS.slice(10); // 0011–0022
@@ -201,7 +202,7 @@ describe("forward migration — 0001–0010 → 0011–0022", () => {
       .prepare("SELECT filename FROM _migrations ORDER BY filename")
       .pluck()
       .all() as string[];
-    expect(applied).toHaveLength(25);
+    expect(applied).toHaveLength(26);
     for (const f of ALL_MIGRATIONS) {
       expect(applied).toContain(f);
     }
@@ -212,6 +213,6 @@ describe("forward migration — 0001–0010 → 0011–0022", () => {
       .prepare("SELECT filename FROM _migrations ORDER BY filename")
       .pluck()
       .all() as string[];
-    expect(appliedAfter).toHaveLength(25);
+    expect(appliedAfter).toHaveLength(26);
   });
 });

--- a/lib/__tests__/migration_forward.test.ts
+++ b/lib/__tests__/migration_forward.test.ts
@@ -45,6 +45,7 @@ const ALL_MIGRATIONS = [
   "0024_calendar_sync_log.sql",
   "0025_reservation_times.sql",
   "0026_notifications.sql",
+  "0027_owner_notify_prefs.sql",
 ];
 
 const LATER_MIGRATIONS = ALL_MIGRATIONS.slice(10); // 0011–0022
@@ -202,7 +203,7 @@ describe("forward migration — 0001–0010 → 0011–0022", () => {
       .prepare("SELECT filename FROM _migrations ORDER BY filename")
       .pluck()
       .all() as string[];
-    expect(applied).toHaveLength(26);
+    expect(applied).toHaveLength(27);
     for (const f of ALL_MIGRATIONS) {
       expect(applied).toContain(f);
     }
@@ -213,6 +214,6 @@ describe("forward migration — 0001–0010 → 0011–0022", () => {
       .prepare("SELECT filename FROM _migrations ORDER BY filename")
       .pluck()
       .all() as string[];
-    expect(appliedAfter).toHaveLength(26);
+    expect(appliedAfter).toHaveLength(27);
   });
 });

--- a/lib/__tests__/notification-href.test.ts
+++ b/lib/__tests__/notification-href.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { notificationHref } from "../notification-href";
+
+describe("notificationHref", () => {
+  it("returns /calendar?reservation=<id> for entity_type 'reservation'", () => {
+    expect(notificationHref({ entity_type: "reservation", entity_id: 42 })).toBe(
+      "/calendar?reservation=42"
+    );
+  });
+
+  it("returns /trips?trip=<id> for entity_type 'trip'", () => {
+    expect(notificationHref({ entity_type: "trip", entity_id: 7 })).toBe("/trips?trip=7");
+  });
+
+  it("returns empty string for unknown entity_type", () => {
+    expect(notificationHref({ entity_type: "fuel", entity_id: 1 })).toBe("");
+  });
+
+  it("returns empty string for empty entity_type", () => {
+    expect(notificationHref({ entity_type: "", entity_id: 1 })).toBe("");
+  });
+
+  it("uses the correct entity_id", () => {
+    expect(notificationHref({ entity_type: "reservation", entity_id: 100 })).toBe(
+      "/calendar?reservation=100"
+    );
+    expect(notificationHref({ entity_type: "trip", entity_id: 999 })).toBe("/trips?trip=999");
+  });
+});

--- a/lib/__tests__/notifications_queries.test.ts
+++ b/lib/__tests__/notifications_queries.test.ts
@@ -1,0 +1,353 @@
+// lib/__tests__/notifications_queries.test.ts
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+import { runMigrations } from "../db/migrate";
+import { insertPerson, updatePerson } from "../queries/people";
+import {
+  insertNotification,
+  listNotifications,
+  markRead,
+  unreadCount,
+} from "../queries/notifications";
+
+function makeDb() {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  runMigrations(db);
+  return db;
+}
+
+const basePerson = {
+  first_name: "",
+  last_name: "",
+  discount: 0,
+  discount_long: 0,
+  active: 1 as const,
+  username: null,
+  password_hash: null,
+  is_admin: 0 as const,
+  bank_account: "",
+  email: null,
+  theme_preference: "mono" as const,
+};
+
+describe("insertNotification", () => {
+  it("returns a numeric id", () => {
+    const db = makeDb();
+    const aliceId = insertPerson(db, { ...basePerson, first_name: "Alice" });
+    const id = insertNotification(db, {
+      recipientPersonId: aliceId,
+      type: "new_reservation",
+      entityType: "reservation",
+      entityId: 1,
+      message: "A new reservation was made",
+    });
+    expect(typeof id).toBe("number");
+    expect(id).toBeGreaterThan(0);
+  });
+
+  it("stores the notification with correct fields", () => {
+    const db = makeDb();
+    const aliceId = insertPerson(db, { ...basePerson, first_name: "Alice" });
+    const id = insertNotification(db, {
+      recipientPersonId: aliceId,
+      type: "new_reservation",
+      entityType: "reservation",
+      entityId: 42,
+      message: "Car AA was reserved",
+    });
+    const row = db.prepare("SELECT * FROM notifications WHERE id=?").get(id) as any;
+    expect(row.recipient_person_id).toBe(aliceId);
+    expect(row.type).toBe("new_reservation");
+    expect(row.entity_type).toBe("reservation");
+    expect(row.entity_id).toBe(42);
+    expect(row.message).toBe("Car AA was reserved");
+    expect(row.read_at).toBeNull();
+    expect(typeof row.created_at).toBe("string");
+  });
+});
+
+describe("listNotifications", () => {
+  it("returns empty array when no notifications", () => {
+    const db = makeDb();
+    const aliceId = insertPerson(db, { ...basePerson, first_name: "Alice" });
+    expect(listNotifications(db, aliceId)).toEqual([]);
+  });
+
+  it("returns newest-first for a single recipient", () => {
+    const db = makeDb();
+    const aliceId = insertPerson(db, { ...basePerson, first_name: "Alice" });
+
+    insertNotification(db, {
+      recipientPersonId: aliceId,
+      type: "new_reservation",
+      entityType: "reservation",
+      entityId: 1,
+      message: "First",
+    });
+    insertNotification(db, {
+      recipientPersonId: aliceId,
+      type: "new_reservation",
+      entityType: "reservation",
+      entityId: 2,
+      message: "Second",
+    });
+    insertNotification(db, {
+      recipientPersonId: aliceId,
+      type: "new_trip",
+      entityType: "trip",
+      entityId: 3,
+      message: "Third",
+    });
+
+    const list = listNotifications(db, aliceId);
+    expect(list).toHaveLength(3);
+    expect(list[0].message).toBe("Third");
+    expect(list[1].message).toBe("Second");
+    expect(list[2].message).toBe("First");
+  });
+
+  it("recipient scoping: Alice never sees Bob's notifications", () => {
+    const db = makeDb();
+    const aliceId = insertPerson(db, { ...basePerson, first_name: "Alice" });
+    const bobId = insertPerson(db, { ...basePerson, first_name: "Bob" });
+
+    insertNotification(db, {
+      recipientPersonId: aliceId,
+      type: "new_reservation",
+      entityType: "reservation",
+      entityId: 1,
+      message: "Alice's notification",
+    });
+    insertNotification(db, {
+      recipientPersonId: bobId,
+      type: "new_trip",
+      entityType: "trip",
+      entityId: 2,
+      message: "Bob's notification",
+    });
+
+    const aliceList = listNotifications(db, aliceId);
+    expect(aliceList).toHaveLength(1);
+    expect(aliceList[0].message).toBe("Alice's notification");
+
+    const bobList = listNotifications(db, bobId);
+    expect(bobList).toHaveLength(1);
+    expect(bobList[0].message).toBe("Bob's notification");
+  });
+
+  it("respects the limit parameter", () => {
+    const db = makeDb();
+    const aliceId = insertPerson(db, { ...basePerson, first_name: "Alice" });
+    for (let i = 1; i <= 10; i++) {
+      insertNotification(db, {
+        recipientPersonId: aliceId,
+        type: "new_trip",
+        entityType: "trip",
+        entityId: i,
+        message: `Notification ${i}`,
+      });
+    }
+    const limited = listNotifications(db, aliceId, 3);
+    expect(limited).toHaveLength(3);
+  });
+
+  it("default limit is 50", () => {
+    const db = makeDb();
+    const aliceId = insertPerson(db, { ...basePerson, first_name: "Alice" });
+    for (let i = 1; i <= 60; i++) {
+      insertNotification(db, {
+        recipientPersonId: aliceId,
+        type: "new_trip",
+        entityType: "trip",
+        entityId: i,
+        message: `Notification ${i}`,
+      });
+    }
+    const all = listNotifications(db, aliceId);
+    expect(all).toHaveLength(50);
+  });
+});
+
+describe("unreadCount", () => {
+  it("returns 0 when no notifications", () => {
+    const db = makeDb();
+    const aliceId = insertPerson(db, { ...basePerson, first_name: "Alice" });
+    expect(unreadCount(db, aliceId)).toBe(0);
+  });
+
+  it("counts only unread notifications", () => {
+    const db = makeDb();
+    const aliceId = insertPerson(db, { ...basePerson, first_name: "Alice" });
+
+    const id1 = insertNotification(db, {
+      recipientPersonId: aliceId,
+      type: "new_reservation",
+      entityType: "reservation",
+      entityId: 1,
+      message: "First (will be read)",
+    });
+    insertNotification(db, {
+      recipientPersonId: aliceId,
+      type: "new_reservation",
+      entityType: "reservation",
+      entityId: 2,
+      message: "Second (unread)",
+    });
+
+    // Mark the first one as read
+    db.prepare("UPDATE notifications SET read_at=datetime('now') WHERE id=?").run(id1);
+
+    expect(unreadCount(db, aliceId)).toBe(1);
+  });
+
+  it("recipient scoping: Bob's unread don't affect Alice's count", () => {
+    const db = makeDb();
+    const aliceId = insertPerson(db, { ...basePerson, first_name: "Alice" });
+    const bobId = insertPerson(db, { ...basePerson, first_name: "Bob" });
+
+    insertNotification(db, {
+      recipientPersonId: aliceId,
+      type: "new_trip",
+      entityType: "trip",
+      entityId: 1,
+      message: "Alice's notification",
+    });
+    insertNotification(db, {
+      recipientPersonId: bobId,
+      type: "new_trip",
+      entityType: "trip",
+      entityId: 2,
+      message: "Bob's notification",
+    });
+    insertNotification(db, {
+      recipientPersonId: bobId,
+      type: "new_trip",
+      entityType: "trip",
+      entityId: 3,
+      message: "Bob's second notification",
+    });
+
+    expect(unreadCount(db, aliceId)).toBe(1);
+    expect(unreadCount(db, bobId)).toBe(2);
+  });
+});
+
+describe("markRead", () => {
+  it("marks all unread notifications when no ids supplied", () => {
+    const db = makeDb();
+    const aliceId = insertPerson(db, { ...basePerson, first_name: "Alice" });
+
+    insertNotification(db, {
+      recipientPersonId: aliceId,
+      type: "new_reservation",
+      entityType: "reservation",
+      entityId: 1,
+      message: "First",
+    });
+    insertNotification(db, {
+      recipientPersonId: aliceId,
+      type: "new_reservation",
+      entityType: "reservation",
+      entityId: 2,
+      message: "Second",
+    });
+
+    expect(unreadCount(db, aliceId)).toBe(2);
+    markRead(db, aliceId);
+    expect(unreadCount(db, aliceId)).toBe(0);
+  });
+
+  it("marks only specific ids when ids are supplied", () => {
+    const db = makeDb();
+    const aliceId = insertPerson(db, { ...basePerson, first_name: "Alice" });
+
+    const id1 = insertNotification(db, {
+      recipientPersonId: aliceId,
+      type: "new_reservation",
+      entityType: "reservation",
+      entityId: 1,
+      message: "First",
+    });
+    insertNotification(db, {
+      recipientPersonId: aliceId,
+      type: "new_reservation",
+      entityType: "reservation",
+      entityId: 2,
+      message: "Second",
+    });
+
+    markRead(db, aliceId, [id1]);
+    expect(unreadCount(db, aliceId)).toBe(1);
+  });
+
+  it("recipient-scoped: markRead all for Alice does not read Bob's notifications", () => {
+    const db = makeDb();
+    const aliceId = insertPerson(db, { ...basePerson, first_name: "Alice" });
+    const bobId = insertPerson(db, { ...basePerson, first_name: "Bob" });
+
+    insertNotification(db, {
+      recipientPersonId: aliceId,
+      type: "new_trip",
+      entityType: "trip",
+      entityId: 1,
+      message: "Alice's notification",
+    });
+    insertNotification(db, {
+      recipientPersonId: bobId,
+      type: "new_trip",
+      entityType: "trip",
+      entityId: 2,
+      message: "Bob's notification",
+    });
+
+    markRead(db, aliceId);
+    expect(unreadCount(db, aliceId)).toBe(0);
+    expect(unreadCount(db, bobId)).toBe(1);
+  });
+
+  it("recipient-scoped: Alice cannot mark Bob's specific notification as read", () => {
+    const db = makeDb();
+    const aliceId = insertPerson(db, { ...basePerson, first_name: "Alice" });
+    const bobId = insertPerson(db, { ...basePerson, first_name: "Bob" });
+
+    const bobNotifId = insertNotification(db, {
+      recipientPersonId: bobId,
+      type: "new_trip",
+      entityType: "trip",
+      entityId: 1,
+      message: "Bob's notification",
+    });
+
+    // Alice tries to mark Bob's notification as read — should be a no-op
+    markRead(db, aliceId, [bobNotifId]);
+    expect(unreadCount(db, bobId)).toBe(1);
+  });
+});
+
+describe("person notify preference columns", () => {
+  it("returns default 'off' values for new person", () => {
+    const db = makeDb();
+    const aliceId = insertPerson(db, { ...basePerson, first_name: "Alice" });
+    const row = db.prepare("SELECT * FROM people WHERE id=?").get(aliceId) as any;
+    expect(row.notify_new_reservations).toBe("off");
+    expect(row.notify_reservation_updates).toBe("off");
+    expect(row.notify_new_trips).toBe("off");
+  });
+
+  it("updatePerson persists notify preference columns", () => {
+    const db = makeDb();
+    const aliceId = insertPerson(db, { ...basePerson, first_name: "Alice" });
+    const row = db.prepare("SELECT * FROM people WHERE id=?").get(aliceId) as any;
+    updatePerson(db, aliceId, {
+      ...row,
+      notify_new_reservations: "all",
+      notify_reservation_updates: "own",
+      notify_new_trips: "all",
+    });
+    const updated = db.prepare("SELECT * FROM people WHERE id=?").get(aliceId) as any;
+    expect(updated.notify_new_reservations).toBe("all");
+    expect(updated.notify_reservation_updates).toBe("own");
+    expect(updated.notify_new_trips).toBe("all");
+  });
+});

--- a/lib/__tests__/notifications_queries.test.ts
+++ b/lib/__tests__/notifications_queries.test.ts
@@ -326,13 +326,17 @@ describe("markRead", () => {
 });
 
 describe("person notify preference columns", () => {
-  it("returns default 'off' values for new person", () => {
+  it("returns default opt-out values for new person", () => {
     const db = makeDb();
     const aliceId = insertPerson(db, { ...basePerson, first_name: "Alice" });
     const row = db.prepare("SELECT * FROM people WHERE id=?").get(aliceId) as any;
     expect(row.notify_new_reservations).toBe("off");
-    expect(row.notify_reservation_updates).toBe("off");
+    // Reservation updates default to 'mine': your own outcome is always sent,
+    // but you don't see other people's updates unless you opt in.
+    expect(row.notify_reservation_updates).toBe("mine");
     expect(row.notify_new_trips).toBe("off");
+    expect(row.notify_my_car_reservations).toBe("off");
+    expect(row.notify_my_car_trips).toBe("off");
   });
 
   it("updatePerson persists notify preference columns", () => {

--- a/lib/__tests__/notify-users.test.ts
+++ b/lib/__tests__/notify-users.test.ts
@@ -281,3 +281,76 @@ describe("notifyUsersOfEvent — error swallowing", () => {
     ).resolves.toBeUndefined();
   });
 });
+
+describe("notifyUsersOfEvent — alwaysNotifyPersonId (reserver outcome)", () => {
+  it("notifies the always-notify person even when their pref is 'off'", async () => {
+    const db = makeDb();
+    const reserverId = insertPerson(db, {
+      ...basePerson,
+      first_name: "Reserver",
+      notify_reservation_updates: "off",
+    });
+    const actorId = insertPerson(db, { ...basePerson, first_name: "Owner" });
+    const carId = insertCar(db, actorId);
+
+    await notifyUsersOfEvent({
+      db,
+      trigger: "reservation_update",
+      entityType: "reservation",
+      entityId: 7,
+      carId,
+      actorPersonId: actorId,
+      alwaysNotifyPersonId: reserverId,
+      message: "approved",
+    });
+
+    expect(listNotifications(db, reserverId)).toHaveLength(1);
+  });
+
+  it("does not notify the always-notify person when they are the actor", async () => {
+    const db = makeDb();
+    const actorId = insertPerson(db, {
+      ...basePerson,
+      first_name: "Owner",
+      notify_reservation_updates: "off",
+    });
+    const carId = insertCar(db, actorId);
+
+    await notifyUsersOfEvent({
+      db,
+      trigger: "reservation_update",
+      entityType: "reservation",
+      entityId: 8,
+      carId,
+      actorPersonId: actorId,
+      alwaysNotifyPersonId: actorId,
+      message: "approved",
+    });
+
+    expect(listNotifications(db, actorId)).toHaveLength(0);
+  });
+
+  it("does not double-notify when the reserver is also opted in", async () => {
+    const db = makeDb();
+    const reserverId = insertPerson(db, {
+      ...basePerson,
+      first_name: "Reserver",
+      notify_reservation_updates: "all",
+    });
+    const actorId = insertPerson(db, { ...basePerson, first_name: "Owner" });
+    const carId = insertCar(db, actorId);
+
+    await notifyUsersOfEvent({
+      db,
+      trigger: "reservation_update",
+      entityType: "reservation",
+      entityId: 9,
+      carId,
+      actorPersonId: actorId,
+      alwaysNotifyPersonId: reserverId,
+      message: "approved",
+    });
+
+    expect(listNotifications(db, reserverId)).toHaveLength(1);
+  });
+});

--- a/lib/__tests__/notify-users.test.ts
+++ b/lib/__tests__/notify-users.test.ts
@@ -354,3 +354,36 @@ describe("notifyUsersOfEvent — alwaysNotifyPersonId (reserver outcome)", () =>
     expect(listNotifications(db, reserverId)).toHaveLength(1);
   });
 });
+
+describe("notifyUsersOfEvent — per-recipient message", () => {
+  it("uses alwaysNotifyMessage for the reserver and message for others", async () => {
+    const db = makeDb();
+    const watcherId = insertPerson(db, {
+      ...basePerson,
+      first_name: "Watcher",
+      notify_reservation_updates: "all",
+    });
+    const reserverId = insertPerson(db, {
+      ...basePerson,
+      first_name: "Reserver",
+      notify_reservation_updates: "off",
+    });
+    const actorId = insertPerson(db, { ...basePerson, first_name: "Owner" });
+    const carId = insertCar(db, actorId);
+
+    await notifyUsersOfEvent({
+      db,
+      trigger: "reservation_update",
+      entityType: "reservation",
+      entityId: 11,
+      carId,
+      actorPersonId: actorId,
+      alwaysNotifyPersonId: reserverId,
+      message: "generic",
+      alwaysNotifyMessage: "yours",
+    });
+
+    expect(listNotifications(db, reserverId)[0].message).toBe("yours");
+    expect(listNotifications(db, watcherId)[0].message).toBe("generic");
+  });
+});

--- a/lib/__tests__/notify-users.test.ts
+++ b/lib/__tests__/notify-users.test.ts
@@ -94,17 +94,19 @@ describe("notifyUsersOfEvent — new_reservation trigger", () => {
     expect(listNotifications(db, aliceId)).toHaveLength(0);
   });
 
-  it("inserts for pref='own' only if they own the car", async () => {
+  it("owner toggle notifies only the person who owns the car", async () => {
     const db = makeDb();
+    // Alice owns Car AA and opted into reservations on her car.
     const ownerAliceId = insertPerson(db, {
       ...basePerson,
       first_name: "Alice",
-      notify_new_reservations: "own",
+      notify_my_car_reservations: "on",
     });
+    // Bob has the same toggle on but owns no car → must not be notified.
     const nonOwnerBobId = insertPerson(db, {
       ...basePerson,
       first_name: "Bob",
-      notify_new_reservations: "own",
+      notify_my_car_reservations: "on",
     });
     const actorId = insertPerson(db, { ...basePerson, first_name: "Actor" });
 
@@ -123,6 +125,31 @@ describe("notifyUsersOfEvent — new_reservation trigger", () => {
 
     expect(listNotifications(db, ownerAliceId)).toHaveLength(1);
     expect(listNotifications(db, nonOwnerBobId)).toHaveLength(0);
+  });
+
+  it("owner toggle does NOT notify for events on a car they do not own", async () => {
+    const db = makeDb();
+    const ownerAliceId = insertPerson(db, {
+      ...basePerson,
+      first_name: "Alice",
+      notify_my_car_reservations: "on",
+    });
+    const actorId = insertPerson(db, { ...basePerson, first_name: "Actor" });
+    // Alice owns Car AA, but the event is on Car BB (owned by the actor).
+    insertCar(db, ownerAliceId, "AA");
+    const otherCarId = insertCar(db, actorId, "BB");
+
+    await notifyUsersOfEvent({
+      db,
+      trigger: "new_reservation",
+      entityType: "reservation",
+      entityId: 1,
+      carId: otherCarId,
+      actorPersonId: actorId,
+      message: "Reservation on Car BB",
+    });
+
+    expect(listNotifications(db, ownerAliceId)).toHaveLength(0);
   });
 
   it("always excludes the actor, even if they have pref='all'", async () => {
@@ -198,6 +225,30 @@ describe("notifyUsersOfEvent — new_trip trigger", () => {
     });
 
     expect(listNotifications(db, aliceId)).toHaveLength(1);
+  });
+
+  it("owner toggle notify_my_car_trips notifies the car owner", async () => {
+    const db = makeDb();
+    const ownerAliceId = insertPerson(db, {
+      ...basePerson,
+      first_name: "Alice",
+      notify_my_car_trips: "on",
+      notify_new_trips: "off",
+    });
+    const actorId = insertPerson(db, { ...basePerson, first_name: "Actor" });
+    const carId = insertCar(db, ownerAliceId);
+
+    await notifyUsersOfEvent({
+      db,
+      trigger: "new_trip",
+      entityType: "trip",
+      entityId: 12,
+      carId,
+      actorPersonId: actorId,
+      message: "Trip on Alice's car",
+    });
+
+    expect(listNotifications(db, ownerAliceId)).toHaveLength(1);
   });
 });
 
@@ -283,7 +334,31 @@ describe("notifyUsersOfEvent — error swallowing", () => {
 });
 
 describe("notifyUsersOfEvent — alwaysNotifyPersonId (reserver outcome)", () => {
-  it("notifies the always-notify person even when their pref is 'off'", async () => {
+  it("notifies the always-notify person even when their pref is 'mine'", async () => {
+    const db = makeDb();
+    const reserverId = insertPerson(db, {
+      ...basePerson,
+      first_name: "Reserver",
+      notify_reservation_updates: "mine",
+    });
+    const actorId = insertPerson(db, { ...basePerson, first_name: "Owner" });
+    const carId = insertCar(db, actorId);
+
+    await notifyUsersOfEvent({
+      db,
+      trigger: "reservation_update",
+      entityType: "reservation",
+      entityId: 7,
+      carId,
+      actorPersonId: actorId,
+      alwaysNotifyPersonId: reserverId,
+      message: "approved",
+    });
+
+    expect(listNotifications(db, reserverId)).toHaveLength(1);
+  });
+
+  it("does NOT notify the always-notify person when they opted fully out ('off')", async () => {
     const db = makeDb();
     const reserverId = insertPerson(db, {
       ...basePerson,
@@ -304,7 +379,7 @@ describe("notifyUsersOfEvent — alwaysNotifyPersonId (reserver outcome)", () =>
       message: "approved",
     });
 
-    expect(listNotifications(db, reserverId)).toHaveLength(1);
+    expect(listNotifications(db, reserverId)).toHaveLength(0);
   });
 
   it("does not notify the always-notify person when they are the actor", async () => {
@@ -312,7 +387,7 @@ describe("notifyUsersOfEvent — alwaysNotifyPersonId (reserver outcome)", () =>
     const actorId = insertPerson(db, {
       ...basePerson,
       first_name: "Owner",
-      notify_reservation_updates: "off",
+      notify_reservation_updates: "mine",
     });
     const carId = insertCar(db, actorId);
 
@@ -366,7 +441,7 @@ describe("notifyUsersOfEvent — per-recipient message", () => {
     const reserverId = insertPerson(db, {
       ...basePerson,
       first_name: "Reserver",
-      notify_reservation_updates: "off",
+      notify_reservation_updates: "mine",
     });
     const actorId = insertPerson(db, { ...basePerson, first_name: "Owner" });
     const carId = insertCar(db, actorId);

--- a/lib/__tests__/notify-users.test.ts
+++ b/lib/__tests__/notify-users.test.ts
@@ -1,0 +1,283 @@
+// lib/__tests__/notify-users.test.ts
+import Database from "better-sqlite3";
+import { describe, expect, it, vi } from "vitest";
+import { runMigrations } from "../db/migrate";
+import { insertNotification, listNotifications } from "../queries/notifications";
+import { insertPerson } from "../queries/people";
+import { notifyUsersOfEvent } from "../notify-users";
+
+function makeDb() {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  runMigrations(db);
+  return db;
+}
+
+const basePerson = {
+  first_name: "",
+  last_name: "",
+  discount: 0,
+  discount_long: 0,
+  active: 1 as const,
+  username: null,
+  password_hash: null,
+  is_admin: 0 as const,
+  bank_account: "",
+  email: null,
+  theme_preference: "mono" as const,
+};
+
+/**
+ * Helper: insert a car owned by ownerPersonId and return the car id.
+ */
+function insertCar(
+  db: Database.Database,
+  ownerPersonId: number,
+  short = "AA"
+): number {
+  const result = db
+    .prepare(
+      `INSERT INTO cars (short, name, price_per_km, owner_person_id, owner_from, active)
+       VALUES (?, 'Car AA', 0.3, ?, '2020-01-01', 1)`
+    )
+    .run(short, ownerPersonId);
+  return result.lastInsertRowid as number;
+}
+
+describe("notifyUsersOfEvent — new_reservation trigger", () => {
+  it("inserts a notification for a user with pref='all'", async () => {
+    const db = makeDb();
+    const aliceId = insertPerson(db, {
+      ...basePerson,
+      first_name: "Alice",
+      notify_new_reservations: "all",
+    });
+    const actorId = insertPerson(db, { ...basePerson, first_name: "Actor" });
+    const carId = insertCar(db, aliceId);
+
+    await notifyUsersOfEvent({
+      db,
+      trigger: "new_reservation",
+      entityType: "reservation",
+      entityId: 1,
+      carId,
+      actorPersonId: actorId,
+      message: "A new reservation was created",
+    });
+
+    const notifs = listNotifications(db, aliceId);
+    expect(notifs).toHaveLength(1);
+    expect(notifs[0].recipient_person_id).toBe(aliceId);
+    expect(notifs[0].message).toBe("A new reservation was created");
+  });
+
+  it("does NOT insert for a user with pref='off'", async () => {
+    const db = makeDb();
+    const aliceId = insertPerson(db, {
+      ...basePerson,
+      first_name: "Alice",
+      notify_new_reservations: "off",
+    });
+    const actorId = insertPerson(db, { ...basePerson, first_name: "Actor" });
+    const carId = insertCar(db, aliceId);
+
+    await notifyUsersOfEvent({
+      db,
+      trigger: "new_reservation",
+      entityType: "reservation",
+      entityId: 1,
+      carId,
+      actorPersonId: actorId,
+      message: "A new reservation was created",
+    });
+
+    expect(listNotifications(db, aliceId)).toHaveLength(0);
+  });
+
+  it("inserts for pref='own' only if they own the car", async () => {
+    const db = makeDb();
+    const ownerAliceId = insertPerson(db, {
+      ...basePerson,
+      first_name: "Alice",
+      notify_new_reservations: "own",
+    });
+    const nonOwnerBobId = insertPerson(db, {
+      ...basePerson,
+      first_name: "Bob",
+      notify_new_reservations: "own",
+    });
+    const actorId = insertPerson(db, { ...basePerson, first_name: "Actor" });
+
+    // Only Alice owns Car AA
+    const carId = insertCar(db, ownerAliceId);
+
+    await notifyUsersOfEvent({
+      db,
+      trigger: "new_reservation",
+      entityType: "reservation",
+      entityId: 1,
+      carId,
+      actorPersonId: actorId,
+      message: "A reservation was made on Car AA",
+    });
+
+    expect(listNotifications(db, ownerAliceId)).toHaveLength(1);
+    expect(listNotifications(db, nonOwnerBobId)).toHaveLength(0);
+  });
+
+  it("always excludes the actor, even if they have pref='all'", async () => {
+    const db = makeDb();
+    const actorId = insertPerson(db, {
+      ...basePerson,
+      first_name: "Actor",
+      notify_new_reservations: "all",
+    });
+    const carId = insertCar(db, actorId);
+
+    await notifyUsersOfEvent({
+      db,
+      trigger: "new_reservation",
+      entityType: "reservation",
+      entityId: 1,
+      carId,
+      actorPersonId: actorId,
+      message: "Self-triggered reservation",
+    });
+
+    // Actor must not receive a notification about their own action
+    expect(listNotifications(db, actorId)).toHaveLength(0);
+  });
+});
+
+describe("notifyUsersOfEvent — reservation_update trigger", () => {
+  it("maps reservation_update to notify_reservation_updates pref column", async () => {
+    const db = makeDb();
+    const aliceId = insertPerson(db, {
+      ...basePerson,
+      first_name: "Alice",
+      notify_reservation_updates: "all",
+      notify_new_reservations: "off", // ensure only the right column is checked
+    });
+    const actorId = insertPerson(db, { ...basePerson, first_name: "Actor" });
+    const carId = insertCar(db, aliceId);
+
+    await notifyUsersOfEvent({
+      db,
+      trigger: "reservation_update",
+      entityType: "reservation",
+      entityId: 5,
+      carId,
+      actorPersonId: actorId,
+      message: "Reservation updated",
+    });
+
+    expect(listNotifications(db, aliceId)).toHaveLength(1);
+  });
+});
+
+describe("notifyUsersOfEvent — new_trip trigger", () => {
+  it("maps new_trip to notify_new_trips pref column", async () => {
+    const db = makeDb();
+    const aliceId = insertPerson(db, {
+      ...basePerson,
+      first_name: "Alice",
+      notify_new_trips: "all",
+      notify_new_reservations: "off",
+    });
+    const actorId = insertPerson(db, { ...basePerson, first_name: "Actor" });
+    const carId = insertCar(db, aliceId);
+
+    await notifyUsersOfEvent({
+      db,
+      trigger: "new_trip",
+      entityType: "trip",
+      entityId: 10,
+      carId,
+      actorPersonId: actorId,
+      message: "A new trip was logged",
+    });
+
+    expect(listNotifications(db, aliceId)).toHaveLength(1);
+  });
+});
+
+describe("notifyUsersOfEvent — multiple recipients", () => {
+  it("sends to all eligible recipients", async () => {
+    const db = makeDb();
+    const aliceId = insertPerson(db, {
+      ...basePerson,
+      first_name: "Alice",
+      notify_new_trips: "all",
+    });
+    const bobId = insertPerson(db, {
+      ...basePerson,
+      first_name: "Bob",
+      notify_new_trips: "all",
+    });
+    const carolId = insertPerson(db, {
+      ...basePerson,
+      first_name: "Carol",
+      notify_new_trips: "off",
+    });
+    const actorId = insertPerson(db, { ...basePerson, first_name: "Actor" });
+    const carId = insertCar(db, aliceId);
+
+    await notifyUsersOfEvent({
+      db,
+      trigger: "new_trip",
+      entityType: "trip",
+      entityId: 7,
+      carId,
+      actorPersonId: actorId,
+      message: "New trip logged",
+    });
+
+    expect(listNotifications(db, aliceId)).toHaveLength(1);
+    expect(listNotifications(db, bobId)).toHaveLength(1);
+    expect(listNotifications(db, carolId)).toHaveLength(0);
+  });
+
+  it("does not send to inactive people, even with pref='all'", async () => {
+    const db = makeDb();
+    const inactiveId = insertPerson(db, {
+      ...basePerson,
+      first_name: "Inactive",
+      active: 0,
+      notify_new_trips: "all",
+    });
+    const actorId = insertPerson(db, { ...basePerson, first_name: "Actor" });
+    const carId = insertCar(db, actorId);
+
+    await notifyUsersOfEvent({
+      db,
+      trigger: "new_trip",
+      entityType: "trip",
+      entityId: 8,
+      carId,
+      actorPersonId: actorId,
+      message: "New trip",
+    });
+
+    expect(listNotifications(db, inactiveId)).toHaveLength(0);
+  });
+});
+
+describe("notifyUsersOfEvent — error swallowing", () => {
+  it("does not throw when an internal error occurs", async () => {
+    // Pass a broken db (already closed) to simulate internal error
+    const db = makeDb();
+    db.close();
+
+    await expect(
+      notifyUsersOfEvent({
+        db,
+        trigger: "new_reservation",
+        entityType: "reservation",
+        entityId: 1,
+        carId: 999,
+        actorPersonId: 1,
+        message: "Should not throw",
+      })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -661,9 +661,13 @@ export const en: Messages = {
   "pwa.refresh_blocked_offline": "Can't refresh — you're offline with unsynced changes.",
 
   // In-app notifications
-  "notif.new_reservation": "New reservation for {car} on {date}",
-  "notif.reservation_update": "Reservation for {car} on {date} updated",
+  "notif.new_reservation": "New reservation for {car} from {start} to {end}",
+  "notif.reservation_update": "Reservation for {car} from {start} to {end} {status}",
   "notif.new_trip": "New trip with {car} on {date}",
+  "notif.status_confirmed": "approved",
+  "notif.status_rejected": "rejected",
+  "notif.status_pending": "set to pending",
+  "notif.status_deleted": "deleted",
 
   // Notification preferences (profile page)
   "notif.pref_section": "Notifications",

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -663,6 +663,7 @@ export const en: Messages = {
   // In-app notifications
   "notif.new_reservation": "New reservation for {car} from {start} to {end}",
   "notif.reservation_update": "Reservation for {car} from {start} to {end} {status}",
+  "notif.reservation_update_self": "Your reservation for {car} from {start} to {end} {status}",
   "notif.new_trip": "New trip with {car} on {date}",
   "notif.status_confirmed": "approved",
   "notif.status_rejected": "rejected",

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -660,6 +660,11 @@ export const en: Messages = {
   "pwa.refreshing": "Refreshing…",
   "pwa.refresh_blocked_offline": "Can't refresh — you're offline with unsynced changes.",
 
+  // In-app notifications
+  "notif.new_reservation": "New reservation for {car} on {date}",
+  "notif.reservation_update": "Reservation for {car} on {date} updated",
+  "notif.new_trip": "New trip with {car} on {date}",
+
   // Owner dashboard
   "owner.title": "My cars",
   "owner.subtitle": "Fleet economics · {year}",

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -665,6 +665,21 @@ export const en: Messages = {
   "notif.reservation_update": "Reservation for {car} on {date} updated",
   "notif.new_trip": "New trip with {car} on {date}",
 
+  // Notification preferences (profile page)
+  "notif.pref_section": "Notifications",
+  "notif.pref_new_reservations": "New reservations",
+  "notif.pref_reservation_updates": "Reservation updates",
+  "notif.pref_new_trips": "New trips",
+  "notif.pref_scope_all": "All cars",
+  "notif.pref_scope_own": "Only my cars",
+  "notif.pref_enabled": "Enabled",
+
+  // Notifications page
+  "notif.page_title": "Notifications",
+  "notif.empty": "No notifications",
+  "notif.mark_all_read": "Mark all read",
+  "notif.unread_badge": "{count} unread",
+
   // Owner dashboard
   "owner.title": "My cars",
   "owner.subtitle": "Fleet economics · {year}",

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -670,14 +670,17 @@ export const en: Messages = {
   "notif.status_pending": "set to pending",
   "notif.status_deleted": "deleted",
 
-  // Notification preferences (profile page)
+  // Notification preferences (profile page) — driver block (all members)
   "notif.pref_section": "Notifications",
-  "notif.pref_new_reservations": "New reservations",
+  "notif.pref_new_reservations": "New reservations by others",
   "notif.pref_reservation_updates": "Reservation updates",
-  "notif.pref_new_trips": "New trips",
-  "notif.pref_scope_all": "All cars",
-  "notif.pref_scope_own": "Only my cars",
-  "notif.pref_enabled": "Enabled",
+  "notif.pref_updates_all": "All reservations",
+  "notif.pref_updates_mine": "Only my reservations",
+  "notif.pref_new_trips": "New trips by others",
+  // Owner block (only people who own a car)
+  "notif.pref_section_owner": "Notifications for my car",
+  "notif.pref_my_car_reservations": "Reservations for my car",
+  "notif.pref_my_car_trips": "Trips with my car",
 
   // Notifications page
   "notif.page_title": "Notifications",

--- a/lib/i18n/messages/nl.ts
+++ b/lib/i18n/messages/nl.ts
@@ -661,9 +661,13 @@ export const nl = {
     "Verversen kan niet — je bent offline met niet-gesynchroniseerde wijzigingen.",
 
   // In-app notifications
-  "notif.new_reservation": "Nieuwe reservering voor {car} op {date}",
-  "notif.reservation_update": "Reservering voor {car} op {date} bijgewerkt",
+  "notif.new_reservation": "Nieuwe reservering voor {car} van {start} tot {end}",
+  "notif.reservation_update": "Reservering voor {car} van {start} tot {end} {status}",
   "notif.new_trip": "Nieuwe rit met {car} op {date}",
+  "notif.status_confirmed": "goedgekeurd",
+  "notif.status_rejected": "geweigerd",
+  "notif.status_pending": "opnieuw in behandeling",
+  "notif.status_deleted": "verwijderd",
 
   // Notification preferences (profile page)
   "notif.pref_section": "Meldingen",

--- a/lib/i18n/messages/nl.ts
+++ b/lib/i18n/messages/nl.ts
@@ -660,6 +660,11 @@ export const nl = {
   "pwa.refresh_blocked_offline":
     "Verversen kan niet — je bent offline met niet-gesynchroniseerde wijzigingen.",
 
+  // In-app notifications
+  "notif.new_reservation": "Nieuwe reservering voor {car} op {date}",
+  "notif.reservation_update": "Reservering voor {car} op {date} bijgewerkt",
+  "notif.new_trip": "Nieuwe rit met {car} op {date}",
+
   // Owner dashboard
   "owner.title": "Mijn wagens",
   "owner.subtitle": "Economische gezondheid · {year}",

--- a/lib/i18n/messages/nl.ts
+++ b/lib/i18n/messages/nl.ts
@@ -665,6 +665,21 @@ export const nl = {
   "notif.reservation_update": "Reservering voor {car} op {date} bijgewerkt",
   "notif.new_trip": "Nieuwe rit met {car} op {date}",
 
+  // Notification preferences (profile page)
+  "notif.pref_section": "Meldingen",
+  "notif.pref_new_reservations": "Nieuwe reserveringen",
+  "notif.pref_reservation_updates": "Reserveringsupdates",
+  "notif.pref_new_trips": "Nieuwe ritten",
+  "notif.pref_scope_all": "Alle wagens",
+  "notif.pref_scope_own": "Alleen mijn wagens",
+  "notif.pref_enabled": "Ingeschakeld",
+
+  // Notifications page
+  "notif.page_title": "Meldingen",
+  "notif.empty": "Geen meldingen",
+  "notif.mark_all_read": "Alles gelezen",
+  "notif.unread_badge": "{count} ongelezen",
+
   // Owner dashboard
   "owner.title": "Mijn wagens",
   "owner.subtitle": "Economische gezondheid · {year}",

--- a/lib/i18n/messages/nl.ts
+++ b/lib/i18n/messages/nl.ts
@@ -663,6 +663,7 @@ export const nl = {
   // In-app notifications
   "notif.new_reservation": "Nieuwe reservering voor {car} van {start} tot {end}",
   "notif.reservation_update": "Reservering voor {car} van {start} tot {end} {status}",
+  "notif.reservation_update_self": "Jouw reservering voor {car} van {start} tot {end} {status}",
   "notif.new_trip": "Nieuwe rit met {car} op {date}",
   "notif.status_confirmed": "goedgekeurd",
   "notif.status_rejected": "geweigerd",

--- a/lib/i18n/messages/nl.ts
+++ b/lib/i18n/messages/nl.ts
@@ -670,14 +670,17 @@ export const nl = {
   "notif.status_pending": "opnieuw in behandeling",
   "notif.status_deleted": "verwijderd",
 
-  // Notification preferences (profile page)
+  // Notification preferences (profile page) — driver block (all members)
   "notif.pref_section": "Meldingen",
-  "notif.pref_new_reservations": "Nieuwe reserveringen",
+  "notif.pref_new_reservations": "Nieuwe reserveringen van anderen",
   "notif.pref_reservation_updates": "Reserveringsupdates",
-  "notif.pref_new_trips": "Nieuwe ritten",
-  "notif.pref_scope_all": "Alle wagens",
-  "notif.pref_scope_own": "Alleen mijn wagens",
-  "notif.pref_enabled": "Ingeschakeld",
+  "notif.pref_updates_all": "Alle reserveringen",
+  "notif.pref_updates_mine": "Enkel mijn reserveringen",
+  "notif.pref_new_trips": "Nieuwe ritten van anderen",
+  // Owner block (only people who own a car)
+  "notif.pref_section_owner": "Meldingen voor mijn wagen(s)",
+  "notif.pref_my_car_reservations": "Reserveringen op mijn wagen",
+  "notif.pref_my_car_trips": "Ritten met mijn wagen",
 
   // Notifications page
   "notif.page_title": "Meldingen",

--- a/lib/notification-href.ts
+++ b/lib/notification-href.ts
@@ -1,0 +1,17 @@
+import type { Notification } from "@/types";
+
+/**
+ * Returns the in-app deep-link URL for a notification.
+ * - reservation → /calendar?reservation=<id>
+ * - trip        → /trips?trip=<id>
+ * - anything else → "" (no link)
+ */
+export function notificationHref(n: Pick<Notification, "entity_type" | "entity_id">): string {
+  if (n.entity_type === "reservation") {
+    return `/calendar?reservation=${n.entity_id}`;
+  }
+  if (n.entity_type === "trip") {
+    return `/trips?trip=${n.entity_id}`;
+  }
+  return "";
+}

--- a/lib/notify-users.ts
+++ b/lib/notify-users.ts
@@ -31,6 +31,12 @@ export interface NotifyUsersOptions {
   carId: number;
   /** The person performing the action; always excluded from recipients. */
   actorPersonId: number;
+  /**
+   * A person who must be notified regardless of their preferences — e.g. the
+   * reserver, told their reservation was approved/rejected/deleted. Still
+   * excluded if they are the actor; de-duplicated against opt-in recipients.
+   */
+  alwaysNotifyPersonId?: number | null;
   message: string;
 }
 
@@ -76,6 +82,12 @@ export async function notifyUsersOfEvent(opts: NotifyUsersOptions): Promise<void
       ...allRecipients.map((r) => r.id),
       ...ownRecipients.map((r) => r.id),
     ]);
+
+    // Always-notify recipient (e.g. the reserver) — regardless of prefs, but not
+    // when they are the actor; the Set de-duplicates against opt-in recipients.
+    if (opts.alwaysNotifyPersonId != null && opts.alwaysNotifyPersonId !== opts.actorPersonId) {
+      recipientIds.add(opts.alwaysNotifyPersonId);
+    }
 
     for (const recipientPersonId of recipientIds) {
       insertNotification(opts.db, {

--- a/lib/notify-users.ts
+++ b/lib/notify-users.ts
@@ -38,6 +38,11 @@ export interface NotifyUsersOptions {
    */
   alwaysNotifyPersonId?: number | null;
   message: string;
+  /**
+   * Message for `alwaysNotifyPersonId` only (e.g. "Your reservation …" addressed
+   * to the reserver). Falls back to `message` when not set.
+   */
+  alwaysNotifyMessage?: string;
 }
 
 /**
@@ -90,12 +95,16 @@ export async function notifyUsersOfEvent(opts: NotifyUsersOptions): Promise<void
     }
 
     for (const recipientPersonId of recipientIds) {
+      const message =
+        opts.alwaysNotifyMessage != null && recipientPersonId === opts.alwaysNotifyPersonId
+          ? opts.alwaysNotifyMessage
+          : opts.message;
       insertNotification(opts.db, {
         recipientPersonId,
         type: opts.trigger,
         entityType: opts.entityType,
         entityId: opts.entityId,
-        message: opts.message,
+        message,
       });
     }
   } catch {

--- a/lib/notify-users.ts
+++ b/lib/notify-users.ts
@@ -15,11 +15,18 @@ import { insertNotification } from "@/lib/queries/notifications";
 
 export type NotifyTrigger = "new_reservation" | "reservation_update" | "new_trip";
 
-/** Maps a trigger to the people.notify_* column name. */
-const TRIGGER_TO_COLUMN: Record<NotifyTrigger, string> = {
+/** Driver/member pref column per trigger ('all' = notify about others' events). */
+const DRIVER_COLUMN: Record<NotifyTrigger, string> = {
   new_reservation: "notify_new_reservations",
   reservation_update: "notify_reservation_updates",
   new_trip: "notify_new_trips",
+};
+
+/** Owner toggle column per trigger ('on' = notify about events on cars I own). */
+const OWNER_COLUMN: Record<NotifyTrigger, string> = {
+  new_reservation: "notify_my_car_reservations",
+  reservation_update: "notify_my_car_reservations",
+  new_trip: "notify_my_car_trips",
 };
 
 export interface NotifyUsersOptions {
@@ -49,49 +56,52 @@ export interface NotifyUsersOptions {
  * Determines which active people should receive an in-app notification for
  * the event and inserts one row per recipient.
  *
- * Recipient rules:
- *  - pref = 'all'  → always included (unless they are the actor)
- *  - pref = 'own'  → only if they own `carId` (via cars.owner_person_id)
- *  - pref = 'off'  → never included
- *  - inactive people → never included
- *  - actorPersonId → always excluded
+ * Recipient rules (active people only, actor always excluded):
+ *  - driver pref = 'all' → notified about everyone's events of this type
+ *  - owner toggle = 'on' AND owns `carId` → notified about events on their car
+ *  - alwaysNotifyPersonId (e.g. the reserver) → notified regardless of prefs
+ *  Recipients are de-duplicated; the reserver gets `alwaysNotifyMessage`.
  */
 export async function notifyUsersOfEvent(opts: NotifyUsersOptions): Promise<void> {
   try {
-    const prefColumn = TRIGGER_TO_COLUMN[opts.trigger];
+    const driverColumn = DRIVER_COLUMN[opts.trigger];
+    const ownerColumn = OWNER_COLUMN[opts.trigger];
 
-    // Recipients with pref = 'all' (active, not the actor)
-    const allRecipients = opts.db
+    // Driver/member recipients: opted into all events of this type (self excluded).
+    const driverRecipients = opts.db
       .prepare(
         `SELECT id FROM people
-         WHERE active = 1
-           AND id != ?
-           AND ${prefColumn} = 'all'`
+         WHERE active = 1 AND id != ? AND ${driverColumn} = 'all'`
       )
       .all(opts.actorPersonId) as { id: number }[];
 
-    // Recipients with pref = 'own' who own the car (active, not the actor)
-    const ownRecipients = opts.db
+    // Owner recipients: own the car AND opted into events on their car (self excluded).
+    const ownerRecipients = opts.db
       .prepare(
         `SELECT p.id FROM people p
          INNER JOIN cars c ON c.owner_person_id = p.id
-         WHERE p.active = 1
-           AND p.id != ?
-           AND p.${prefColumn} = 'own'
-           AND c.id = ?`
+         WHERE p.active = 1 AND p.id != ? AND p.${ownerColumn} = 'on' AND c.id = ?`
       )
       .all(opts.actorPersonId, opts.carId) as { id: number }[];
 
-    // De-duplicate (a person can't appear in both since pref is a single value)
     const recipientIds = new Set<number>([
-      ...allRecipients.map((r) => r.id),
-      ...ownRecipients.map((r) => r.id),
+      ...driverRecipients.map((r) => r.id),
+      ...ownerRecipients.map((r) => r.id),
     ]);
 
-    // Always-notify recipient (e.g. the reserver) — regardless of prefs, but not
-    // when they are the actor; the Set de-duplicates against opt-in recipients.
+    // Always-notify recipient (e.g. the reserver, told their own reservation was
+    // approved/rejected/deleted). Sent regardless of the 'mine'/'all' choice, but
+    // NOT when they are the actor, and NOT when they fully opted out ('off' on the
+    // trigger's driver column — e.g. notify_reservation_updates='off' means no
+    // reservation-update notifications at all, not even your own outcome).
+    // The Set de-duplicates against opt-in recipients.
     if (opts.alwaysNotifyPersonId != null && opts.alwaysNotifyPersonId !== opts.actorPersonId) {
-      recipientIds.add(opts.alwaysNotifyPersonId);
+      const pref = opts.db
+        .prepare(`SELECT ${driverColumn} AS v FROM people WHERE id = ? AND active = 1`)
+        .get(opts.alwaysNotifyPersonId) as { v: string } | undefined;
+      if (pref && pref.v !== "off") {
+        recipientIds.add(opts.alwaysNotifyPersonId);
+      }
     }
 
     for (const recipientPersonId of recipientIds) {

--- a/lib/notify-users.ts
+++ b/lib/notify-users.ts
@@ -1,0 +1,92 @@
+/**
+ * lib/notify-users.ts
+ *
+ * In-app notification generation helper.
+ *
+ * Inserts notification rows for all eligible recipients based on their
+ * per-person notification preferences and car ownership.
+ *
+ * The call never throws — any error is swallowed so the invoking mutation
+ * path is always unaffected.
+ */
+
+import type Database from "better-sqlite3";
+import { insertNotification } from "@/lib/queries/notifications";
+
+export type NotifyTrigger = "new_reservation" | "reservation_update" | "new_trip";
+
+/** Maps a trigger to the people.notify_* column name. */
+const TRIGGER_TO_COLUMN: Record<NotifyTrigger, string> = {
+  new_reservation: "notify_new_reservations",
+  reservation_update: "notify_reservation_updates",
+  new_trip: "notify_new_trips",
+};
+
+export interface NotifyUsersOptions {
+  db: Database.Database;
+  trigger: NotifyTrigger;
+  entityType: string;
+  entityId: number;
+  /** The car involved in the event — used to resolve 'own' recipients. */
+  carId: number;
+  /** The person performing the action; always excluded from recipients. */
+  actorPersonId: number;
+  message: string;
+}
+
+/**
+ * Determines which active people should receive an in-app notification for
+ * the event and inserts one row per recipient.
+ *
+ * Recipient rules:
+ *  - pref = 'all'  → always included (unless they are the actor)
+ *  - pref = 'own'  → only if they own `carId` (via cars.owner_person_id)
+ *  - pref = 'off'  → never included
+ *  - inactive people → never included
+ *  - actorPersonId → always excluded
+ */
+export async function notifyUsersOfEvent(opts: NotifyUsersOptions): Promise<void> {
+  try {
+    const prefColumn = TRIGGER_TO_COLUMN[opts.trigger];
+
+    // Recipients with pref = 'all' (active, not the actor)
+    const allRecipients = opts.db
+      .prepare(
+        `SELECT id FROM people
+         WHERE active = 1
+           AND id != ?
+           AND ${prefColumn} = 'all'`
+      )
+      .all(opts.actorPersonId) as { id: number }[];
+
+    // Recipients with pref = 'own' who own the car (active, not the actor)
+    const ownRecipients = opts.db
+      .prepare(
+        `SELECT p.id FROM people p
+         INNER JOIN cars c ON c.owner_person_id = p.id
+         WHERE p.active = 1
+           AND p.id != ?
+           AND p.${prefColumn} = 'own'
+           AND c.id = ?`
+      )
+      .all(opts.actorPersonId, opts.carId) as { id: number }[];
+
+    // De-duplicate (a person can't appear in both since pref is a single value)
+    const recipientIds = new Set<number>([
+      ...allRecipients.map((r) => r.id),
+      ...ownRecipients.map((r) => r.id),
+    ]);
+
+    for (const recipientPersonId of recipientIds) {
+      insertNotification(opts.db, {
+        recipientPersonId,
+        type: opts.trigger,
+        entityType: opts.entityType,
+        entityId: opts.entityId,
+        message: opts.message,
+      });
+    }
+  } catch {
+    // Swallow — notification failures must never affect the calling mutation.
+  }
+}

--- a/lib/queries/notifications.ts
+++ b/lib/queries/notifications.ts
@@ -1,0 +1,84 @@
+import type { Notification } from "@/types";
+import type Database from "better-sqlite3";
+
+export interface InsertNotificationInput {
+  recipientPersonId: number;
+  type: string;
+  entityType: string;
+  entityId: number;
+  message: string;
+}
+
+/**
+ * Inserts a new notification record and returns the new row's id.
+ */
+export function insertNotification(
+  db: Database.Database,
+  input: InsertNotificationInput
+): number {
+  const result = db
+    .prepare(
+      `INSERT INTO notifications (recipient_person_id, type, entity_type, entity_id, message)
+       VALUES (?, ?, ?, ?, ?)`
+    )
+    .run(input.recipientPersonId, input.type, input.entityType, input.entityId, input.message);
+  return result.lastInsertRowid as number;
+}
+
+/**
+ * Lists notifications for a recipient, newest first, up to `limit` rows.
+ */
+export function listNotifications(
+  db: Database.Database,
+  personId: number,
+  limit = 50
+): Notification[] {
+  return db
+    .prepare(
+      `SELECT id, recipient_person_id, type, entity_type, entity_id, message, read_at, created_at
+       FROM notifications
+       WHERE recipient_person_id = ?
+       ORDER BY id DESC
+       LIMIT ?`
+    )
+    .all(personId, limit) as Notification[];
+}
+
+/**
+ * Returns the number of unread notifications for a recipient.
+ */
+export function unreadCount(db: Database.Database, personId: number): number {
+  const row = db
+    .prepare(
+      `SELECT COUNT(*) AS n FROM notifications
+       WHERE recipient_person_id = ? AND read_at IS NULL`
+    )
+    .get(personId) as { n: number };
+  return row.n;
+}
+
+/**
+ * Marks notifications as read for a recipient.
+ *
+ * - No `ids` supplied → marks ALL unread for that recipient.
+ * - `ids` supplied    → marks only those ids, still recipient-scoped (can't
+ *                       mark another person's notifications).
+ */
+export function markRead(db: Database.Database, personId: number, ids?: number[]): void {
+  if (!ids || ids.length === 0) {
+    db.prepare(
+      `UPDATE notifications
+       SET read_at = datetime('now')
+       WHERE recipient_person_id = ? AND read_at IS NULL`
+    ).run(personId);
+    return;
+  }
+
+  // Build a parameterised IN clause; scope to personId for safety.
+  const placeholders = ids.map(() => "?").join(",");
+  db.prepare(
+    `UPDATE notifications
+     SET read_at = datetime('now')
+     WHERE recipient_person_id = ? AND id IN (${placeholders}) AND read_at IS NULL`
+  ).run(personId, ...ids);
+}

--- a/lib/queries/people.ts
+++ b/lib/queries/people.ts
@@ -57,13 +57,25 @@ export function getPersonByEmail(db: Database.Database, email: string): Person |
   );
 }
 
-export function insertPerson(
-  db: Database.Database,
-  data: Omit<Person, "id" | "updated_at"> & { password_hash?: string | null }
-): number {
+type NotifyPref = "off" | "all" | "own";
+
+export type PersonWriteData = Omit<
+  Person,
+  "id" | "updated_at" | "notify_new_reservations" | "notify_reservation_updates" | "notify_new_trips"
+> & {
+  password_hash?: string | null;
+  notify_new_reservations?: NotifyPref;
+  notify_reservation_updates?: NotifyPref;
+  notify_new_trips?: NotifyPref;
+};
+
+export function insertPerson(db: Database.Database, data: PersonWriteData): number {
   const result = db
     .prepare(
-      "INSERT INTO people (first_name,last_name,discount,discount_long,active,username,is_admin,bank_account,email,theme_preference) VALUES (?,?,?,?,?,?,?,?,?,?)"
+      `INSERT INTO people
+         (first_name,last_name,discount,discount_long,active,username,is_admin,bank_account,
+          email,theme_preference,notify_new_reservations,notify_reservation_updates,notify_new_trips)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)`
     )
     .run(
       data.first_name,
@@ -75,18 +87,22 @@ export function insertPerson(
       data.is_admin ?? 0,
       data.bank_account ?? "",
       data.email ?? null,
-      data.theme_preference ?? "mono"
+      data.theme_preference ?? "mono",
+      data.notify_new_reservations ?? "off",
+      data.notify_reservation_updates ?? "off",
+      data.notify_new_trips ?? "off"
     );
   return result.lastInsertRowid as number;
 }
 
-export function updatePerson(
-  db: Database.Database,
-  id: number,
-  data: Omit<Person, "id" | "updated_at"> & { password_hash?: string | null }
-): void {
+export function updatePerson(db: Database.Database, id: number, data: PersonWriteData): void {
   db.prepare(
-    "UPDATE people SET first_name=?,last_name=?,discount=?,discount_long=?,active=?,username=?,is_admin=?,bank_account=?,email=?,theme_preference=?,updated_at=datetime('now') WHERE id=?"
+    `UPDATE people
+     SET first_name=?,last_name=?,discount=?,discount_long=?,active=?,username=?,is_admin=?,
+         bank_account=?,email=?,theme_preference=?,
+         notify_new_reservations=?,notify_reservation_updates=?,notify_new_trips=?,
+         updated_at=datetime('now')
+     WHERE id=?`
   ).run(
     data.first_name,
     data.last_name,
@@ -98,6 +114,9 @@ export function updatePerson(
     data.bank_account ?? "",
     data.email ?? null,
     data.theme_preference ?? "mono",
+    data.notify_new_reservations ?? "off",
+    data.notify_reservation_updates ?? "off",
+    data.notify_new_trips ?? "off",
     id
   );
 }

--- a/lib/queries/people.ts
+++ b/lib/queries/people.ts
@@ -57,16 +57,22 @@ export function getPersonByEmail(db: Database.Database, email: string): Person |
   );
 }
 
-type NotifyPref = "off" | "all" | "own";
-
 export type PersonWriteData = Omit<
   Person,
-  "id" | "updated_at" | "notify_new_reservations" | "notify_reservation_updates" | "notify_new_trips"
+  | "id"
+  | "updated_at"
+  | "notify_new_reservations"
+  | "notify_reservation_updates"
+  | "notify_new_trips"
+  | "notify_my_car_reservations"
+  | "notify_my_car_trips"
 > & {
   password_hash?: string | null;
-  notify_new_reservations?: NotifyPref;
-  notify_reservation_updates?: NotifyPref;
-  notify_new_trips?: NotifyPref;
+  notify_new_reservations?: Person["notify_new_reservations"];
+  notify_reservation_updates?: Person["notify_reservation_updates"];
+  notify_new_trips?: Person["notify_new_trips"];
+  notify_my_car_reservations?: Person["notify_my_car_reservations"];
+  notify_my_car_trips?: Person["notify_my_car_trips"];
 };
 
 export function insertPerson(db: Database.Database, data: PersonWriteData): number {
@@ -74,8 +80,9 @@ export function insertPerson(db: Database.Database, data: PersonWriteData): numb
     .prepare(
       `INSERT INTO people
          (first_name,last_name,discount,discount_long,active,username,is_admin,bank_account,
-          email,theme_preference,notify_new_reservations,notify_reservation_updates,notify_new_trips)
-       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)`
+          email,theme_preference,notify_new_reservations,notify_reservation_updates,notify_new_trips,
+          notify_my_car_reservations,notify_my_car_trips)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`
     )
     .run(
       data.first_name,
@@ -89,8 +96,10 @@ export function insertPerson(db: Database.Database, data: PersonWriteData): numb
       data.email ?? null,
       data.theme_preference ?? "mono",
       data.notify_new_reservations ?? "off",
-      data.notify_reservation_updates ?? "off",
-      data.notify_new_trips ?? "off"
+      data.notify_reservation_updates ?? "mine",
+      data.notify_new_trips ?? "off",
+      data.notify_my_car_reservations ?? "off",
+      data.notify_my_car_trips ?? "off"
     );
   return result.lastInsertRowid as number;
 }
@@ -101,6 +110,7 @@ export function updatePerson(db: Database.Database, id: number, data: PersonWrit
      SET first_name=?,last_name=?,discount=?,discount_long=?,active=?,username=?,is_admin=?,
          bank_account=?,email=?,theme_preference=?,
          notify_new_reservations=?,notify_reservation_updates=?,notify_new_trips=?,
+         notify_my_car_reservations=?,notify_my_car_trips=?,
          updated_at=datetime('now')
      WHERE id=?`
   ).run(
@@ -115,8 +125,10 @@ export function updatePerson(db: Database.Database, id: number, data: PersonWrit
     data.email ?? null,
     data.theme_preference ?? "mono",
     data.notify_new_reservations ?? "off",
-    data.notify_reservation_updates ?? "off",
+    data.notify_reservation_updates ?? "mine",
     data.notify_new_trips ?? "off",
+    data.notify_my_car_reservations ?? "off",
+    data.notify_my_car_trips ?? "off",
     id
   );
 }

--- a/migrations/0026_notifications.sql
+++ b/migrations/0026_notifications.sql
@@ -1,0 +1,22 @@
+-- In-app notification storage for per-user notification preferences and
+-- notification records (#358).
+
+-- Notification records
+CREATE TABLE IF NOT EXISTS notifications (
+  id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+  recipient_person_id INTEGER NOT NULL,
+  type               TEXT NOT NULL,
+  entity_type        TEXT NOT NULL,
+  entity_id          INTEGER NOT NULL,
+  message            TEXT NOT NULL,
+  read_at            TEXT,
+  created_at         TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_notifications_recipient
+  ON notifications(recipient_person_id, read_at);
+
+-- Per-person notification preferences (default 'off' = no notifications)
+ALTER TABLE people ADD COLUMN notify_new_reservations    TEXT NOT NULL DEFAULT 'off';
+ALTER TABLE people ADD COLUMN notify_reservation_updates TEXT NOT NULL DEFAULT 'off';
+ALTER TABLE people ADD COLUMN notify_new_trips           TEXT NOT NULL DEFAULT 'off';

--- a/migrations/0027_owner_notify_prefs.sql
+++ b/migrations/0027_owner_notify_prefs.sql
@@ -1,0 +1,11 @@
+-- Owner-specific notification toggles: events on cars the person owns (#358).
+-- Separate from the driver/member prefs so an owner who also drives other cars
+-- can follow their own reservations/trips (driver prefs) AND their car (these).
+ALTER TABLE people ADD COLUMN notify_my_car_reservations TEXT NOT NULL DEFAULT 'off';
+ALTER TABLE people ADD COLUMN notify_my_car_trips        TEXT NOT NULL DEFAULT 'off';
+
+-- Reservation updates default to 'mine' (your own outcome is always delivered).
+-- 0026 added the column with a column-level default of 'off'; normalise existing
+-- rows so nobody is silently opted out of their own reservation outcomes. Users
+-- can still choose 'off' explicitly to suppress all reservation-update notices.
+UPDATE people SET notify_reservation_updates = 'mine' WHERE notify_reservation_updates = 'off';

--- a/types/index.ts
+++ b/types/index.ts
@@ -14,9 +14,15 @@ export interface Person {
   /** Bumped to revoke all of a user's existing sessions ("log out everywhere"). */
   session_epoch?: number;
   updated_at: string;
-  notify_new_reservations: "off" | "all" | "own";
-  notify_reservation_updates: "off" | "all" | "own";
-  notify_new_trips: "off" | "all" | "own";
+  // Driver/member prefs: notifications about activity by others (self excluded).
+  notify_new_reservations: "off" | "all";
+  // 'off' = no reservation-update notifications at all (not even your own outcome).
+  // 'mine' = only your own reservation outcome. 'all' = yours + everyone else's.
+  notify_reservation_updates: "off" | "all" | "mine";
+  notify_new_trips: "off" | "all";
+  // Owner prefs: events on cars this person owns.
+  notify_my_car_reservations: "off" | "on";
+  notify_my_car_trips: "off" | "on";
 }
 
 export interface Notification {

--- a/types/index.ts
+++ b/types/index.ts
@@ -14,6 +14,20 @@ export interface Person {
   /** Bumped to revoke all of a user's existing sessions ("log out everywhere"). */
   session_epoch?: number;
   updated_at: string;
+  notify_new_reservations: "off" | "all" | "own";
+  notify_reservation_updates: "off" | "all" | "own";
+  notify_new_trips: "off" | "all" | "own";
+}
+
+export interface Notification {
+  id: number;
+  recipient_person_id: number;
+  type: string;
+  entity_type: string;
+  entity_id: number;
+  message: string;
+  read_at: string | null;
+  created_at: string;
 }
 
 export interface Car {


### PR DESCRIPTION
Closes #358.

In-app notification system: a bell + `/notifications` page, opt-in per-person preferences, and notification generation on reservation/trip mutations.

## Notification settings — two-block model
**Driver block (all members):**
- **New reservations** `off|all` — others' new reservations
- **Reservation updates** `off|all|mine` — `off` = none (not even your own outcome); `mine` = only your own outcome; `all` = yours + everyone else's
- **New trips** `off|all` — others' trips

**Owner block (only car owners, gated on `me.isOwner`):**
- **Reservations for my car(s)** `off|on`
- **Trips with my car(s)** `off|on`

An owner who also drives other cars follows their *own* activity via the driver block and their *car* via the owner block — independent, no overlap.

## Behaviour
- The reserver is always told their own outcome (approved/rejected/deleted) **unless** they set reservation updates to `off`.
- Self-outcome notifications are worded "Your reservation …"; others' are "Reservation …".
- Messages include the date range + specific status word.
- Notifications mark read per-item on click; "mark all read" is a subtle text link, disabled when nothing is unread.
- Profile page auto-saves on blur (no Save button); theme + notification saves share the top-right indicator; save errors toast.

## Data
- `migrations/0026_notifications.sql` — notifications table + driver pref columns
- `migrations/0027_owner_notify_prefs.sql` — owner toggle columns + normalises existing `reservation_updates 'off' -> 'mine'`

## Verification
- typecheck ✅ · lint ✅ (0 errors) · **942** unit ✅
- e2e (prod build, port 4358): notifications + reservations + members + profile + trips ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)