### PR TITLE
feat(multi-tenant): Phase 1 — tenant isolation, host routing, seed scripts, and Edge Runtime fix

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,9 +49,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: |
-            ghcr.io/demeesterroel/carsharing
-            demeesterroel/carsharing
+          images: ghcr.io/demeesterroel/carsharing
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=,format=short,enable={{is_default_branch}}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,6 +26,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Log in to Docker Hub
+        if: "${{ secrets.DOCKERHUB_TOKEN != '' || secrets.DOCKER_HUB_TOKEN != '' }}"
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME || 'demeesterroel' }}
+          password: ${{ secrets.DOCKERHUB_TOKEN || secrets.DOCKER_HUB_TOKEN }}
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
         with:
@@ -42,7 +49,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/demeesterroel/carsharing
+          images: |
+            ghcr.io/demeesterroel/carsharing
+            demeesterroel/carsharing
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=,format=short,enable={{is_default_branch}}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,11 +27,11 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        if: "${{ secrets.DOCKERHUB_TOKEN != '' || secrets.DOCKER_HUB_TOKEN != '' }}"
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME || 'demeesterroel' }}
-          password: ${{ secrets.DOCKERHUB_TOKEN || secrets.DOCKER_HUB_TOKEN }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        continue-on-error: true
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,5 @@
 name: Build and push Docker image
+run-name: ${{ github.event_name == 'release' && github.event.release.name || (github.event_name == 'workflow_dispatch' && inputs.version != '' && format('{0} - Docker Build', inputs.version)) || github.event.head_commit.message }}
 
 on:
   push:

--- a/app/login/login-form.tsx
+++ b/app/login/login-form.tsx
@@ -7,7 +7,15 @@ import { Eye, EyeOff } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
-export default function LoginForm({ mailEnabled }: { mailEnabled: boolean }) {
+export default function LoginForm({
+  mailEnabled,
+  tenantName,
+  tenantSlug,
+}: {
+  mailEnabled: boolean;
+  tenantName?: string;
+  tenantSlug?: string;
+}) {
   const router = useRouter();
   const qc = useQueryClient();
   const t = useT();
@@ -133,6 +141,32 @@ export default function LoginForm({ mailEnabled }: { mailEnabled: boolean }) {
           >
             {t("brand.tagline")}
           </p>
+
+          {tenantName && (
+            <div
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 6,
+                marginTop: 12,
+                padding: "4px 12px",
+                background: tokens.paperDark,
+                borderRadius: 16,
+                fontFamily: fontMono,
+                fontSize: 11,
+                fontWeight: 600,
+                color: tokens.ink,
+              }}
+            >
+              <span>{tenantName}</span>
+              {tenantSlug && tenantSlug !== "primary" && (
+                <span style={{ fontSize: 9, color: tokens.inkDim, textTransform: "uppercase" }}>
+                  ({tenantSlug})
+                </span>
+              )}
+            </div>
+          )}
+
           <div style={{ display: "flex", justifyContent: "center", marginTop: 16 }}>
             <LangSwitcher />
           </div>

--- a/app/login/login-form.tsx
+++ b/app/login/login-form.tsx
@@ -133,39 +133,27 @@ export default function LoginForm({
           <p
             style={{
               fontFamily: fontMono,
-              fontSize: 11,
-              color: tokens.inkDim,
+              fontSize: 12,
+              fontWeight: 600,
+              color: tokens.ink,
               marginTop: 6,
-              letterSpacing: 1,
+              letterSpacing: 0.5,
             }}
           >
-            {t("brand.tagline")}
+            {tenantName ?? t("brand.tagline")}
+            {tenantSlug && tenantSlug !== "primary" && (
+              <span
+                style={{
+                  fontSize: 10,
+                  color: tokens.inkDim,
+                  marginLeft: 6,
+                  textTransform: "uppercase",
+                }}
+              >
+                ({tenantSlug})
+              </span>
+            )}
           </p>
-
-          {tenantName && (
-            <div
-              style={{
-                display: "inline-flex",
-                alignItems: "center",
-                gap: 6,
-                marginTop: 12,
-                padding: "4px 12px",
-                background: tokens.paperDark,
-                borderRadius: 16,
-                fontFamily: fontMono,
-                fontSize: 11,
-                fontWeight: 600,
-                color: tokens.ink,
-              }}
-            >
-              <span>{tenantName}</span>
-              {tenantSlug && tenantSlug !== "primary" && (
-                <span style={{ fontSize: 9, color: tokens.inkDim, textTransform: "uppercase" }}>
-                  ({tenantSlug})
-                </span>
-              )}
-            </div>
-          )}
 
           <div style={{ display: "flex", justifyContent: "center", marginTop: 16 }}>
             <LangSwitcher />

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,10 +1,23 @@
 import { isMailEnabled } from "@/lib/mailer";
+import { getTenantBySlug } from "@/lib/platform-db";
+import { headers } from "next/headers";
 import LoginForm from "./login-form";
 
-// Read mail config at request time so the magic-link option appears as soon as a
-// transport is configured (#277), without a rebuild.
+// Read mail config and tenant context at request time
 export const dynamic = "force-dynamic";
 
-export default function LoginPage() {
-  return <LoginForm mailEnabled={isMailEnabled()} />;
+export default async function LoginPage() {
+  const reqHeaders = await headers();
+  const tenantSlug = reqHeaders.get("x-tenant-slug") ?? "primary";
+  const tenant = getTenantBySlug(tenantSlug);
+
+  const tenantName = tenant?.name ?? `Cooperative ${tenantSlug}`;
+
+  return (
+    <LoginForm
+      mailEnabled={isMailEnabled()}
+      tenantName={tenantName}
+      tenantSlug={tenantSlug}
+    />
+  );
 }

--- a/docs/multi-tenant.md
+++ b/docs/multi-tenant.md
@@ -1,0 +1,121 @@
+# Multi-Tenant Mode — Developer & Operator Guide
+
+This guide explains how Multi-Tenant mode works in CarSharing, how to enable it, and how to provision and manage new tenant cooperatives.
+
+---
+
+## 1. Architecture Overview
+
+CarSharing uses a **Database-per-Tenant** isolation model:
+
+- **Central Platform DB (`data/platform.db`)**: Manages the tenant registry (`tenants` table) and routing for external integrations (such as Google Calendar webhooks).
+- **Tenant Databases (`data/tenants/{slug}.db`)**: Each cooperative tenant operates on an isolated SQLite database containing its own members, cars, trips, fuel fill-ups, expenses, reservations, and settlements.
+- **Backward Compatibility**: Single-tenant deployments continue operating seamlessly with zero configuration changes using `data/carsharing.db` mapped to the default tenant slug `primary`.
+
+---
+
+## 2. Enabling Multi-Tenant Mode
+
+Multi-tenant mode requires no complex infrastructure services. Configure your environment variables in `.env` or `.env.local`:
+
+```env
+# Default tenant slug for main domain requests or fallback (default: "primary")
+DEFAULT_TENANT_SLUG=primary
+
+# Directory where per-tenant SQLite database files are stored
+TENANTS_DIR=data/tenants
+```
+
+### Request Tenant Resolution Strategy (Drupal Sites-Style)
+
+The application extracts the tenant slug and metadata for each HTTP request in the following priority order:
+
+1. **`x-tenant-slug` HTTP Header**: Injected by a reverse proxy (e.g. Nginx, Caddy, Cloudflare, Traefik).
+2. **`tenants.json` Site Mapping (Drupal Multisite Style)**:
+   Define exact host mappings or wildcard subdomains in `tenants.json` (or path in `TENANTS_CONFIG_PATH`):
+   ```json
+   {
+     "default": "primary",
+     "sites": {
+       "autodelen.bluette.be": {
+         "slug": "autodelen",
+         "name": "Van Trier"
+       },
+       "wim.autodelen.bluette.be": {
+         "slug": "wim",
+         "name": "Wim",
+         "adminEmail": "wim@autodelen.bluette.be"
+       },
+       "*.mycoop.org": {
+         "name": "MyCoop Branch"
+       }
+     }
+   }
+   ```
+3. **Dynamic Host Subdomain**:
+   - Production: `coop-gent.example.com` extracts tenant slug `coop-gent`.
+   - Local Development: `coop-gent.localhost:3000` extracts tenant slug `coop-gent`.
+4. **Fallback**: Default tenant slug defined in `tenants.json` or `DEFAULT_TENANT_SLUG` (`primary`).
+
+---
+
+## 3. Provisioning & Configuring a New Tenant
+
+### Step 1: Register the Tenant in the Platform Database
+
+Run the tenant creation helper via CLI or Node script:
+
+```bash
+npx tsx -e '
+  import { createTenantRecord } from "./lib/platform-db";
+  createTenantRecord("coop-gent", "Cooperative Gent", "admin@coop-gent.be");
+  console.log("Tenant registered!");
+'
+```
+
+### Step 2: Database Initialization
+
+When the new tenant URL (e.g., `http://coop-gent.localhost:3000` or `https://coop-gent.example.com`) receives its first request, the database connection resolver (`lib/db.ts`) will:
+
+1. Automatically create `data/tenants/coop-gent.db`.
+2. Apply all SQLite schema migrations (`0001` through latest).
+
+### Step 3: Populate Demo Accounts or Seed Data (Optional)
+
+To populate demo members (`admin`/`admin`, `owner`/`owner`, `alice`, `bob`, `carol`) and sample trips into the new tenant DB:
+
+```bash
+DB_PATH=data/tenants/coop-gent.db npx tsx scripts/seed-demo.ts
+```
+
+---
+
+## 4. Local Development with Multi-Tenant Mode
+
+### Convenience Seed Script
+
+To reset and seed the platform DB along with all demo tenant databases (`primary`, `coop-a`, `coop-b`) in one command:
+
+```bash
+npm run dev:seed
+```
+
+This populates `data/platform.db`, `data/tenants/primary.db`, `data/tenants/coop-a.db`, `data/tenants/coop-b.db` and starts the Next.js dev server.
+
+### Local Subdomain URLs
+
+You can test multi-tenant subdomains locally out of the box in modern browsers:
+
+- `http://primary.localhost:3000`
+- `http://coop-a.localhost:3000`
+- `http://coop-b.localhost:3000`
+
+---
+
+## 5. Backup & Restore Operations
+
+When performing backups in multi-tenant mode, include all platform and tenant database files:
+
+- **Platform Registry**: `data/platform.db` (and `-wal`, `-shm` files)
+- **Tenant Databases**: `data/tenants/*.db` (and `-wal`, `-shm` files)
+- **Legacy Primary DB**: `data/carsharing.db` (if upgraded from single-tenant)

--- a/lib/__tests__/multi_tenant.test.ts
+++ b/lib/__tests__/multi_tenant.test.ts
@@ -1,6 +1,7 @@
 import { closeAllTenantDbs, getDb, getTenantDbPath } from "@/lib/db";
 import {
   createTenantRecord,
+  formatTenantName,
   getPlatformDb,
   getTenantBySlug,
   getTenantSlugByCalendarChannel,
@@ -15,7 +16,7 @@ import path from "path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 describe("Multi-Tenant Architecture", () => {
-  const testTenantSlugs = ["tenant-a", "tenant-b", "zonnedael"];
+  const testTenantSlugs = ["tenant-a", "tenant-b", "zonnedael", "custom-coop"];
 
   function cleanupTestArtifacts() {
     closeAllTenantDbs();
@@ -41,10 +42,10 @@ describe("Multi-Tenant Architecture", () => {
       try {
         const platformDb = getPlatformDb();
         platformDb
-          .prepare("DELETE FROM tenants WHERE slug IN (?, ?, ?)")
+          .prepare("DELETE FROM tenants WHERE slug IN (?, ?, ?, ?)")
           .run(...testTenantSlugs);
         platformDb
-          .prepare("DELETE FROM calendar_channels WHERE tenant_slug IN (?, ?, ?)")
+          .prepare("DELETE FROM calendar_channels WHERE tenant_slug IN (?, ?, ?, ?)")
           .run(...testTenantSlugs);
       } catch {
         // ignore
@@ -70,6 +71,20 @@ describe("Multi-Tenant Architecture", () => {
       expect(defaultTenant).not.toBeNull();
       expect(defaultTenant?.name).toBe("Primary Cooperative");
       expect(defaultTenant?.status).toBe("active");
+    });
+
+    it("formats generic tenant names cleanly from slugs", () => {
+      expect(formatTenantName("coop-a")).toBe("Cooperative A");
+      expect(formatTenantName("groene-buurt")).toBe("Groene Buurt");
+      expect(formatTenantName("my-car-share")).toBe("My Car Share");
+    });
+
+    it("dynamically auto-registers unknown tenant slugs with formatted generic names", () => {
+      const tenant = getTenantBySlug("custom-coop");
+      expect(tenant).toBeDefined();
+      expect(tenant.slug).toBe("custom-coop");
+      expect(tenant.name).toBe("Custom Coop");
+      expect(tenant.status).toBe("active");
     });
 
     it("provisions new tenant records and updates status", () => {

--- a/lib/__tests__/multi_tenant.test.ts
+++ b/lib/__tests__/multi_tenant.test.ts
@@ -1,0 +1,170 @@
+import { closeAllTenantDbs, getDb, getTenantDbPath } from "@/lib/db";
+import {
+  createTenantRecord,
+  getPlatformDb,
+  getTenantBySlug,
+  getTenantSlugByCalendarChannel,
+  registerCalendarChannel,
+  resetPlatformDbInstanceForTesting,
+  setTenantStatus,
+} from "@/lib/platform-db";
+import { extractTenantSlug } from "@/lib/tenant-context";
+import fs from "fs";
+import { NextRequest } from "next/server";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+describe("Multi-Tenant Architecture", () => {
+  const testTenantSlugs = ["tenant-a", "tenant-b", "zonnedael"];
+
+  function cleanupTestArtifacts() {
+    closeAllTenantDbs();
+    resetPlatformDbInstanceForTesting();
+
+    // Clean up test tenant database files
+    for (const slug of testTenantSlugs) {
+      const dbPath = path.join(process.cwd(), "data", "tenants", `${slug}.db`);
+      for (const file of [dbPath, `${dbPath}-wal`, `${dbPath}-shm`]) {
+        if (fs.existsSync(file)) {
+          try {
+            fs.unlinkSync(file);
+          } catch {
+            // ignore
+          }
+        }
+      }
+    }
+
+    // Clean up test tenant records from platform.db if platform.db exists
+    const platformDbPath = path.join(process.cwd(), "data", "platform.db");
+    if (fs.existsSync(platformDbPath)) {
+      try {
+        const platformDb = getPlatformDb();
+        platformDb
+          .prepare("DELETE FROM tenants WHERE slug IN (?, ?, ?)")
+          .run(...testTenantSlugs);
+        platformDb
+          .prepare("DELETE FROM calendar_channels WHERE tenant_slug IN (?, ?, ?)")
+          .run(...testTenantSlugs);
+      } catch {
+        // ignore
+      }
+      resetPlatformDbInstanceForTesting();
+    }
+  }
+
+  beforeEach(() => {
+    cleanupTestArtifacts();
+  });
+
+  afterEach(() => {
+    cleanupTestArtifacts();
+  });
+
+  describe("Platform Database & Tenant Registry", () => {
+    it("initializes platform database with default primary tenant", () => {
+      const platformDb = getPlatformDb();
+      expect(platformDb).toBeDefined();
+
+      const defaultTenant = getTenantBySlug("primary");
+      expect(defaultTenant).not.toBeNull();
+      expect(defaultTenant?.name).toBe("Primary Cooperative");
+      expect(defaultTenant?.status).toBe("active");
+    });
+
+    it("provisions new tenant records and updates status", () => {
+      const tenant = createTenantRecord(
+        "zonnedael",
+        "Zonnedael Autodeel",
+        "admin@zonnedael.be"
+      );
+      expect(tenant.slug).toBe("zonnedael");
+      expect(tenant.name).toBe("Zonnedael Autodeel");
+      expect(tenant.admin_email).toBe("admin@zonnedael.be");
+      expect(tenant.status).toBe("active");
+
+      setTenantStatus("zonnedael", "suspended");
+      const updated = getTenantBySlug("zonnedael");
+      expect(updated?.status).toBe("suspended");
+    });
+
+    it("registers and looks up google calendar webhook channels per tenant", () => {
+      registerCalendarChannel("channel-xyz-123", "zonnedael", "resource-abc-789");
+
+      const slug = getTenantSlugByCalendarChannel("channel-xyz-123");
+      expect(slug).toBe("zonnedael");
+
+      const unknown = getTenantSlugByCalendarChannel("non-existent-channel");
+      expect(unknown).toBeNull();
+    });
+  });
+
+  describe("Tenant Database Connection Resolver", () => {
+    it("resolves default tenant DB path correctly", () => {
+      const defaultPath = getTenantDbPath();
+      expect(defaultPath).toContain("primary.db");
+    });
+
+    it("creates isolated DB connections and applies migrations for distinct tenants", () => {
+      const dbA = getDb("tenant-a");
+      const dbB = getDb("tenant-b");
+
+      expect(dbA).not.toBe(dbB);
+
+      // Verify schema was initialized on tenant-a
+      const tablesA = dbA
+        .prepare("SELECT name FROM sqlite_master WHERE type='table'")
+        .all() as { name: string }[];
+      const tableNamesA = tablesA.map((t) => t.name);
+      expect(tableNamesA).toContain("people");
+      expect(tableNamesA).toContain("cars");
+      expect(tableNamesA).toContain("trips");
+
+      // Verify tenant data isolation
+      dbA.prepare(
+        "INSERT INTO people (first_name, last_name, discount) VALUES ('Alice', 'Smith', 0)"
+      ).run();
+      dbB.prepare(
+        "INSERT INTO people (first_name, last_name, discount) VALUES ('Bob', 'Jones', 0)"
+      ).run();
+
+      const peopleA = dbA
+        .prepare("SELECT first_name FROM people WHERE first_name IN ('Alice', 'Bob')")
+        .all() as { first_name: string }[];
+      const peopleB = dbB
+        .prepare("SELECT first_name FROM people WHERE first_name IN ('Alice', 'Bob')")
+        .all() as { first_name: string }[];
+
+      expect(peopleA.map((p) => p.first_name)).toEqual(["Alice"]);
+      expect(peopleB.map((p) => p.first_name)).toEqual(["Bob"]);
+    });
+  });
+
+  describe("Tenant Context Extraction", () => {
+    it("extracts tenant slug from x-tenant-slug header", () => {
+      const req = new NextRequest("http://localhost:3000/", {
+        headers: { "x-tenant-slug": "groenebuurt" },
+      });
+      expect(extractTenantSlug(req)).toBe("groenebuurt");
+    });
+
+    it("extracts tenant slug from subdomain", () => {
+      const req = new NextRequest("http://groenebuurt.carsharing.app/trips", {
+        headers: { host: "groenebuurt.carsharing.app" },
+      });
+      expect(extractTenantSlug(req)).toBe("groenebuurt");
+    });
+
+    it("falls back to default tenant for main domain or localhost", () => {
+      const reqLocal = new NextRequest("http://localhost:3000/", {
+        headers: { host: "localhost:3000" },
+      });
+      expect(extractTenantSlug(reqLocal)).toBe("primary");
+
+      const reqApp = new NextRequest("http://app.carsharing.app/", {
+        headers: { host: "app.carsharing.app" },
+      });
+      expect(extractTenantSlug(reqApp)).toBe("primary");
+    });
+  });
+});

--- a/lib/__tests__/multi_tenant.test.ts
+++ b/lib/__tests__/multi_tenant.test.ts
@@ -10,6 +10,7 @@ import {
   setTenantStatus,
 } from "@/lib/platform-db";
 import { extractTenantSlug } from "@/lib/tenant-context";
+import { resetTenantsConfigCache } from "@/lib/tenants-config";
 import fs from "fs";
 import { NextRequest } from "next/server";
 import path from "path";
@@ -195,6 +196,59 @@ describe("Multi-Tenant Architecture", () => {
         headers: { host: "subdomain.carsharing.app" },
       });
       expect(extractTenantSlug(reqTenant)).toBe("subdomain");
+    });
+  });
+
+  describe("Drupal-Style Site Mapping (tenants.json)", () => {
+    const testJsonPath = path.join(process.cwd(), "tenants.test.json");
+
+    beforeEach(() => {
+      process.env.TENANTS_CONFIG_PATH = "tenants.test.json";
+      resetTenantsConfigCache();
+      fs.writeFileSync(
+        testJsonPath,
+        JSON.stringify({
+          default: "main-coop",
+          sites: {
+            "demo.carsharing.app": { slug: "demo-site", name: "Demo Site" },
+            "custom.cooperative.org": { slug: "custom-org", name: "Custom Org" },
+            "*.mycoop.org": { name: "MyCoop Branch" },
+          },
+        })
+      );
+    });
+
+    afterEach(() => {
+      delete process.env.TENANTS_CONFIG_PATH;
+      resetTenantsConfigCache();
+      if (fs.existsSync(testJsonPath)) {
+        try {
+          fs.unlinkSync(testJsonPath);
+        } catch {
+          // ignore
+        }
+      }
+    });
+
+    it("matches exact domains from tenants.json", () => {
+      const reqDemo = new NextRequest("http://demo.carsharing.app/login", {
+        headers: { host: "demo.carsharing.app" },
+      });
+      expect(extractTenantSlug(reqDemo)).toBe("demo-site");
+
+      const reqCustom = new NextRequest("http://custom.cooperative.org/trips", {
+        headers: { host: "custom.cooperative.org:3000" },
+      });
+      expect(extractTenantSlug(reqCustom)).toBe("custom-org");
+      expect(formatTenantName("custom-org")).toBe("Custom Org");
+    });
+
+    it("supports wildcard domain matching in tenants.json", () => {
+      const reqBranch = new NextRequest("http://gent.mycoop.org/login", {
+        headers: { host: "gent.mycoop.org" },
+      });
+      expect(extractTenantSlug(reqBranch)).toBe("gent");
+      expect(formatTenantName("gent")).toBe("MyCoop Branch");
     });
   });
 });

--- a/lib/__tests__/multi_tenant.test.ts
+++ b/lib/__tests__/multi_tenant.test.ts
@@ -148,14 +148,26 @@ describe("Multi-Tenant Architecture", () => {
       expect(extractTenantSlug(req)).toBe("groenebuurt");
     });
 
-    it("extracts tenant slug from subdomain", () => {
+    it("extracts tenant slug from subdomain.domain.tld", () => {
       const req = new NextRequest("http://groenebuurt.carsharing.app/trips", {
         headers: { host: "groenebuurt.carsharing.app" },
       });
       expect(extractTenantSlug(req)).toBe("groenebuurt");
     });
 
-    it("falls back to default tenant for main domain or localhost", () => {
+    it("extracts tenant slug from *.localhost development subdomains", () => {
+      const reqA = new NextRequest("http://coop-a.localhost:3000/login", {
+        headers: { host: "coop-a.localhost:3000" },
+      });
+      expect(extractTenantSlug(reqA)).toBe("coop-a");
+
+      const reqB = new NextRequest("http://coop-b.localhost:3000/login", {
+        headers: { host: "coop-b.localhost:3000" },
+      });
+      expect(extractTenantSlug(reqB)).toBe("coop-b");
+    });
+
+    it("falls back to default tenant for main domain or plain localhost", () => {
       const reqLocal = new NextRequest("http://localhost:3000/", {
         headers: { host: "localhost:3000" },
       });

--- a/lib/__tests__/multi_tenant.test.ts
+++ b/lib/__tests__/multi_tenant.test.ts
@@ -88,11 +88,7 @@ describe("Multi-Tenant Architecture", () => {
     });
 
     it("provisions new tenant records and updates status", () => {
-      const tenant = createTenantRecord(
-        "zonnedael",
-        "Zonnedael Autodeel",
-        "admin@zonnedael.be"
-      );
+      const tenant = createTenantRecord("zonnedael", "Zonnedael Autodeel", "admin@zonnedael.be");
       expect(tenant.slug).toBe("zonnedael");
       expect(tenant.name).toBe("Zonnedael Autodeel");
       expect(tenant.admin_email).toBe("admin@zonnedael.be");
@@ -127,21 +123,23 @@ describe("Multi-Tenant Architecture", () => {
       expect(dbA).not.toBe(dbB);
 
       // Verify schema was initialized on tenant-a
-      const tablesA = dbA
-        .prepare("SELECT name FROM sqlite_master WHERE type='table'")
-        .all() as { name: string }[];
+      const tablesA = dbA.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as {
+        name: string;
+      }[];
       const tableNamesA = tablesA.map((t) => t.name);
       expect(tableNamesA).toContain("people");
       expect(tableNamesA).toContain("cars");
       expect(tableNamesA).toContain("trips");
 
       // Verify tenant data isolation
-      dbA.prepare(
-        "INSERT INTO people (first_name, last_name, discount) VALUES ('Alice', 'Smith', 0)"
-      ).run();
-      dbB.prepare(
-        "INSERT INTO people (first_name, last_name, discount) VALUES ('Bob', 'Jones', 0)"
-      ).run();
+      dbA
+        .prepare(
+          "INSERT INTO people (first_name, last_name, discount) VALUES ('Alice', 'Smith', 0)"
+        )
+        .run();
+      dbB
+        .prepare("INSERT INTO people (first_name, last_name, discount) VALUES ('Bob', 'Jones', 0)")
+        .run();
 
       const peopleA = dbA
         .prepare("SELECT first_name FROM people WHERE first_name IN ('Alice', 'Bob')")
@@ -192,6 +190,11 @@ describe("Multi-Tenant Architecture", () => {
         headers: { host: "app.carsharing.app" },
       });
       expect(extractTenantSlug(reqApp)).toBe("primary");
+
+      const reqAutodelen = new NextRequest("http://autodelen.bluette.be/", {
+        headers: { host: "autodelen.bluette.be" },
+      });
+      expect(extractTenantSlug(reqAutodelen)).toBe("primary");
     });
   });
 });

--- a/lib/__tests__/multi_tenant.test.ts
+++ b/lib/__tests__/multi_tenant.test.ts
@@ -191,10 +191,10 @@ describe("Multi-Tenant Architecture", () => {
       });
       expect(extractTenantSlug(reqApp)).toBe("primary");
 
-      const reqAutodelen = new NextRequest("http://autodelen.bluette.be/", {
-        headers: { host: "autodelen.bluette.be" },
+      const reqTenant = new NextRequest("http://subdomain.carsharing.app/", {
+        headers: { host: "subdomain.carsharing.app" },
       });
-      expect(extractTenantSlug(reqAutodelen)).toBe("primary");
+      expect(extractTenantSlug(reqTenant)).toBe("subdomain");
     });
   });
 });

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,30 +1,78 @@
 // SQL injection audit (issue #30): all queries use ? placeholders — no interpolation found.
 
 import Database from "better-sqlite3";
+import fs from "fs";
+import path from "path";
 import { runMigrations } from "./db/migrate";
 import { env } from "./env";
 
-let _db: Database.Database | null = null;
+const _dbConnections = new Map<string, Database.Database>();
+
+/** Resolves the database file path for a given tenant slug. */
+export function getTenantDbPath(slug?: string): string {
+  const defaultSlug = env.DEFAULT_TENANT_SLUG ?? "primary";
+  const targetSlug = slug || defaultSlug;
+
+  const tenantsDir = env.TENANTS_DIR ?? "data/tenants";
+  const tenantPath = path.join(tenantsDir, `${targetSlug}.db`);
+
+  // Legacy fallback: if target is default tenant and tenant DB file doesn't exist yet,
+  // check if env.DB_PATH (data/carsharing.db) exists.
+  if (targetSlug === defaultSlug && !fs.existsSync(tenantPath)) {
+    if (fs.existsSync(env.DB_PATH)) {
+      return env.DB_PATH;
+    }
+  }
+
+  return tenantPath;
+}
 
 /**
- * Returns the singleton SQLite database connection, initialising it on first call.
+ * Returns the SQLite database connection for the specified tenant slug (or default tenant).
  * Enables WAL mode, foreign keys, and runs pending migrations automatically.
- * @returns The shared `better-sqlite3` database instance.
+ * @param tenantSlug - Optional tenant identifier slug. Defaults to env.DEFAULT_TENANT_SLUG ("primary").
+ * @returns The tenant's `better-sqlite3` database instance.
  */
-export function getDb(): Database.Database {
-  if (!_db) {
-    _db = new Database(env.DB_PATH);
-    _db.pragma("journal_mode = WAL");
-    _db.pragma("foreign_keys = ON");
-    runMigrations(_db);
+export function getDb(tenantSlug?: string): Database.Database {
+  const defaultSlug = env.DEFAULT_TENANT_SLUG ?? "primary";
+  const slug = tenantSlug || defaultSlug;
+
+  let db = _dbConnections.get(slug);
+  if (!db || !db.open) {
+    const dbPath = getTenantDbPath(slug);
+    const parentDir = path.dirname(dbPath);
+    if (!fs.existsSync(parentDir)) {
+      fs.mkdirSync(parentDir, { recursive: true });
+    }
+
+    db = new Database(dbPath);
+    db.pragma("journal_mode = WAL");
+    db.pragma("foreign_keys = ON");
+
+    runMigrations(db);
 
     if (process.env.DEBUG_SQL === "1") {
-      const originalPrepare = _db.prepare.bind(_db);
-      (_db as any).prepare = (sql: string) => {
-        console.log("[sql]", sql.trim().replace(/\s+/g, " "));
+      const originalPrepare = db.prepare.bind(db);
+      (db as any).prepare = (sql: string) => {
+        console.log(`[sql][tenant:${slug}]`, sql.trim().replace(/\s+/g, " "));
         return originalPrepare(sql);
       };
     }
+
+    _dbConnections.set(slug, db);
   }
-  return _db;
+
+  return db;
+}
+
+/** Close all tenant database connections (useful for testing & shutdown). */
+export function closeAllTenantDbs(): void {
+  for (const [slug, db] of _dbConnections.entries()) {
+    try {
+      if (db.open) db.close();
+    } catch {
+      // ignore
+    }
+  }
+  _dbConnections.clear();
 }

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,9 +1,10 @@
 import { z } from "zod";
 
 const isBuildPhase = process.env.NEXT_PHASE === "phase-production-build";
+const isBuildOrTest = isBuildPhase || process.env.NODE_ENV === "test";
 
 const envSchema = z.object({
-  SESSION_PASSWORD: isBuildPhase
+  SESSION_PASSWORD: isBuildOrTest
     ? z.string().optional().default("build-placeholder")
     : z.string().min(1, "SESSION_PASSWORD is required"),
   DB_PATH: z
@@ -23,7 +24,9 @@ const envSchema = z.object({
   MAIL_FROM: z.string().optional(),
   // Resend HTTP API key. When set, transactional mail (reset / magic-link /
   // invite) is sent via Resend; takes precedence over MAIL_WEBHOOK_URL.
-  RESEND_API_KEY: z.string().optional(),
+  // Multi-tenant configuration
+  DEFAULT_TENANT_SLUG: z.string().optional().default("primary"),
+  TENANTS_DIR: z.string().optional().default("data/tenants"),
 });
 
 type Env = z.infer<typeof envSchema>;

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -27,6 +27,7 @@ const envSchema = z.object({
   // Multi-tenant configuration
   DEFAULT_TENANT_SLUG: z.string().optional().default("primary"),
   TENANTS_DIR: z.string().optional().default("data/tenants"),
+  TENANTS_CONFIG_PATH: z.string().optional().default("tenants.json"),
 });
 
 type Env = z.infer<typeof envSchema>;

--- a/lib/platform-db.ts
+++ b/lib/platform-db.ts
@@ -2,6 +2,7 @@ import Database from "better-sqlite3";
 import fs from "fs";
 import path from "path";
 import { env } from "./env";
+import { getTenantConfigBySlug } from "./tenants-config";
 
 export interface TenantRecord {
   id: number;
@@ -62,9 +63,7 @@ function initPlatformSchema(db: Database.Database): void {
 
   // Ensure default primary tenant exists in platform.db
   const defaultSlug = env.DEFAULT_TENANT_SLUG ?? "primary";
-  const existingDefault = db
-    .prepare("SELECT 1 FROM tenants WHERE slug = ?")
-    .get(defaultSlug);
+  const existingDefault = db.prepare("SELECT 1 FROM tenants WHERE slug = ?").get(defaultSlug);
 
   if (!existingDefault) {
     db.prepare(
@@ -75,10 +74,11 @@ function initPlatformSchema(db: Database.Database): void {
 
 /** Formats a generic human-friendly tenant name from a slug (e.g. "coop-a" -> "Cooperative A", "groene-buurt" -> "Groene Buurt") */
 export function formatTenantName(slug: string): string {
+  const config = getTenantConfigBySlug(slug);
+  if (config && config.name) return config.name;
+
   if (!slug || slug === "primary") return "Primary Cooperative";
-  const clean = slug
-    .replace(/^coop[-_]?/i, "Cooperative ")
-    .replace(/[-_]/g, " ");
+  const clean = slug.replace(/^coop[-_]?/i, "Cooperative ").replace(/[-_]/g, " ");
   return clean
     .split(" ")
     .filter(Boolean)
@@ -88,21 +88,31 @@ export function formatTenantName(slug: string): string {
 
 export function getTenantBySlug(slug: string): TenantRecord {
   const db = getPlatformDb();
-  const tenant = db
-    .prepare("SELECT * FROM tenants WHERE slug = ?")
-    .get(slug) as TenantRecord | undefined;
+  const tenant = db.prepare("SELECT * FROM tenants WHERE slug = ?").get(slug) as
+    | TenantRecord
+    | undefined;
+
+  const siteConfig = getTenantConfigBySlug(slug);
 
   if (!tenant) {
     // If querying an unseeded slug, return a synthetic TenantRecord (pure read, no side-effect write)
     return {
       id: 0,
       slug,
-      name: formatTenantName(slug),
+      name: siteConfig?.name || formatTenantName(slug),
       status: "active",
-      admin_email: null,
-      custom_domain: null,
+      admin_email: siteConfig?.adminEmail || null,
+      custom_domain: siteConfig?.customDomain || null,
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
+    };
+  }
+
+  if (siteConfig?.name) {
+    return {
+      ...tenant,
+      name: siteConfig.name,
+      admin_email: siteConfig.adminEmail ?? tenant.admin_email,
     };
   }
 
@@ -120,9 +130,7 @@ export function getTenantByDomain(domain: string): TenantRecord | null {
 
 export function getAllTenants(): TenantRecord[] {
   const db = getPlatformDb();
-  return db
-    .prepare("SELECT * FROM tenants ORDER BY name ASC")
-    .all() as TenantRecord[];
+  return db.prepare("SELECT * FROM tenants ORDER BY name ASC").all() as TenantRecord[];
 }
 
 export function createTenantRecord(
@@ -140,14 +148,12 @@ export function createTenantRecord(
   return getTenantBySlug(slug);
 }
 
-export function setTenantStatus(
-  slug: string,
-  status: "active" | "suspended"
-): void {
+export function setTenantStatus(slug: string, status: "active" | "suspended"): void {
   const db = getPlatformDb();
-  db.prepare(
-    "UPDATE tenants SET status = ?, updated_at = datetime('now') WHERE slug = ?"
-  ).run(status, slug);
+  db.prepare("UPDATE tenants SET status = ?, updated_at = datetime('now') WHERE slug = ?").run(
+    status,
+    slug
+  );
 }
 
 export function registerCalendarChannel(
@@ -162,9 +168,7 @@ export function registerCalendarChannel(
   ).run(channelId, tenantSlug, resourceId);
 }
 
-export function getTenantSlugByCalendarChannel(
-  channelId: string
-): string | null {
+export function getTenantSlugByCalendarChannel(channelId: string): string | null {
   const db = getPlatformDb();
   const row = db
     .prepare("SELECT tenant_slug FROM calendar_channels WHERE channel_id = ?")

--- a/lib/platform-db.ts
+++ b/lib/platform-db.ts
@@ -59,32 +59,49 @@ function initPlatformSchema(db: Database.Database): void {
     );
   `);
 
-  // Ensure default demo tenants exist in platform.db
+  // Ensure default primary tenant exists in platform.db
   const defaultSlug = env.DEFAULT_TENANT_SLUG ?? "primary";
-  const demoTenants = [
-    { slug: defaultSlug, name: "Primary Cooperative" },
-    { slug: "coop-a", name: "Cooperative A (Gent)" },
-    { slug: "coop-b", name: "Cooperative B (Antwerpen)" },
-  ];
-
-  for (const t of demoTenants) {
-    const existing = db.prepare("SELECT 1 FROM tenants WHERE slug = ?").get(t.slug);
-    if (!existing) {
-      db.prepare("INSERT INTO tenants (slug, name, status) VALUES (?, ?, 'active')").run(
-        t.slug,
-        t.name
-      );
-    }
+  const existingDefault = db
+    .prepare("SELECT 1 FROM tenants WHERE slug = ?")
+    .get(defaultSlug);
+  if (!existingDefault) {
+    db.prepare(
+      "INSERT INTO tenants (slug, name, status) VALUES (?, ?, 'active')"
+    ).run(defaultSlug, "Primary Cooperative");
   }
 }
 
-export function getTenantBySlug(slug: string): TenantRecord | null {
+/** Formats a generic human-friendly tenant name from a slug (e.g. "coop-a" -> "Cooperative A", "groene-buurt" -> "Groene Buurt") */
+export function formatTenantName(slug: string): string {
+  if (!slug || slug === "primary") return "Primary Cooperative";
+  const clean = slug
+    .replace(/^coop[-_]?/i, "Cooperative ")
+    .replace(/[-_]/g, " ");
+  return clean
+    .split(" ")
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+    .join(" ");
+}
+
+export function getTenantBySlug(slug: string): TenantRecord {
   const db = getPlatformDb();
-  return (
-    (db.prepare("SELECT * FROM tenants WHERE slug = ?").get(slug) as
-      | TenantRecord
-      | undefined) ?? null
-  );
+  let tenant = db
+    .prepare("SELECT * FROM tenants WHERE slug = ?")
+    .get(slug) as TenantRecord | undefined;
+
+  // Auto-register generic tenant record if accessed dynamically (e.g. on localhost or subdomains)
+  if (!tenant) {
+    const genericName = formatTenantName(slug);
+    db.prepare(
+      "INSERT OR IGNORE INTO tenants (slug, name, status) VALUES (?, ?, 'active')"
+    ).run(slug, genericName);
+    tenant = db
+      .prepare("SELECT * FROM tenants WHERE slug = ?")
+      .get(slug) as TenantRecord;
+  }
+
+  return tenant;
 }
 
 export function getTenantByDomain(domain: string): TenantRecord | null {
@@ -111,11 +128,11 @@ export function createTenantRecord(
 ): TenantRecord {
   const db = getPlatformDb();
   db.prepare(
-    `INSERT INTO tenants (slug, name, admin_email, status)
-     VALUES (?, ?, ?, ?)`
+    `INSERT OR REPLACE INTO tenants (slug, name, admin_email, status, updated_at)
+     VALUES (?, ?, ?, ?, datetime('now'))`
   ).run(slug, name, adminEmail ?? null, status);
 
-  return getTenantBySlug(slug)!;
+  return getTenantBySlug(slug);
 }
 
 export function setTenantStatus(

--- a/lib/platform-db.ts
+++ b/lib/platform-db.ts
@@ -59,15 +59,22 @@ function initPlatformSchema(db: Database.Database): void {
     );
   `);
 
-  // Ensure default primary tenant exists in platform.db
+  // Ensure default demo tenants exist in platform.db
   const defaultSlug = env.DEFAULT_TENANT_SLUG ?? "primary";
-  const existingDefault = db
-    .prepare("SELECT 1 FROM tenants WHERE slug = ?")
-    .get(defaultSlug);
-  if (!existingDefault) {
-    db.prepare(
-      "INSERT INTO tenants (slug, name, status) VALUES (?, ?, 'active')"
-    ).run(defaultSlug, "Primary Cooperative");
+  const demoTenants = [
+    { slug: defaultSlug, name: "Primary Cooperative" },
+    { slug: "coop-a", name: "Cooperative A (Gent)" },
+    { slug: "coop-b", name: "Cooperative B (Antwerpen)" },
+  ];
+
+  for (const t of demoTenants) {
+    const existing = db.prepare("SELECT 1 FROM tenants WHERE slug = ?").get(t.slug);
+    if (!existing) {
+      db.prepare("INSERT INTO tenants (slug, name, status) VALUES (?, ?, 'active')").run(
+        t.slug,
+        t.name
+      );
+    }
   }
 }
 

--- a/lib/platform-db.ts
+++ b/lib/platform-db.ts
@@ -34,12 +34,11 @@ export function getPlatformDb(): Database.Database {
     _platformDb.pragma("foreign_keys = ON");
 
     initPlatformSchema(_platformDb);
-    seedPlatformDb(_platformDb);
   }
   return _platformDb;
 }
 
-/** Initializes the DDL schema for the platform database. */
+/** Initializes the DDL schema for the platform database and ensures default primary tenant exists. */
 function initPlatformSchema(db: Database.Database): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS tenants (
@@ -60,26 +59,18 @@ function initPlatformSchema(db: Database.Database): void {
       updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
     );
   `);
-}
 
-/** Seeds initial platform database records (primary tenant & demo cooperatives). */
-export function seedPlatformDb(db: Database.Database): void {
+  // Ensure default primary tenant exists in platform.db
   const defaultSlug = env.DEFAULT_TENANT_SLUG ?? "primary";
-  const defaultTenants = [
-    { slug: defaultSlug, name: "Primary Cooperative" },
-    { slug: "coop-a", name: "Cooperative A (Gent)" },
-    { slug: "coop-b", name: "Cooperative B (Antwerpen)" },
-  ];
+  const existingDefault = db
+    .prepare("SELECT 1 FROM tenants WHERE slug = ?")
+    .get(defaultSlug);
 
-  const insert = db.prepare(
-    "INSERT OR IGNORE INTO tenants (slug, name, status) VALUES (?, ?, 'active')"
-  );
-
-  db.transaction(() => {
-    for (const t of defaultTenants) {
-      insert.run(t.slug, t.name);
-    }
-  })();
+  if (!existingDefault) {
+    db.prepare(
+      "INSERT INTO tenants (slug, name, status) VALUES (?, 'Primary Cooperative', 'active')"
+    ).run(defaultSlug);
+  }
 }
 
 /** Formats a generic human-friendly tenant name from a slug (e.g. "coop-a" -> "Cooperative A", "groene-buurt" -> "Groene Buurt") */
@@ -97,7 +88,7 @@ export function formatTenantName(slug: string): string {
 
 export function getTenantBySlug(slug: string): TenantRecord {
   const db = getPlatformDb();
-  let tenant = db
+  const tenant = db
     .prepare("SELECT * FROM tenants WHERE slug = ?")
     .get(slug) as TenantRecord | undefined;
 

--- a/lib/platform-db.ts
+++ b/lib/platform-db.ts
@@ -34,10 +34,12 @@ export function getPlatformDb(): Database.Database {
     _platformDb.pragma("foreign_keys = ON");
 
     initPlatformSchema(_platformDb);
+    seedPlatformDb(_platformDb);
   }
   return _platformDb;
 }
 
+/** Initializes the DDL schema for the platform database. */
 function initPlatformSchema(db: Database.Database): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS tenants (
@@ -58,17 +60,26 @@ function initPlatformSchema(db: Database.Database): void {
       updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
     );
   `);
+}
 
-  // Ensure default primary tenant exists in platform.db
+/** Seeds initial platform database records (primary tenant & demo cooperatives). */
+export function seedPlatformDb(db: Database.Database): void {
   const defaultSlug = env.DEFAULT_TENANT_SLUG ?? "primary";
-  const existingDefault = db
-    .prepare("SELECT 1 FROM tenants WHERE slug = ?")
-    .get(defaultSlug);
-  if (!existingDefault) {
-    db.prepare(
-      "INSERT INTO tenants (slug, name, status) VALUES (?, ?, 'active')"
-    ).run(defaultSlug, "Primary Cooperative");
-  }
+  const defaultTenants = [
+    { slug: defaultSlug, name: "Primary Cooperative" },
+    { slug: "coop-a", name: "Cooperative A (Gent)" },
+    { slug: "coop-b", name: "Cooperative B (Antwerpen)" },
+  ];
+
+  const insert = db.prepare(
+    "INSERT OR IGNORE INTO tenants (slug, name, status) VALUES (?, ?, 'active')"
+  );
+
+  db.transaction(() => {
+    for (const t of defaultTenants) {
+      insert.run(t.slug, t.name);
+    }
+  })();
 }
 
 /** Formats a generic human-friendly tenant name from a slug (e.g. "coop-a" -> "Cooperative A", "groene-buurt" -> "Groene Buurt") */
@@ -90,15 +101,18 @@ export function getTenantBySlug(slug: string): TenantRecord {
     .prepare("SELECT * FROM tenants WHERE slug = ?")
     .get(slug) as TenantRecord | undefined;
 
-  // Auto-register generic tenant record if accessed dynamically (e.g. on localhost or subdomains)
   if (!tenant) {
-    const genericName = formatTenantName(slug);
-    db.prepare(
-      "INSERT OR IGNORE INTO tenants (slug, name, status) VALUES (?, ?, 'active')"
-    ).run(slug, genericName);
-    tenant = db
-      .prepare("SELECT * FROM tenants WHERE slug = ?")
-      .get(slug) as TenantRecord;
+    // If querying an unseeded slug, return a synthetic TenantRecord (pure read, no side-effect write)
+    return {
+      id: 0,
+      slug,
+      name: formatTenantName(slug),
+      status: "active",
+      admin_email: null,
+      custom_domain: null,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    };
   }
 
   return tenant;

--- a/lib/platform-db.ts
+++ b/lib/platform-db.ts
@@ -1,0 +1,156 @@
+import Database from "better-sqlite3";
+import fs from "fs";
+import path from "path";
+import { env } from "./env";
+
+export interface TenantRecord {
+  id: number;
+  slug: string;
+  name: string;
+  status: "active" | "suspended" | "pending_setup";
+  admin_email: string | null;
+  custom_domain: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+let _platformDb: Database.Database | null = null;
+
+export function getPlatformDbPath(): string {
+  const dataDir = path.dirname(env.DB_PATH);
+  return path.join(dataDir, "platform.db");
+}
+
+export function getPlatformDb(): Database.Database {
+  if (!_platformDb) {
+    const dbPath = getPlatformDbPath();
+    const dataDir = path.dirname(dbPath);
+    if (!fs.existsSync(dataDir)) {
+      fs.mkdirSync(dataDir, { recursive: true });
+    }
+
+    _platformDb = new Database(dbPath);
+    _platformDb.pragma("journal_mode = WAL");
+    _platformDb.pragma("foreign_keys = ON");
+
+    initPlatformSchema(_platformDb);
+  }
+  return _platformDb;
+}
+
+function initPlatformSchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS tenants (
+      id            INTEGER PRIMARY KEY AUTOINCREMENT,
+      slug          TEXT    NOT NULL UNIQUE,
+      name          TEXT    NOT NULL,
+      status        TEXT    NOT NULL DEFAULT 'active',
+      admin_email   TEXT,
+      custom_domain TEXT    UNIQUE,
+      created_at    TEXT    NOT NULL DEFAULT (datetime('now')),
+      updated_at    TEXT    NOT NULL DEFAULT (datetime('now'))
+    );
+
+    CREATE TABLE IF NOT EXISTS calendar_channels (
+      channel_id  TEXT PRIMARY KEY,
+      tenant_slug TEXT NOT NULL,
+      resource_id TEXT NOT NULL,
+      updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
+
+  // Ensure default primary tenant exists in platform.db
+  const defaultSlug = env.DEFAULT_TENANT_SLUG ?? "primary";
+  const existingDefault = db
+    .prepare("SELECT 1 FROM tenants WHERE slug = ?")
+    .get(defaultSlug);
+  if (!existingDefault) {
+    db.prepare(
+      "INSERT INTO tenants (slug, name, status) VALUES (?, ?, 'active')"
+    ).run(defaultSlug, "Primary Cooperative");
+  }
+}
+
+export function getTenantBySlug(slug: string): TenantRecord | null {
+  const db = getPlatformDb();
+  return (
+    (db.prepare("SELECT * FROM tenants WHERE slug = ?").get(slug) as
+      | TenantRecord
+      | undefined) ?? null
+  );
+}
+
+export function getTenantByDomain(domain: string): TenantRecord | null {
+  const db = getPlatformDb();
+  return (
+    (db.prepare("SELECT * FROM tenants WHERE custom_domain = ?").get(domain) as
+      | TenantRecord
+      | undefined) ?? null
+  );
+}
+
+export function getAllTenants(): TenantRecord[] {
+  const db = getPlatformDb();
+  return db
+    .prepare("SELECT * FROM tenants ORDER BY name ASC")
+    .all() as TenantRecord[];
+}
+
+export function createTenantRecord(
+  slug: string,
+  name: string,
+  adminEmail?: string,
+  status: "active" | "suspended" | "pending_setup" = "active"
+): TenantRecord {
+  const db = getPlatformDb();
+  db.prepare(
+    `INSERT INTO tenants (slug, name, admin_email, status)
+     VALUES (?, ?, ?, ?)`
+  ).run(slug, name, adminEmail ?? null, status);
+
+  return getTenantBySlug(slug)!;
+}
+
+export function setTenantStatus(
+  slug: string,
+  status: "active" | "suspended"
+): void {
+  const db = getPlatformDb();
+  db.prepare(
+    "UPDATE tenants SET status = ?, updated_at = datetime('now') WHERE slug = ?"
+  ).run(status, slug);
+}
+
+export function registerCalendarChannel(
+  channelId: string,
+  tenantSlug: string,
+  resourceId: string
+): void {
+  const db = getPlatformDb();
+  db.prepare(
+    `INSERT OR REPLACE INTO calendar_channels (channel_id, tenant_slug, resource_id, updated_at)
+     VALUES (?, ?, ?, datetime('now'))`
+  ).run(channelId, tenantSlug, resourceId);
+}
+
+export function getTenantSlugByCalendarChannel(
+  channelId: string
+): string | null {
+  const db = getPlatformDb();
+  const row = db
+    .prepare("SELECT tenant_slug FROM calendar_channels WHERE channel_id = ?")
+    .get(channelId) as { tenant_slug: string } | undefined;
+  return row?.tenant_slug ?? null;
+}
+
+/** Reset platform db instance (for unit tests) */
+export function resetPlatformDbInstanceForTesting(): void {
+  if (_platformDb) {
+    try {
+      _platformDb.close();
+    } catch {
+      // ignore
+    }
+    _platformDb = null;
+  }
+}

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -4,6 +4,7 @@ import { env } from "./env";
 /** Shape of the iron-session payload stored in the encrypted cookie. */
 export interface SessionData {
   authenticated: boolean;
+  tenantSlug?: string;
   personId?: number;
   shortName?: string;
   isAdmin?: boolean;

--- a/lib/tenant-context.ts
+++ b/lib/tenant-context.ts
@@ -5,7 +5,7 @@ import { env } from "./env";
  * Extracts the tenant slug from an incoming HTTP request.
  * Strategy:
  * 1. Read `x-tenant-slug` header if present (e.g. injected by reverse proxy).
- * 2. Parse subdomain from `Host` header (e.g. `coop-a.carsharing.app` -> `coop-a`).
+ * 2. Parse subdomain from `Host` header (e.g. `coop-a.localhost` or `coop-a.carsharing.app` -> `coop-a`).
  * 3. Fallback to `env.DEFAULT_TENANT_SLUG` ("primary").
  */
 export function extractTenantSlug(req: NextRequest | Request): string {
@@ -19,16 +19,25 @@ export function extractTenantSlug(req: NextRequest | Request): string {
   const host = req.headers.get("host") || "";
   const hostname = host.split(":")[0].toLowerCase();
 
-  // Exclude IP addresses and localhost
+  // Exclude empty host, plain "localhost", or IP addresses
   if (!hostname || hostname === "localhost" || /^(\d{1,3}\.){3}\d{1,3}$/.test(hostname)) {
     return defaultSlug;
   }
 
   const parts = hostname.split(".");
-  // If subdomain exists (e.g. coop.domain.com or coop.local)
+
+  // Handle subdomain.localhost (e.g., coop-a.localhost -> parts: ['coop-a', 'localhost'])
+  if (parts.length === 2 && parts[1] === "localhost") {
+    const subdomain = parts[0];
+    if (subdomain && subdomain !== "www" && subdomain !== "app") {
+      return subdomain;
+    }
+  }
+
+  // Handle subdomain.domain.tld (e.g. coop-a.carsharing.app -> 3+ parts)
   if (parts.length >= 3) {
     const subdomain = parts[0];
-    if (subdomain !== "www" && subdomain !== "app") {
+    if (subdomain && subdomain !== "www" && subdomain !== "app") {
       return subdomain;
     }
   }

--- a/lib/tenant-context.ts
+++ b/lib/tenant-context.ts
@@ -29,7 +29,7 @@ export function extractTenantSlug(req: NextRequest | Request): string {
   // Handle subdomain.localhost (e.g., coop-a.localhost -> parts: ['coop-a', 'localhost'])
   if (parts.length === 2 && parts[1] === "localhost") {
     const subdomain = parts[0];
-    if (subdomain && subdomain !== "www" && subdomain !== "app") {
+    if (subdomain && !["www", "app", "autodelen"].includes(subdomain)) {
       return subdomain;
     }
   }
@@ -37,7 +37,7 @@ export function extractTenantSlug(req: NextRequest | Request): string {
   // Handle subdomain.domain.tld (e.g. coop-a.carsharing.app -> 3+ parts)
   if (parts.length >= 3) {
     const subdomain = parts[0];
-    if (subdomain && subdomain !== "www" && subdomain !== "app") {
+    if (subdomain && !["www", "app", "autodelen"].includes(subdomain)) {
       return subdomain;
     }
   }

--- a/lib/tenant-context.ts
+++ b/lib/tenant-context.ts
@@ -29,7 +29,7 @@ export function extractTenantSlug(req: NextRequest | Request): string {
   // Handle subdomain.localhost (e.g., coop-a.localhost -> parts: ['coop-a', 'localhost'])
   if (parts.length === 2 && parts[1] === "localhost") {
     const subdomain = parts[0];
-    if (subdomain && !["www", "app", "autodelen"].includes(subdomain)) {
+    if (subdomain && subdomain !== "www" && subdomain !== "app") {
       return subdomain;
     }
   }
@@ -37,7 +37,7 @@ export function extractTenantSlug(req: NextRequest | Request): string {
   // Handle subdomain.domain.tld (e.g. coop-a.carsharing.app -> 3+ parts)
   if (parts.length >= 3) {
     const subdomain = parts[0];
-    if (subdomain && !["www", "app", "autodelen"].includes(subdomain)) {
+    if (subdomain && subdomain !== "www" && subdomain !== "app") {
       return subdomain;
     }
   }

--- a/lib/tenant-context.ts
+++ b/lib/tenant-context.ts
@@ -1,25 +1,32 @@
 import { NextRequest } from "next/server";
 import { env } from "./env";
+import { getTenantConfigForHost, getTenantsConfig } from "./tenants-config";
 
 /**
  * Extracts the tenant slug from an incoming HTTP request.
- * Strategy:
+ * Strategy (Drupal multisite style):
  * 1. Read `x-tenant-slug` header if present (e.g. injected by reverse proxy).
- * 2. Parse subdomain from `Host` header (e.g. `coop-a.localhost` or `coop-a.carsharing.app` -> `coop-a`).
- * 3. Fallback to `env.DEFAULT_TENANT_SLUG` ("primary").
+ * 2. Match host in `tenants.json` site-mapping config (e.g. "wim.autodelen.bluette.be" -> "wim").
+ * 3. Parse subdomain from `Host` header (e.g. `coop-a.localhost` or `coop-a.carsharing.app` -> `coop-a`).
+ * 4. Fallback to `default` tenant slug in `tenants.json` or `env.DEFAULT_TENANT_SLUG` ("primary").
  */
 export function extractTenantSlug(req: NextRequest | Request): string {
-  const defaultSlug = env.DEFAULT_TENANT_SLUG ?? "primary";
+  const config = getTenantsConfig();
+  const defaultSlug = config.default || env.DEFAULT_TENANT_SLUG || "primary";
 
   // 1. Explicit header
   const customHeader = req.headers.get("x-tenant-slug");
   if (customHeader) return customHeader.trim().toLowerCase();
 
-  // 2. Subdomain check from host header
+  // 2. Drupal-style site-mapping match from tenants.json
   const host = req.headers.get("host") || "";
-  const hostname = host.split(":")[0].toLowerCase();
+  const siteConfig = getTenantConfigForHost(host);
+  if (siteConfig && siteConfig.slug) {
+    return siteConfig.slug.trim().toLowerCase();
+  }
 
-  // Exclude empty host, plain "localhost", or IP addresses
+  // 3. Dynamic subdomain check from host header
+  const hostname = host.split(":")[0].toLowerCase();
   if (!hostname || hostname === "localhost" || /^(\d{1,3}\.){3}\d{1,3}$/.test(hostname)) {
     return defaultSlug;
   }

--- a/lib/tenant-context.ts
+++ b/lib/tenant-context.ts
@@ -1,0 +1,37 @@
+import { NextRequest } from "next/server";
+import { env } from "./env";
+
+/**
+ * Extracts the tenant slug from an incoming HTTP request.
+ * Strategy:
+ * 1. Read `x-tenant-slug` header if present (e.g. injected by reverse proxy).
+ * 2. Parse subdomain from `Host` header (e.g. `coop-a.carsharing.app` -> `coop-a`).
+ * 3. Fallback to `env.DEFAULT_TENANT_SLUG` ("primary").
+ */
+export function extractTenantSlug(req: NextRequest | Request): string {
+  const defaultSlug = env.DEFAULT_TENANT_SLUG ?? "primary";
+
+  // 1. Explicit header
+  const customHeader = req.headers.get("x-tenant-slug");
+  if (customHeader) return customHeader.trim().toLowerCase();
+
+  // 2. Subdomain check from host header
+  const host = req.headers.get("host") || "";
+  const hostname = host.split(":")[0].toLowerCase();
+
+  // Exclude IP addresses and localhost
+  if (!hostname || hostname === "localhost" || /^(\d{1,3}\.){3}\d{1,3}$/.test(hostname)) {
+    return defaultSlug;
+  }
+
+  const parts = hostname.split(".");
+  // If subdomain exists (e.g. coop.domain.com or coop.local)
+  if (parts.length >= 3) {
+    const subdomain = parts[0];
+    if (subdomain !== "www" && subdomain !== "app") {
+      return subdomain;
+    }
+  }
+
+  return defaultSlug;
+}

--- a/lib/tenants-config.ts
+++ b/lib/tenants-config.ts
@@ -1,0 +1,116 @@
+import fs from "fs";
+import path from "path";
+import { env } from "./env";
+
+export interface TenantConfig {
+  slug: string;
+  name?: string;
+  adminEmail?: string;
+  customDomain?: string;
+}
+
+export interface TenantsConfigFile {
+  default?: string;
+  sites?: Record<string, TenantConfig>;
+}
+
+let cachedConfig: TenantsConfigFile | null = null;
+let lastMtime = 0;
+
+/**
+ * Loads the Drupal-style `tenants.json` configuration file.
+ * Caches the config in-memory and reloads automatically if the file modification timestamp changes.
+ */
+export function getTenantsConfig(): TenantsConfigFile {
+  try {
+    const targetPath = process.env.TENANTS_CONFIG_PATH || env.TENANTS_CONFIG_PATH || "tenants.json";
+    const configPath = path.isAbsolute(targetPath)
+      ? targetPath
+      : path.join(process.cwd(), targetPath);
+
+    if (!fs.existsSync(configPath)) {
+      return { default: env.DEFAULT_TENANT_SLUG, sites: {} };
+    }
+
+    const stat = fs.statSync(configPath);
+    if (cachedConfig && stat.mtimeMs === lastMtime) {
+      return cachedConfig;
+    }
+
+    const raw = fs.readFileSync(configPath, "utf-8");
+    const parsed = JSON.parse(raw) as TenantsConfigFile;
+
+    cachedConfig = {
+      default: parsed.default || env.DEFAULT_TENANT_SLUG,
+      sites: parsed.sites || {},
+    };
+    lastMtime = stat.mtimeMs;
+    return cachedConfig;
+  } catch (e) {
+    console.warn("[tenants-config] Could not parse tenants.json:", (e as Error).message);
+    return { default: env.DEFAULT_TENANT_SLUG, sites: {} };
+  }
+}
+
+/** Resets the in-memory config cache (useful for testing) */
+export function resetTenantsConfigCache(): void {
+  cachedConfig = null;
+  lastMtime = 0;
+}
+
+/**
+ * Looks up a tenant configuration matching an incoming HTTP host (Drupal sites.php style).
+ * Matching precedence:
+ * 1. Exact host match (e.g. "wim.autodelen.bluette.be")
+ * 2. Host without port (e.g. "wim.autodelen.bluette.be:3000" -> "wim.autodelen.bluette.be")
+ * 3. Wildcard domain match (e.g. "*.autodelen.bluette.be")
+ */
+export function getTenantConfigForHost(host: string): TenantConfig | null {
+  if (!host) return null;
+  const cleanHost = host.split(":")[0].toLowerCase();
+  const config = getTenantsConfig();
+  const sites = config.sites || {};
+
+  // 1. Direct host match
+  if (sites[cleanHost]) {
+    return sites[cleanHost];
+  }
+
+  // 2. Wildcard domain match (e.g. *.autodelen.bluette.be -> match wim.autodelen.bluette.be)
+  const hostParts = cleanHost.split(".");
+  if (hostParts.length > 2) {
+    const parentDomain = "*." + hostParts.slice(1).join(".");
+    if (sites[parentDomain]) {
+      const parent = sites[parentDomain];
+      // Inherit parent config with dynamic subdomain slug
+      return {
+        slug: hostParts[0],
+        name: parent.name,
+        adminEmail: parent.adminEmail,
+      };
+    }
+  }
+
+  return null;
+}
+
+/** Looks up tenant metadata by slug from tenants.json */
+export function getTenantConfigBySlug(slug: string): TenantConfig | null {
+  if (!slug) return null;
+  const config = getTenantsConfig();
+  const sites = config.sites || {};
+
+  for (const [key, item] of Object.entries(sites)) {
+    if (item.slug && item.slug.toLowerCase() === slug.toLowerCase()) {
+      return item;
+    }
+  }
+
+  for (const [key, item] of Object.entries(sites)) {
+    if (key.startsWith("*.") && item.name) {
+      return { slug, name: item.name, adminEmail: item.adminEmail };
+    }
+  }
+
+  return null;
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A self-hosted Progressive Web App (PWA) for managing a car-sharing cooperative. Track mileage trips, fuel fill-ups, maintenance costs, car reservations, and per-member financial balances.",
   "scripts": {
     "dev": "next dev --webpack",
+    "dev:seed": "npm run seed:demo && next dev --webpack",
     "build": "next build --webpack",
     "start": "next start",
     "lint": "eslint .",

--- a/proxy.ts
+++ b/proxy.ts
@@ -36,19 +36,25 @@ const ADMIN_ONLY_PAGES = ["/vehicles", "/people", "/payments"];
 // endpoints and the magic-link consume route stay accessible.
 const GUEST_ONLY_PAGES = ["/login", "/forgot", "/reset"];
 
+import { extractTenantSlug } from "@/lib/tenant-context";
+
 export async function proxy(req: NextRequest) {
   const { pathname } = req.nextUrl;
+  const tenantSlug = extractTenantSlug(req);
 
   // Static assets and Next.js internals are excluded via the matcher below.
   if (PUBLIC_PATHS.some((p) => pathname === p || pathname.startsWith(p + "/"))) {
     if (GUEST_ONLY_PAGES.some((p) => pathname === p || pathname.startsWith(p + "/"))) {
       const res = NextResponse.next();
+      res.headers.set("x-tenant-slug", tenantSlug);
       const session = await getIronSession<SessionData>(req, res, sessionOptions);
       if (session.authenticated) {
         return NextResponse.redirect(new URL("/", req.url));
       }
     }
-    return NextResponse.next();
+    const res = NextResponse.next();
+    res.headers.set("x-tenant-slug", tenantSlug);
+    return res;
   }
 
   // Reject sessions that lack a personId — env-var fallback admin sessions
@@ -68,6 +74,7 @@ export async function proxy(req: NextRequest) {
   }
 
   const res = NextResponse.next();
+  res.headers.set("x-tenant-slug", tenantSlug);
   // Re-read session on the pass-through response so downstream cookie ops are wired correctly.
   await getIronSession<SessionData>(req, res, sessionOptions);
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -42,17 +42,20 @@ export async function proxy(req: NextRequest) {
   const { pathname } = req.nextUrl;
   const tenantSlug = extractTenantSlug(req);
 
+  const requestHeaders = new Headers(req.headers);
+  requestHeaders.set("x-tenant-slug", tenantSlug);
+
   // Static assets and Next.js internals are excluded via the matcher below.
   if (PUBLIC_PATHS.some((p) => pathname === p || pathname.startsWith(p + "/"))) {
     if (GUEST_ONLY_PAGES.some((p) => pathname === p || pathname.startsWith(p + "/"))) {
-      const res = NextResponse.next();
+      const res = NextResponse.next({ request: { headers: requestHeaders } });
       res.headers.set("x-tenant-slug", tenantSlug);
       const session = await getIronSession<SessionData>(req, res, sessionOptions);
       if (session.authenticated) {
         return NextResponse.redirect(new URL("/", req.url));
       }
     }
-    const res = NextResponse.next();
+    const res = NextResponse.next({ request: { headers: requestHeaders } });
     res.headers.set("x-tenant-slug", tenantSlug);
     return res;
   }
@@ -73,7 +76,7 @@ export async function proxy(req: NextRequest) {
     return loginRedirect;
   }
 
-  const res = NextResponse.next();
+  const res = NextResponse.next({ request: { headers: requestHeaders } });
   res.headers.set("x-tenant-slug", tenantSlug);
   // Re-read session on the pass-through response so downstream cookie ops are wired correctly.
   await getIronSession<SessionData>(req, res, sessionOptions);

--- a/scripts/seed-demo.ts
+++ b/scripts/seed-demo.ts
@@ -1,5 +1,9 @@
+process.env.SESSION_PASSWORD =
+  process.env.SESSION_PASSWORD || "dev-session-password-placeholder-32-chars";
+
 import bcrypt from "bcryptjs";
 import Database from "better-sqlite3";
+import { execSync } from "child_process";
 import { mkdirSync } from "fs";
 import path from "path";
 import { runMigrations } from "../lib/db/migrate.js";
@@ -7,638 +11,579 @@ import { calcPricePerLiter, calcTripAmount } from "../lib/formulas.js";
 import { shortNameOf } from "../lib/person-utils.js";
 import { getSettlement } from "../lib/queries/settlement.js";
 
-const DB_PATH = process.env.DB_PATH ?? path.join(process.cwd(), "data", "carsharing.db");
-mkdirSync(path.dirname(DB_PATH), { recursive: true });
-const db = new Database(DB_PATH);
-db.pragma("journal_mode = WAL");
-db.pragma("foreign_keys = ON");
-runMigrations(db);
+// First, seed the Platform DB (Default + Demo Tenants)
+console.log("Seeding platform database with demo tenants...");
+execSync("npx tsx scripts/seed-platform.ts", { stdio: "inherit" });
 
-// ── Seeded RNG ────────────────────────────────────────────────────────────────
+function seedSingleTenantDb(targetPath: string) {
+  console.log(`\n--- Seeding tenant database: ${path.basename(targetPath)} ---`);
+  mkdirSync(path.dirname(targetPath), { recursive: true });
+  const db = new Database(targetPath);
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+  runMigrations(db);
 
-function mulberry32(seed: number) {
-  return () => {
-    seed |= 0;
-    seed = (seed + 0x6d2b79f5) | 0;
-    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
-    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  function mulberry32(seed: number) {
+    return () => {
+      seed |= 0;
+      seed = (seed + 0x6d2b79f5) | 0;
+      let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+      t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+  }
+
+  const rng = mulberry32(0xdeadbeef);
+  const rand = (min: number, max: number) => min + rng() * (max - min);
+  const randInt = (min: number, max: number) => Math.floor(rand(min, max + 1));
+  const pick = <T>(arr: readonly T[] | T[]): T => arr[Math.floor(rng() * arr.length)];
+
+  const YEARS = [2021, 2022, 2023, 2024, 2025, 2026];
+
+  const PEOPLE = [
+    {
+      first_name: "Admin",
+      last_name: "One",
+      username: "admin",
+      password: "admin",
+      is_admin: 1,
+      discount: 0,
+      discount_long: 0,
+      bank_account: "BE00 0000 0000 0001",
+      email: "admin@demo.local",
+    },
+    {
+      first_name: "Owner",
+      last_name: "Two",
+      username: "owner",
+      password: "owner",
+      is_admin: 0,
+      discount: 0,
+      discount_long: 0,
+      bank_account: "BE00 0000 0000 0002",
+      email: "owner@demo.local",
+    },
+    {
+      first_name: "Alice",
+      last_name: "Smith",
+      username: "alice",
+      password: "alice",
+      is_admin: 0,
+      discount: 0,
+      discount_long: 0,
+      bank_account: "BE00 0000 0000 0003",
+      email: "alice@demo.local",
+    },
+    {
+      first_name: "Bob",
+      last_name: "Jones",
+      username: "bob",
+      password: "bob",
+      is_admin: 0,
+      discount: 0.25,
+      discount_long: 0.5,
+      bank_account: "BE00 0000 0000 0004",
+      email: "bob@demo.local",
+    },
+    {
+      first_name: "Carol",
+      last_name: "Brown",
+      username: "carol",
+      password: "carol",
+      is_admin: 0,
+      discount: 0.25,
+      discount_long: 0.5,
+      bank_account: "BE00 0000 0000 0005",
+      email: "carol@demo.local",
+    },
+  ] as const;
+
+  const CARS = [
+    {
+      short: "AA",
+      name: "Car AA",
+      price_per_km: 0.28,
+      owner_username: "admin",
+      start_odometer: 45000,
+      active: 1,
+    },
+    {
+      short: "BB",
+      name: "Car BB",
+      price_per_km: 0.3,
+      owner_username: "owner",
+      start_odometer: 30000,
+      active: 1,
+    },
+    {
+      short: "CC",
+      name: "Car CC",
+      price_per_km: 0.26,
+      owner_username: "admin",
+      start_odometer: 62000,
+      active: 1,
+    },
+    {
+      short: "DD",
+      name: "Car DD",
+      price_per_km: 0.32,
+      owner_username: "owner",
+      start_odometer: 15000,
+      active: 0,
+    },
+  ] as const;
+
+  const LOCATIONS = [
+    "Antwerpen",
+    "Gent",
+    "Brussel",
+    "Leuven",
+    "Mechelen",
+    "Hasselt",
+    "Turnhout",
+    "Herentals",
+    "Mol",
+    "Aarschot",
+  ];
+
+  const EXPENSE_CATEGORIES = ["maintenance", "repair", "insurance"] as const;
+  const EXPENSE_DESCRIPTIONS: Record<string, string[]> = {
+    maintenance: ["Oil change", "Tire rotation", "Air filter", "Brake inspection"],
+    repair: ["Windshield repair", "Battery replacement", "Wiper blades", "Coolant flush"],
+    insurance: ["Annual premium", "Third-party top-up", "Roadside assistance"],
   };
-}
 
-const rng = mulberry32(0xdeadbeef);
-const rand = (min: number, max: number) => min + rng() * (max - min);
-const randInt = (min: number, max: number) => Math.floor(rand(min, max + 1));
-const pick = <T>(arr: readonly T[] | T[]): T => arr[Math.floor(rng() * arr.length)];
-
-// ── Static data ───────────────────────────────────────────────────────────────
-
-const YEARS = [2021, 2022, 2023, 2024, 2025, 2026];
-
-const PEOPLE = [
-  {
-    first_name: "Admin",
-    last_name: "One",
-    username: "admin",
-    password: "admin",
-    is_admin: 1,
-    discount: 0,
-    discount_long: 0,
-    bank_account: "BE00 0000 0000 0001",
-    email: "admin@demo.local",
-  },
-  {
-    first_name: "Owner",
-    last_name: "Two",
-    username: "owner",
-    password: "owner",
-    is_admin: 0,
-    discount: 0,
-    discount_long: 0,
-    bank_account: "BE00 0000 0000 0002",
-    email: "owner@demo.local",
-  },
-  {
-    first_name: "Alice",
-    last_name: "Smith",
-    username: "alice",
-    password: "alice",
-    is_admin: 0,
-    discount: 0,
-    discount_long: 0,
-    bank_account: "BE00 0000 0000 0003",
-    email: "alice@demo.local",
-  },
-  {
-    first_name: "Bob",
-    last_name: "Jones",
-    username: "bob",
-    password: "bob",
-    is_admin: 0,
-    discount: 0.25,
-    discount_long: 0.5,
-    bank_account: "BE00 0000 0000 0004",
-    email: "bob@demo.local",
-  },
-  {
-    first_name: "Carol",
-    last_name: "Brown",
-    username: "carol",
-    password: "carol",
-    is_admin: 0,
-    discount: 0.25,
-    discount_long: 0.5,
-    bank_account: "BE00 0000 0000 0005",
-    email: "carol@demo.local",
-  },
-] as const;
-
-const CARS = [
-  {
-    short: "AA",
-    name: "Car AA",
-    price_per_km: 0.28,
-    owner_username: "admin",
-    start_odometer: 45000,
-    active: 1,
-  },
-  {
-    short: "BB",
-    name: "Car BB",
-    price_per_km: 0.3,
-    owner_username: "owner",
-    start_odometer: 30000,
-    active: 1,
-  },
-  {
-    short: "CC",
-    name: "Car CC",
-    price_per_km: 0.26,
-    owner_username: "admin",
-    start_odometer: 62000,
-    active: 1,
-  },
-  {
-    short: "DD",
-    name: "Car DD",
-    price_per_km: 0.32,
-    owner_username: "owner",
-    start_odometer: 15000,
-    active: 0,
-  },
-] as const;
-
-const LOCATIONS = [
-  "Antwerpen",
-  "Gent",
-  "Brussel",
-  "Leuven",
-  "Mechelen",
-  "Hasselt",
-  "Turnhout",
-  "Herentals",
-  "Mol",
-  "Aarschot",
-];
-
-const EXPENSE_CATEGORIES = ["maintenance", "repair", "insurance"] as const;
-const EXPENSE_DESCRIPTIONS: Record<string, string[]> = {
-  maintenance: ["Oil change", "Tire rotation", "Air filter", "Brake inspection"],
-  repair: ["Windshield repair", "Battery replacement", "Wiper blades", "Coolant flush"],
-  insurance: ["Annual premium", "Third-party top-up", "Roadside assistance"],
-};
-
-// ── 1. People ─────────────────────────────────────────────────────────────────
-
-console.log("Seeding people...");
-
-// Purge leftover automated-test members that earlier runs may have written into
-// this DB (e.g. the E2E* fixtures from the Playwright suite). They are never part
-// of the demo set, carry no trips/fuel/expenses/payments, and — being created in
-// triplicate — collide on shortName, which trips the settlement annotation
-// warning. Username-less E2E rows are unambiguously test debris; drop them so
-// reseeds stay clean.
-db.prepare("DELETE FROM people WHERE first_name LIKE 'E2E%' AND username IS NULL").run();
-
-const insertPerson = db.prepare(`
-  INSERT OR IGNORE INTO people
-    (first_name, last_name, username, password_hash, is_admin, discount, discount_long, bank_account, email, active)
-  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
-`);
-const updatePerson = db.prepare(`
-  UPDATE people SET first_name = ?, last_name = ?, is_admin = ?, discount = ?, discount_long = ?, bank_account = ?, email = ? WHERE username = ?
-`);
-
-db.transaction(() => {
-  for (const p of PEOPLE) {
-    const hash = bcrypt.hashSync(p.password, 10);
-    insertPerson.run(
-      p.first_name,
-      p.last_name,
-      p.username,
-      hash,
-      p.is_admin,
-      p.discount,
-      p.discount_long,
-      p.bank_account,
-      p.email
-    );
-    updatePerson.run(
-      p.first_name,
-      p.last_name,
-      p.is_admin,
-      p.discount,
-      p.discount_long,
-      p.bank_account,
-      p.email,
-      p.username
-    );
-  }
-})();
-
-const getPersonByUsername = db.prepare("SELECT id FROM people WHERE username = ?");
-const personIdByUsername: Record<string, number> = {};
-for (const p of PEOPLE) {
-  const row = getPersonByUsername.get(p.username) as { id: number };
-  personIdByUsername[p.username] = row.id;
-}
-
-// Build discount lookup map: person id → {discount, discount_long}
-const personDiscounts = new Map<number, { discount: number; discount_long: number }>();
-for (const p of PEOPLE) {
-  personDiscounts.set(personIdByUsername[p.username], {
-    discount: p.discount,
-    discount_long: p.discount_long,
-  });
-}
-
-console.log(`  → ${PEOPLE.length} people`);
-
-// ── 2. Cars ───────────────────────────────────────────────────────────────────
-
-console.log("Seeding cars...");
-
-const insertCar = db.prepare(`
-  INSERT OR IGNORE INTO cars (short, name, price_per_km, owner_person_id, owner_from, active)
-  VALUES (?, ?, ?, ?, ?, ?)
-`);
-const updateCar = db.prepare(`
-  UPDATE cars SET name = ?, price_per_km = ?, owner_person_id = ?, owner_from = ?, active = ? WHERE short = ?
-`);
-
-const OWNER_FROM = "2020-01-01";
-
-db.transaction(() => {
-  for (const c of CARS) {
-    const ownerId = personIdByUsername[c.owner_username];
-    insertCar.run(c.short, c.name, c.price_per_km, ownerId, OWNER_FROM, c.active);
-    updateCar.run(c.name, c.price_per_km, ownerId, OWNER_FROM, c.active, c.short);
-  }
-})();
-
-const getCarByShort = db.prepare("SELECT id FROM cars WHERE short = ?");
-const carIdByShort: Record<string, number> = {};
-const carOdometer: Record<string, number> = {};
-for (const c of CARS) {
-  const row = getCarByShort.get(c.short) as { id: number };
-  carIdByShort[c.short] = row.id;
-  if (c.active) {
-    const existing = db
-      .prepare("SELECT MAX(end_odometer) AS max_odo FROM trips WHERE car_id = ?")
-      .get(row.id) as { max_odo: number | null };
-    carOdometer[c.short] = existing.max_odo ?? c.start_odometer;
-  }
-}
-
-const ACTIVE_CARS = CARS.filter((c) => c.active !== 0);
-console.log(`  → ${CARS.length} cars (${ACTIVE_CARS.length} active)`);
-
-// ── Price per litre drift table ───────────────────────────────────────────────
-
-function buildPriceTable(): Map<string, number> {
-  const prices = new Map<string, number>();
-  let price = 1.85;
-  for (const year of YEARS) {
-    for (let month = 1; month <= 12; month++) {
-      const step = (rng() - 0.5) * 0.1;
-      price = Math.max(1.5, Math.min(2.5, price + step));
-      prices.set(`${year}-${String(month).padStart(2, "0")}`, +price.toFixed(4));
-    }
-  }
-  return prices;
-}
-
-const priceTable = buildPriceTable();
-
-function priceForDate(dateStr: string): number {
-  const ym = dateStr.slice(0, 7);
-  return priceTable.get(ym) ?? 1.85;
-}
-
-// ── Date helpers ──────────────────────────────────────────────────────────────
-
-function randomDateInMonth(year: number, month: number): string {
-  const daysInMonth = new Date(year, month, 0).getDate();
-  const day = randInt(1, daysInMonth);
-  return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
-}
-
-function datesSpreadAcrossYear(year: number, count: number): string[] {
-  const dates: string[] = [];
-  const base = Math.floor(count / 12);
-  const extra = count % 12;
-  for (let m = 1; m <= 12; m++) {
-    const n = base + (m <= extra ? 1 : 0);
-    for (let i = 0; i < n; i++) dates.push(randomDateInMonth(year, m));
-  }
-  return dates.sort();
-}
-
-// ── 3. Trips ──────────────────────────────────────────────────────────────────
-
-console.log("Seeding trips...");
-
-const checkTrips = db.prepare(
-  "SELECT COUNT(*) AS n FROM trips WHERE car_id = ? AND date LIKE ? || '%'"
-);
-const insertTrip = db.prepare(`
-  INSERT INTO trips (person_id, car_id, date, start_odometer, end_odometer, km, amount, location)
-  VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-`);
-
-let tripsTotal = 0;
-const peopleIds = Object.values(personIdByUsername);
-
-for (const car of ACTIVE_CARS) {
-  const carId = carIdByShort[car.short];
-  for (const year of YEARS) {
-    const existing = (checkTrips.get(carId, String(year)) as { n: number }).n;
-    if (existing > 0) continue;
-
-    const TARGET_KM = randInt(5000, 10000);
-    const dates = datesSpreadAcrossYear(year, 50);
-    let kmBudget = TARGET_KM;
-
-    db.transaction(() => {
-      for (let i = 0; i < dates.length; i++) {
-        const remaining = dates.length - i;
-        const maxKm = Math.min(250, Math.floor((kmBudget / remaining) * 1.5));
-        const minKm = Math.max(80, Math.floor((kmBudget / remaining) * 0.5));
-        const km = Math.max(1, Math.min(maxKm, randInt(Math.min(minKm, maxKm), maxKm)));
-
-        const personId = peopleIds[Math.floor(rng() * peopleIds.length)];
-        const person = personDiscounts.get(personId)!;
-        const amount = calcTripAmount(km, car.price_per_km, person.discount, person.discount_long);
-
-        const start_odometer = carOdometer[car.short];
-        const end_odometer = start_odometer + km;
-        carOdometer[car.short] = end_odometer;
-        kmBudget -= km;
-
-        insertTrip.run(
-          personId,
-          carId,
-          dates[i],
-          start_odometer,
-          end_odometer,
-          km,
-          +amount.toFixed(2),
-          pick(LOCATIONS)
-        );
-      }
-    })();
-    tripsTotal += dates.length;
-  }
-}
-
-console.log(`  → ${tripsTotal} trips`);
-
-// ── 4. Fuel fill-ups ──────────────────────────────────────────────────────────
-
-console.log("Seeding fuel fill-ups...");
-
-const checkFuel = db.prepare(
-  "SELECT COUNT(*) AS n FROM fuel_fillups WHERE car_id = ? AND date LIKE ? || '%'"
-);
-const insertFuel = db.prepare(`
-  INSERT INTO fuel_fillups (person_id, car_id, date, amount, liters, price_per_liter)
-  VALUES (?, ?, ?, ?, ?, ?)
-`);
-
-let fuelTotal = 0;
-
-for (const car of ACTIVE_CARS) {
-  const carId = carIdByShort[car.short];
-  for (const year of YEARS) {
-    const existing = (checkFuel.get(carId, String(year)) as { n: number }).n;
-    if (existing > 0) continue;
-
-    const TARGET_LITERS = 700;
-    const dates = datesSpreadAcrossYear(year, 20);
-    let litersBudget = TARGET_LITERS;
-
-    db.transaction(() => {
-      for (let i = 0; i < dates.length; i++) {
-        const remaining = dates.length - i;
-        const avgNeeded = litersBudget / remaining;
-        const liters = +Math.max(10, Math.min(45, rand(avgNeeded * 0.8, avgNeeded * 1.2))).toFixed(
-          1
-        );
-        const ppl = priceForDate(dates[i]);
-        const amount = +(liters * ppl).toFixed(2);
-        const price_per_liter = +calcPricePerLiter(amount, liters).toFixed(4);
-        const personId = peopleIds[Math.floor(rng() * peopleIds.length)];
-        litersBudget -= liters;
-
-        insertFuel.run(personId, carId, dates[i], amount, liters, price_per_liter);
-      }
-    })();
-    fuelTotal += dates.length;
-  }
-}
-
-console.log(`  → ${fuelTotal} fuel fill-ups`);
-
-// ── 5. Expenses ───────────────────────────────────────────────────────────────
-
-console.log("Seeding expenses...");
-
-const checkExpenses = db.prepare(
-  "SELECT COUNT(*) AS n FROM expenses WHERE car_id = ? AND date LIKE ? || '%'"
-);
-const insertExpense = db.prepare(`
-  INSERT INTO expenses (person_id, car_id, date, amount, description, category)
-  VALUES (?, ?, ?, ?, ?, ?)
-`);
-
-let expensesTotal = 0;
-
-for (const car of ACTIVE_CARS) {
-  const carId = carIdByShort[car.short];
-  for (const year of YEARS) {
-    const existing = (checkExpenses.get(carId, String(year)) as { n: number }).n;
-    if (existing > 0) continue;
-
-    const count = randInt(1, 3);
-    db.transaction(() => {
-      for (let i = 0; i < count; i++) {
-        const category = pick(EXPENSE_CATEGORIES);
-        const description = pick(EXPENSE_DESCRIPTIONS[category]);
-        const amount = +rand(50, 500).toFixed(2);
-        const date = randomDateInMonth(year, randInt(1, 12));
-        const personId = peopleIds[Math.floor(rng() * peopleIds.length)];
-        insertExpense.run(personId, carId, date, amount, description, category);
-      }
-    })();
-    expensesTotal += count;
-  }
-}
-
-console.log(`  → ${expensesTotal} expenses`);
-
-// ── Odometer gap for AA (shows in admin inbox) ────────────────────────────────
-{
-  const lastTrip = db
-    .prepare("SELECT end_odometer FROM trips WHERE car_id = ? ORDER BY date DESC, id DESC LIMIT 1")
-    .get(carIdByShort["AA"]) as { end_odometer: number } | undefined;
-  if (lastTrip) {
-    const gapStart = lastTrip.end_odometer + 300;
-    const alreadyExists = db
-      .prepare("SELECT 1 FROM trips WHERE car_id = ? AND start_odometer = ?")
-      .get(carIdByShort["AA"], gapStart);
-    if (!alreadyExists) {
-      db.prepare(
-        `
-        INSERT INTO trips (person_id, car_id, date, start_odometer, end_odometer, km, amount, location)
-        VALUES (?, ?, '2026-12-30', ?, ?, 85, 23.80, 'Turnhout')
-      `
-      ).run(personIdByUsername["alice"], carIdByShort["AA"], gapStart, gapStart + 85);
-    }
-  }
-}
-
-// ── 5b. Out-of-date-order trips for BB (proves odometer sort) ────────────────
-// Two trips where date order ≠ odometer order.
-// Old sort (date DESC) would show Jan-15 first → start=X before end=X+120 of Jan-10 → broken.
-// New sort (start_odometer DESC) shows Jan-10 trip first → correct chain.
-{
-  const bbId = carIdByShort["BB"];
-  const aliceId = personIdByUsername["alice"];
-  const lastBB = db
-    .prepare("SELECT end_odometer FROM trips WHERE car_id = ? ORDER BY start_odometer DESC LIMIT 1")
-    .get(bbId) as { end_odometer: number } | undefined;
-  if (lastBB) {
-    const base = lastBB.end_odometer + 50;
-    const alreadyExists = db
-      .prepare("SELECT 1 FROM trips WHERE car_id = ? AND start_odometer = ?")
-      .get(bbId, base);
-    if (!alreadyExists) {
-      // Trip entered late: date=Jan-10 but odometer continues after Jan-15 trip
-      db.prepare(
-        `INSERT INTO trips (person_id, car_id, date, start_odometer, end_odometer, km, amount, location)
-         VALUES (?, ?, '2027-01-15', ?, ?, 120, 36.00, 'Leuven')`
-      ).run(aliceId, bbId, base, base + 120);
-      db.prepare(
-        `INSERT INTO trips (person_id, car_id, date, start_odometer, end_odometer, km, amount, location)
-         VALUES (?, ?, '2027-01-10', ?, ?, 200, 60.00, 'Mechelen')`
-      ).run(aliceId, bbId, base + 120, base + 320);
-    }
-  }
-}
-
-// ── 5c. Duplicate trips (proves duplicate-detection feature) ─────────────────
-// Insert 2 pairs of trips with identical person+car+odometer range.
-{
-  const aaId = carIdByShort["AA"];
-  const bbId = carIdByShort["BB"];
-  const aliceId = personIdByUsername["alice"];
-  const ownerIdVal = personIdByUsername["owner"];
-
-  // Pair 1: Alice on AA — same range entered twice on different dates
-  const p1Exists = db
-    .prepare(
-      "SELECT 1 FROM trips WHERE car_id = ? AND person_id = ? AND start_odometer = ? AND end_odometer = ?"
-    )
-    .get(aaId, aliceId, 9000, 9080);
-  if (!p1Exists) {
-    db.prepare(
-      `INSERT INTO trips (person_id, car_id, date, start_odometer, end_odometer, km, amount, location)
-       VALUES (?, ?, '2025-03-12', 9000, 9080, 80, 24.00, 'Gent')`
-    ).run(aliceId, aaId);
-    db.prepare(
-      `INSERT INTO trips (person_id, car_id, date, start_odometer, end_odometer, km, amount, location)
-       VALUES (?, ?, '2025-03-13', 9000, 9080, 80, 24.00, 'Gent (dup)')`
-    ).run(aliceId, aaId);
-  }
-
-  // Pair 2: Owner on BB — same range, different dates
-  const p2Exists = db
-    .prepare(
-      "SELECT 1 FROM trips WHERE car_id = ? AND person_id = ? AND start_odometer = ? AND end_odometer = ?"
-    )
-    .get(bbId, ownerIdVal, 8800, 8950);
-  if (!p2Exists) {
-    db.prepare(
-      `INSERT INTO trips (person_id, car_id, date, start_odometer, end_odometer, km, amount, location)
-       VALUES (?, ?, '2025-04-05', 8800, 8950, 150, 45.00, 'Antwerpen')`
-    ).run(ownerIdVal, bbId);
-    db.prepare(
-      `INSERT INTO trips (person_id, car_id, date, start_odometer, end_odometer, km, amount, location)
-       VALUES (?, ?, '2025-04-06', 8800, 8950, 150, 45.00, 'Antwerpen (dup)')`
-    ).run(ownerIdVal, bbId);
-  }
-}
-
-// ── 6. Payments ───────────────────────────────────────────────────────────────
-// 2023: all transfers fully paid (settlement will be finalized).
-// 2024: all transfers paid EXCEPT Owner — they still have an outstanding balance.
-
-console.log("Seeding payments...");
-
-const deletePaymentsByYear = db.prepare("DELETE FROM payments WHERE year = ?");
-const insertPayment = db.prepare(
-  "INSERT INTO payments (person_id, date, amount, note, year) VALUES (?, ?, ?, ?, ?)"
-);
-
-interface PersonRow {
-  id: number;
-  first_name: string;
-  last_name: string;
-  username: string | null;
-}
-const allPeople = db
-  .prepare("SELECT id, first_name, last_name, username FROM people")
-  .all() as PersonRow[];
-const personByShort = new Map<string, number>(allPeople.map((p) => [shortNameOf(p), p.id]));
-const ownerPersonId = personIdByUsername["owner"];
-
-let paymentsTotal = 0;
-
-for (const { year, skipPersonIds } of [
-  { year: 2023, skipPersonIds: new Set<number>() },
-  { year: 2024, skipPersonIds: new Set([ownerPersonId]) },
-]) {
-  deletePaymentsByYear.run(year);
-  const settlement = getSettlement(db, year);
-  const payDate = `${year + 1}-02-15`;
+  db.prepare("DELETE FROM people WHERE first_name LIKE 'E2E%' AND username IS NULL").run();
+
+  const insertPerson = db.prepare(`
+    INSERT OR IGNORE INTO people
+      (first_name, last_name, username, password_hash, is_admin, discount, discount_long, bank_account, email, active)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
+  `);
+  const updatePerson = db.prepare(`
+    UPDATE people SET first_name = ?, last_name = ?, is_admin = ?, discount = ?, discount_long = ?, bank_account = ?, email = ? WHERE username = ?
+  `);
 
   db.transaction(() => {
-    for (const transfer of settlement.transfers) {
-      if (transfer.payment_status === null) continue;
-      const personName = transfer.from === "co-op" ? transfer.to : transfer.from;
-      const personId = personByShort.get(personName);
-      if (!personId) continue;
-      if (skipPersonIds.has(personId)) continue;
-      // Positive = person pays co-op; negative = co-op pays person.
-      // Step 2 (owner transfers) uses abs(sum), so sign doesn't matter for them.
-      const amount = transfer.from === "co-op" ? -transfer.amount : transfer.amount;
-      insertPayment.run(personId, payDate, +amount.toFixed(2), null, year);
-      paymentsTotal++;
+    for (const p of PEOPLE) {
+      const hash = bcrypt.hashSync(p.password, 10);
+      insertPerson.run(
+        p.first_name,
+        p.last_name,
+        p.username,
+        hash,
+        p.is_admin,
+        p.discount,
+        p.discount_long,
+        p.bank_account,
+        p.email
+      );
+      updatePerson.run(
+        p.first_name,
+        p.last_name,
+        p.is_admin,
+        p.discount,
+        p.discount_long,
+        p.bank_account,
+        p.email,
+        p.username
+      );
     }
   })();
+
+  const getPersonByUsername = db.prepare("SELECT id FROM people WHERE username = ?");
+  const personIdByUsername: Record<string, number> = {};
+  for (const p of PEOPLE) {
+    const row = getPersonByUsername.get(p.username) as { id: number };
+    personIdByUsername[p.username] = row.id;
+  }
+
+  const personDiscounts = new Map<number, { discount: number; discount_long: number }>();
+  for (const p of PEOPLE) {
+    personDiscounts.set(personIdByUsername[p.username], {
+      discount: p.discount,
+      discount_long: p.discount_long,
+    });
+  }
+
+  const insertCar = db.prepare(`
+    INSERT OR IGNORE INTO cars (short, name, price_per_km, owner_person_id, owner_from, active)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `);
+  const updateCar = db.prepare(`
+    UPDATE cars SET name = ?, price_per_km = ?, owner_person_id = ?, owner_from = ?, active = ? WHERE short = ?
+  `);
+
+  const OWNER_FROM = "2020-01-01";
+
+  db.transaction(() => {
+    for (const c of CARS) {
+      const ownerId = personIdByUsername[c.owner_username];
+      insertCar.run(c.short, c.name, c.price_per_km, ownerId, OWNER_FROM, c.active);
+      updateCar.run(c.name, c.price_per_km, ownerId, OWNER_FROM, c.active, c.short);
+    }
+  })();
+
+  const getCarByShort = db.prepare("SELECT id FROM cars WHERE short = ?");
+  const carIdByShort: Record<string, number> = {};
+  const carOdometer: Record<string, number> = {};
+  for (const c of CARS) {
+    const row = getCarByShort.get(c.short) as { id: number };
+    carIdByShort[c.short] = row.id;
+    if (c.active) {
+      const existing = db
+        .prepare("SELECT MAX(end_odometer) AS max_odo FROM trips WHERE car_id = ?")
+        .get(row.id) as { max_odo: number | null };
+      carOdometer[c.short] = existing.max_odo ?? c.start_odometer;
+    }
+  }
+
+  const ACTIVE_CARS = CARS.filter((c) => c.active !== 0);
+
+  function buildPriceTable(): Map<string, number> {
+    const prices = new Map<string, number>();
+    let price = 1.85;
+    for (const year of YEARS) {
+      for (let month = 1; month <= 12; month++) {
+        const step = (rng() - 0.5) * 0.1;
+        price = Math.max(1.5, Math.min(2.5, price + step));
+        prices.set(`${year}-${String(month).padStart(2, "0")}`, +price.toFixed(4));
+      }
+    }
+    return prices;
+  }
+
+  const priceTable = buildPriceTable();
+
+  function priceForDate(dateStr: string): number {
+    const ym = dateStr.slice(0, 7);
+    return priceTable.get(ym) ?? 1.85;
+  }
+
+  function randomDateInMonth(year: number, month: number): string {
+    const daysInMonth = new Date(year, month, 0).getDate();
+    const day = randInt(1, daysInMonth);
+    return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+  }
+
+  function datesSpreadAcrossYear(year: number, count: number): string[] {
+    const dates: string[] = [];
+    const base = Math.floor(count / 12);
+    const extra = count % 12;
+    for (let m = 1; m <= 12; m++) {
+      const n = base + (m <= extra ? 1 : 0);
+      for (let i = 0; i < n; i++) dates.push(randomDateInMonth(year, m));
+    }
+    return dates.sort();
+  }
+
+  const checkTrips = db.prepare(
+    "SELECT COUNT(*) AS n FROM trips WHERE car_id = ? AND date LIKE ? || '%'"
+  );
+  const insertTrip = db.prepare(`
+    INSERT INTO trips (person_id, car_id, date, start_odometer, end_odometer, km, amount, location)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+
+  const peopleIds = Object.values(personIdByUsername);
+
+  for (const car of ACTIVE_CARS) {
+    const carId = carIdByShort[car.short];
+    for (const year of YEARS) {
+      const existing = (checkTrips.get(carId, String(year)) as { n: number }).n;
+      if (existing > 0) continue;
+
+      const TARGET_KM = randInt(5000, 10000);
+      const dates = datesSpreadAcrossYear(year, 50);
+      let kmBudget = TARGET_KM;
+
+      db.transaction(() => {
+        for (let i = 0; i < dates.length; i++) {
+          const remaining = dates.length - i;
+          const maxKm = Math.min(250, Math.floor((kmBudget / remaining) * 1.5));
+          const minKm = Math.max(80, Math.floor((kmBudget / remaining) * 0.5));
+          const km = Math.max(1, Math.min(maxKm, randInt(Math.min(minKm, maxKm), maxKm)));
+
+          const personId = peopleIds[Math.floor(rng() * peopleIds.length)];
+          const person = personDiscounts.get(personId)!;
+          const amount = calcTripAmount(
+            km,
+            car.price_per_km,
+            person.discount,
+            person.discount_long
+          );
+
+          const start_odometer = carOdometer[car.short];
+          const end_odometer = start_odometer + km;
+          carOdometer[car.short] = end_odometer;
+          kmBudget -= km;
+
+          insertTrip.run(
+            personId,
+            carId,
+            dates[i],
+            start_odometer,
+            end_odometer,
+            km,
+            +amount.toFixed(2),
+            pick(LOCATIONS)
+          );
+        }
+      })();
+    }
+  }
+
+  const checkFuel = db.prepare(
+    "SELECT COUNT(*) AS n FROM fuel_fillups WHERE car_id = ? AND date LIKE ? || '%'"
+  );
+  const insertFuel = db.prepare(`
+    INSERT INTO fuel_fillups (person_id, car_id, date, amount, liters, price_per_liter)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `);
+
+  for (const car of ACTIVE_CARS) {
+    const carId = carIdByShort[car.short];
+    for (const year of YEARS) {
+      const existing = (checkFuel.get(carId, String(year)) as { n: number }).n;
+      if (existing > 0) continue;
+
+      const TARGET_LITERS = 700;
+      const dates = datesSpreadAcrossYear(year, 20);
+      let litersBudget = TARGET_LITERS;
+
+      db.transaction(() => {
+        for (let i = 0; i < dates.length; i++) {
+          const remaining = dates.length - i;
+          const avgNeeded = litersBudget / remaining;
+          const liters = +Math.max(
+            10,
+            Math.min(45, rand(avgNeeded * 0.8, avgNeeded * 1.2))
+          ).toFixed(1);
+          const ppl = priceForDate(dates[i]);
+          const amount = +(liters * ppl).toFixed(2);
+          const price_per_liter = +calcPricePerLiter(amount, liters).toFixed(4);
+          const personId = peopleIds[Math.floor(rng() * peopleIds.length)];
+          litersBudget -= liters;
+
+          insertFuel.run(personId, carId, dates[i], amount, liters, price_per_liter);
+        }
+      })();
+    }
+  }
+
+  const checkExpenses = db.prepare(
+    "SELECT COUNT(*) AS n FROM expenses WHERE car_id = ? AND date LIKE ? || '%'"
+  );
+  const insertExpense = db.prepare(`
+    INSERT INTO expenses (person_id, car_id, date, amount, description, category)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `);
+
+  for (const car of ACTIVE_CARS) {
+    const carId = carIdByShort[car.short];
+    for (const year of YEARS) {
+      const existing = (checkExpenses.get(carId, String(year)) as { n: number }).n;
+      if (existing > 0) continue;
+
+      const count = randInt(1, 3);
+      db.transaction(() => {
+        for (let i = 0; i < count; i++) {
+          const category = pick(EXPENSE_CATEGORIES);
+          const description = pick(EXPENSE_DESCRIPTIONS[category]);
+          const amount = +rand(50, 500).toFixed(2);
+          const date = randomDateInMonth(year, randInt(1, 12));
+          const personId = peopleIds[Math.floor(rng() * peopleIds.length)];
+          insertExpense.run(personId, carId, date, amount, description, category);
+        }
+      })();
+    }
+  }
+
+  {
+    const lastTrip = db
+      .prepare(
+        "SELECT end_odometer FROM trips WHERE car_id = ? ORDER BY date DESC, id DESC LIMIT 1"
+      )
+      .get(carIdByShort["AA"]) as { end_odometer: number } | undefined;
+    if (lastTrip) {
+      const gapStart = lastTrip.end_odometer + 300;
+      const alreadyExists = db
+        .prepare("SELECT 1 FROM trips WHERE car_id = ? AND start_odometer = ?")
+        .get(carIdByShort["AA"], gapStart);
+      if (!alreadyExists) {
+        db.prepare(
+          `
+          INSERT INTO trips (person_id, car_id, date, start_odometer, end_odometer, km, amount, location)
+          VALUES (?, ?, '2026-12-30', ?, ?, 85, 23.80, 'Turnhout')
+        `
+        ).run(personIdByUsername["alice"], carIdByShort["AA"], gapStart, gapStart + 85);
+      }
+    }
+  }
+
+  {
+    const bbId = carIdByShort["BB"];
+    const aliceIdVal = personIdByUsername["alice"];
+    const lastBB = db
+      .prepare(
+        "SELECT end_odometer FROM trips WHERE car_id = ? ORDER BY start_odometer DESC LIMIT 1"
+      )
+      .get(bbId) as { end_odometer: number } | undefined;
+    if (lastBB) {
+      const base = lastBB.end_odometer + 50;
+      const alreadyExists = db
+        .prepare("SELECT 1 FROM trips WHERE car_id = ? AND start_odometer = ?")
+        .get(bbId, base);
+      if (!alreadyExists) {
+        db.prepare(
+          `INSERT INTO trips (person_id, car_id, date, start_odometer, end_odometer, km, amount, location)
+           VALUES (?, ?, '2027-01-15', ?, ?, 120, 36.00, 'Leuven')`
+        ).run(aliceIdVal, bbId, base, base + 120);
+        db.prepare(
+          `INSERT INTO trips (person_id, car_id, date, start_odometer, end_odometer, km, amount, location)
+           VALUES (?, ?, '2027-01-10', ?, ?, 200, 60.00, 'Mechelen')`
+        ).run(aliceIdVal, bbId, base + 120, base + 320);
+      }
+    }
+  }
+
+  {
+    const aaId = carIdByShort["AA"];
+    const bbId = carIdByShort["BB"];
+    const aliceIdVal = personIdByUsername["alice"];
+    const ownerIdVal = personIdByUsername["owner"];
+
+    const p1Exists = db
+      .prepare(
+        "SELECT 1 FROM trips WHERE car_id = ? AND person_id = ? AND start_odometer = ? AND end_odometer = ?"
+      )
+      .get(aaId, aliceIdVal, 9000, 9080);
+    if (!p1Exists) {
+      db.prepare(
+        `INSERT INTO trips (person_id, car_id, date, start_odometer, end_odometer, km, amount, location)
+         VALUES (?, ?, '2025-03-12', 9000, 9080, 80, 24.00, 'Gent')`
+      ).run(aliceIdVal, aaId);
+      db.prepare(
+        `INSERT INTO trips (person_id, car_id, date, start_odometer, end_odometer, km, amount, location)
+         VALUES (?, ?, '2025-03-13', 9000, 9080, 80, 24.00, 'Gent (dup)')`
+      ).run(aliceIdVal, aaId);
+    }
+
+    const p2Exists = db
+      .prepare(
+        "SELECT 1 FROM trips WHERE car_id = ? AND person_id = ? AND start_odometer = ? AND end_odometer = ?"
+      )
+      .get(bbId, ownerIdVal, 8800, 8950);
+    if (!p2Exists) {
+      db.prepare(
+        `INSERT INTO trips (person_id, car_id, date, start_odometer, end_odometer, km, amount, location)
+         VALUES (?, ?, '2025-04-05', 8800, 8950, 150, 45.00, 'Antwerpen')`
+      ).run(ownerIdVal, bbId);
+      db.prepare(
+        `INSERT INTO trips (person_id, car_id, date, start_odometer, end_odometer, km, amount, location)
+         VALUES (?, ?, '2025-04-06', 8800, 8950, 150, 45.00, 'Antwerpen (dup)')`
+      ).run(ownerIdVal, bbId);
+    }
+  }
+
+  const deletePaymentsByYear = db.prepare("DELETE FROM payments WHERE year = ?");
+  const insertPayment = db.prepare(
+    "INSERT INTO payments (person_id, date, amount, note, year) VALUES (?, ?, ?, ?, ?)"
+  );
+
+  interface PersonRow {
+    id: number;
+    first_name: string;
+    last_name: string;
+    username: string | null;
+  }
+  const allPeople = db
+    .prepare("SELECT id, first_name, last_name, username FROM people")
+    .all() as PersonRow[];
+  const personByShort = new Map<string, number>(allPeople.map((p) => [shortNameOf(p), p.id]));
+  const ownerPersonId = personIdByUsername["owner"];
+
+  for (const { year, skipPersonIds } of [
+    { year: 2023, skipPersonIds: new Set<number>() },
+    { year: 2024, skipPersonIds: new Set([ownerPersonId]) },
+  ]) {
+    deletePaymentsByYear.run(year);
+    const settlement = getSettlement(db, year);
+    const payDate = `${year + 1}-02-15`;
+
+    db.transaction(() => {
+      for (const transfer of settlement.transfers) {
+        if (transfer.payment_status === null) continue;
+        const personName = transfer.from === "co-op" ? transfer.to : transfer.from;
+        const personId = personByShort.get(personName);
+        if (!personId) continue;
+        if (skipPersonIds.has(personId)) continue;
+        const amount = transfer.from === "co-op" ? -transfer.amount : transfer.amount;
+        insertPayment.run(personId, payDate, +amount.toFixed(2), null, year);
+      }
+    })();
+  }
+
+  db.prepare(
+    `
+    INSERT OR IGNORE INTO settlements (year, settled_at, settled_by) VALUES
+    (2021, '2022-02-01T10:00:00', 'admin'),
+    (2022, '2023-02-01T10:00:00', 'admin'),
+    (2023, '2024-02-01T10:00:00', 'admin')
+  `
+  ).run();
+  db.prepare("DELETE FROM settlements WHERE year = 2024").run();
+
+  db.prepare(
+    `
+    INSERT OR IGNORE INTO settings (key, value)
+    VALUES ('coop_bank_account', 'BE00 0000 0000 0000')
+  `
+  ).run();
+
+  const aliceIdRes = personIdByUsername["alice"];
+  const carolIdRes = personIdByUsername["carol"];
+  db.prepare("DELETE FROM reservations WHERE status IN ('pending', 'confirmed')").run();
+  db.prepare(
+    `
+    INSERT INTO reservations (person_id, car_id, start_date, end_date, start_time, end_time, status, note)
+    VALUES
+      (?, ?, '2026-05-15', '2026-05-17', NULL,    NULL,    'pending',   'Weekend trip to Ghent'),
+      (?, ?, '2026-05-20', '2026-05-25', NULL,    NULL,    'confirmed', 'Family visit'),
+      (?, ?, '2026-06-01', '2026-06-04', NULL,    NULL,    'confirmed', 'School run week'),
+      (?, ?, '2026-05-18', '2026-05-18', '09:00', '12:30', 'pending',   'Morning errands (half day)')
+  `
+  ).run(
+    aliceIdRes,
+    carIdByShort["AA"],
+    personIdByUsername["bob"],
+    carIdByShort["BB"],
+    carolIdRes,
+    carIdByShort["CC"],
+    aliceIdRes,
+    carIdByShort["AA"]
+  );
+
+  console.log(`  ✓ Demo seed complete for ${path.basename(targetPath)}`);
 }
 
-console.log(`  → ${paymentsTotal} payments`);
+// 2. Determine target databases to seed
+const targetPaths: string[] = [];
 
-// ── 7. Settlements + settings ─────────────────────────────────────────────────
+if (process.env.DB_PATH) {
+  targetPaths.push(process.env.DB_PATH);
+} else {
+  targetPaths.push(
+    path.join(process.cwd(), "data", "carsharing.db"),
+    path.join(process.cwd(), "data", "tenants", "primary.db"),
+    path.join(process.cwd(), "data", "tenants", "coop-a.db"),
+    path.join(process.cwd(), "data", "tenants", "coop-b.db")
+  );
+}
 
-console.log("Seeding settlements and settings...");
+for (const targetPath of targetPaths) {
+  seedSingleTenantDb(targetPath);
+}
 
-db.prepare(
-  `
-  INSERT OR IGNORE INTO settlements (year, settled_at, settled_by) VALUES
-  (2021, '2022-02-01T10:00:00', 'admin'),
-  (2022, '2023-02-01T10:00:00', 'admin'),
-  (2023, '2024-02-01T10:00:00', 'admin')
-`
-).run();
-// 2024 is intentionally left open so screenshots show an active settlement
-db.prepare("DELETE FROM settlements WHERE year = 2024").run();
-
-db.prepare(
-  `
-  INSERT OR IGNORE INTO settings (key, value)
-  VALUES ('coop_bank_account', 'BE00 0000 0000 0000')
-`
-).run();
-
-// ── Reservations (for screenshots) ─────────────────────────────────────────
-const aliceId = personIdByUsername["alice"];
-const carolId = personIdByUsername["carol"];
-db.prepare("DELETE FROM reservations WHERE status IN ('pending', 'confirmed')").run();
-db.prepare(
-  `
-  INSERT INTO reservations (person_id, car_id, start_date, end_date, start_time, end_time, status, note)
-  VALUES
-    (?, ?, '2026-05-15', '2026-05-17', NULL,    NULL,    'pending',   'Weekend trip to Ghent'),
-    (?, ?, '2026-05-20', '2026-05-25', NULL,    NULL,    'confirmed', 'Family visit'),
-    (?, ?, '2026-06-01', '2026-06-04', NULL,    NULL,    'confirmed', 'School run week'),
-    (?, ?, '2026-05-18', '2026-05-18', '09:00', '12:30', 'pending',   'Morning errands (half day)')
-`
-).run(
-  aliceId,
-  carIdByShort["AA"],
-  personIdByUsername["bob"],
-  carIdByShort["BB"],
-  carolId,
-  carIdByShort["CC"],
-  aliceId,
-  carIdByShort["AA"]
-);
-
-// ── Summary ───────────────────────────────────────────────────────────────────
-
-const counts = {
-  people: (db.prepare("SELECT COUNT(*) AS n FROM people").get() as { n: number }).n,
-  cars: (db.prepare("SELECT COUNT(*) AS n FROM cars").get() as { n: number }).n,
-  trips: (db.prepare("SELECT COUNT(*) AS n FROM trips").get() as { n: number }).n,
-  fuel: (db.prepare("SELECT COUNT(*) AS n FROM fuel_fillups").get() as { n: number }).n,
-  expenses: (db.prepare("SELECT COUNT(*) AS n FROM expenses").get() as { n: number }).n,
-  payments: (db.prepare("SELECT COUNT(*) AS n FROM payments").get() as { n: number }).n,
-  settlements: (db.prepare("SELECT COUNT(*) AS n FROM settlements").get() as { n: number }).n,
-  reservations: (db.prepare("SELECT COUNT(*) AS n FROM reservations").get() as { n: number }).n,
-};
-
-console.log("\n✅ Demo seed complete:");
-console.table(counts);
-console.log("\nLogin: admin / admin  (or owner/owner, alice/alice, bob/bob, carol/carol)");
+console.log("\n✅ All demo tenant databases seeded successfully!");
+console.log("Login: admin / admin  (or owner/owner, alice/alice, bob/bob, carol/carol)");

--- a/scripts/seed-platform.ts
+++ b/scripts/seed-platform.ts
@@ -1,0 +1,6 @@
+import { getPlatformDb, seedPlatformDb } from "../lib/platform-db";
+
+console.log("Seeding platform database...");
+const db = getPlatformDb();
+seedPlatformDb(db);
+console.log("✅ Platform database seeded successfully.");

--- a/scripts/seed-platform.ts
+++ b/scripts/seed-platform.ts
@@ -1,6 +1,18 @@
-import { getPlatformDb, seedPlatformDb } from "../lib/platform-db";
+process.env.SESSION_PASSWORD =
+  process.env.SESSION_PASSWORD || "dev-session-password-placeholder-32-chars";
 
-console.log("Seeding platform database...");
+import { createTenantRecord, getPlatformDb } from "../lib/platform-db.js";
+
+console.log("Seeding platform database with demo cooperatives...");
 const db = getPlatformDb();
-seedPlatformDb(db);
-console.log("✅ Platform database seeded successfully.");
+
+const demoTenants = [
+  { slug: "coop-a", name: "Cooperative A (Gent)", email: "admin@coop-a.local" },
+  { slug: "coop-b", name: "Cooperative B (Antwerpen)", email: "admin@coop-b.local" },
+];
+
+for (const t of demoTenants) {
+  createTenantRecord(t.slug, t.name, t.email);
+}
+
+console.log(`✅ Platform database seeded with ${demoTenants.length} demo cooperatives.`);

--- a/tenants.example.json
+++ b/tenants.example.json
@@ -1,0 +1,15 @@
+{
+  "default": "primary",
+  "sites": {
+    "coop-a.localhost": {
+      "slug": "coop-a",
+      "name": "Cooperative A (Gent)",
+      "adminEmail": "admin@coop-a.local"
+    },
+    "coop-b.localhost": {
+      "slug": "coop-b",
+      "name": "Cooperative B (Antwerpen)",
+      "adminEmail": "admin@coop-b.local"
+    }
+  }
+}


### PR DESCRIPTION
Closes #379

## What's in this PR

### Architecture
- Per-tenant SQLite databases in `data/tenants/{slug}.db`
- Drupal-style host mapping via `tenants.json` / `tenants.example.json`
- Middleware sets `x-tenant-slug` + `x-tenant-name` headers per request

### Fixes
- Edge Runtime (middleware) can't use `fs` — embedded config via `NEXT_PUBLIC_TENANTS_CONFIG` env var
- Login route was always querying `primary.db` — now reads `x-tenant-slug` header to select the correct DB
- Standalone server writes `data/` to its own CWD — fixed via symlink
- Static assets (`public/`, `.next/static/`) now symlinked instead of copied

### Config
- `tenants.example.json` is the committed dev fallback
- Multiple hosts can map to the same slug (URL aliases sharing one DB)
- Each host alias can have its own display name via `name` field